### PR TITLE
feat: add multi-theme system with dark, otter, and light themes

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en" class="dark" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/packages/web/src/components/graph/AgentGraph.tsx
+++ b/packages/web/src/components/graph/AgentGraph.tsx
@@ -100,7 +100,7 @@ function buildLayout(
         source: parentId,
         target: agent.id,
         animated: agent.status === "thinking" || agent.status === "acting",
-        style: { stroke: "hsl(0 0% 30%)" },
+        style: { stroke: "hsl(var(--muted-foreground))" },
       });
     }
   }
@@ -201,7 +201,7 @@ function AgentGraphInner({
           minZoom={0.5}
           maxZoom={1.5}
         >
-          <Background color="hsl(0 0% 15%)" gap={20} size={1} />
+          <Background color="hsl(var(--secondary))" gap={20} size={1} />
         </ReactFlow>
         {selectedAgentId && <AgentDetailPanel />}
       </div>

--- a/packages/web/src/components/settings/AppearanceTab.tsx
+++ b/packages/web/src/components/settings/AppearanceTab.tsx
@@ -1,0 +1,69 @@
+import { useThemeStore, type Theme } from "../../stores/theme-store";
+import { cn } from "../../lib/utils";
+
+const THEMES: { id: Theme; label: string; description: string; swatches: string[] }[] = [
+  {
+    id: "dark",
+    label: "Dark",
+    description: "Neutral dark with blue accents",
+    swatches: ["hsl(0 0% 7%)", "hsl(0 0% 9%)", "hsl(217 92% 60%)"],
+  },
+  {
+    id: "otter",
+    label: "Otter",
+    description: "Navy & cyan brand palette",
+    swatches: ["hsl(216 57% 10%)", "hsl(216 62% 16%)", "hsl(191 100% 50%)"],
+  },
+  {
+    id: "light",
+    label: "Light",
+    description: "Light with teal accents",
+    swatches: ["hsl(195 30% 97%)", "hsl(0 0% 100%)", "hsl(189 93% 36%)"],
+  },
+];
+
+export function AppearanceTab() {
+  const theme = useThemeStore((s) => s.theme);
+  const setTheme = useThemeStore((s) => s.setTheme);
+
+  return (
+    <div className="p-5 space-y-4">
+      <div>
+        <h3 className="text-xs font-semibold mb-1">Theme</h3>
+        <p className="text-xs text-muted-foreground mb-3">
+          Choose how Otterbot looks.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        {THEMES.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTheme(t.id)}
+            className={cn(
+              "flex flex-col items-start gap-2 rounded-lg border p-3 text-left transition-colors",
+              theme === t.id
+                ? "border-primary ring-1 ring-primary"
+                : "border-border hover:border-muted-foreground/40",
+            )}
+          >
+            {/* Color swatch preview */}
+            <div className="flex gap-1.5 w-full">
+              {t.swatches.map((color, i) => (
+                <div
+                  key={i}
+                  className="h-6 flex-1 rounded"
+                  style={{ backgroundColor: color }}
+                />
+              ))}
+            </div>
+            <div>
+              <p className="text-xs font-medium">{t.label}</p>
+              <p className="text-[10px] text-muted-foreground">{t.description}</p>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/SettingsPanel.tsx
+++ b/packages/web/src/components/settings/SettingsPanel.tsx
@@ -8,10 +8,12 @@ import { SearchTab } from "./SearchTab";
 import { SpeechTab } from "./SpeechTab";
 import { LiveViewTab } from "./LiveViewTab";
 import { OpenCodeTab } from "./OpenCodeTab";
+import { AppearanceTab } from "./AppearanceTab";
 
-type Tab = "providers" | "models" | "templates" | "search" | "speech" | "liveview" | "opencode";
+type Tab = "appearance" | "providers" | "models" | "templates" | "search" | "speech" | "liveview" | "opencode";
 
 const TABS: { id: Tab; label: string }[] = [
+  { id: "appearance", label: "Appearance" },
   { id: "providers", label: "Providers" },
   { id: "models", label: "Models" },
   { id: "templates", label: "Agent Templates" },
@@ -22,7 +24,7 @@ const TABS: { id: Tab; label: string }[] = [
 ];
 
 export function SettingsPanel({ onClose }: { onClose: () => void }) {
-  const [activeTab, setActiveTab] = useState<Tab>("providers");
+  const [activeTab, setActiveTab] = useState<Tab>("appearance");
   const loadSettings = useSettingsStore((s) => s.loadSettings);
   const loading = useSettingsStore((s) => s.loading);
 
@@ -67,7 +69,9 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
 
         {/* Tab content */}
         <div className="flex-1 overflow-y-auto">
-          {loading ? (
+          {activeTab === "appearance" ? (
+            <AppearanceTab />
+          ) : loading ? (
             <div className="flex items-center justify-center h-48 text-sm text-muted-foreground">
               Loading settings...
             </div>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -6,6 +6,11 @@
 
 @layer base {
   :root {
+    --radius: 0.5rem;
+  }
+
+  /* Dark theme (default) — current values preserved exactly */
+  [data-theme="dark"] {
     --background: 0 0% 7%;
     --foreground: 0 0% 93%;
     --card: 0 0% 9%;
@@ -23,7 +28,57 @@
     --border: 0 0% 18%;
     --input: 0 0% 18%;
     --ring: 217 92% 60%;
-    --radius: 0.5rem;
+    --scrollbar-thumb: 0 0% 25%;
+    --scrollbar-thumb-hover: 0 0% 35%;
+    --code-block-bg: rgba(255, 255, 255, 0.05);
+  }
+
+  /* Otter theme — brand colors from otterbot-site */
+  [data-theme="otter"] {
+    --background: 216 57% 10%;
+    --foreground: 195 50% 94%;
+    --card: 216 62% 16%;
+    --card-foreground: 195 40% 85%;
+    --primary: 191 100% 50%;
+    --primary-foreground: 216 57% 10%;
+    --secondary: 216 63% 20%;
+    --secondary-foreground: 195 50% 94%;
+    --muted: 216 63% 20%;
+    --muted-foreground: 207 31% 60%;
+    --accent: 216 63% 20%;
+    --accent-foreground: 195 50% 94%;
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 216 50% 25%;
+    --input: 216 50% 25%;
+    --ring: 189 93% 36%;
+    --scrollbar-thumb: 216 50% 30%;
+    --scrollbar-thumb-hover: 216 50% 40%;
+    --code-block-bg: rgba(255, 255, 255, 0.06);
+  }
+
+  /* Light theme — inverted brand variant */
+  [data-theme="light"] {
+    --background: 195 30% 97%;
+    --foreground: 216 50% 15%;
+    --card: 0 0% 100%;
+    --card-foreground: 216 50% 15%;
+    --primary: 189 93% 36%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 195 20% 92%;
+    --secondary-foreground: 216 50% 15%;
+    --muted: 195 20% 92%;
+    --muted-foreground: 216 20% 45%;
+    --accent: 195 20% 92%;
+    --accent-foreground: 216 50% 15%;
+    --destructive: 0 84% 50%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 195 20% 85%;
+    --input: 195 20% 85%;
+    --ring: 189 93% 36%;
+    --scrollbar-thumb: 195 15% 75%;
+    --scrollbar-thumb-hover: 195 15% 60%;
+    --code-block-bg: rgba(0, 0, 0, 0.04);
   }
 }
 
@@ -45,17 +100,17 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(0 0% 25%);
+  background: hsl(var(--scrollbar-thumb));
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(0 0% 35%);
+  background: hsl(var(--scrollbar-thumb-hover));
 }
 
 /* Panel resize handles */
 .panel-resize-handle {
   width: 1px;
-  background: hsl(0 0% 18%);
+  background: hsl(var(--border));
   transition: background 150ms, width 150ms;
   position: relative;
 }
@@ -125,7 +180,7 @@
   margin-bottom: 0.5em;
   padding: 0.75em 1em;
   border-radius: 0.5rem;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--code-block-bg);
 }
 
 /* Remove backtick decoration that prose adds to inline code */
@@ -143,4 +198,44 @@
 
 .prose :where(th, td):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   padding: 0.35em 0.625em;
+}
+
+/* Syntax highlighting overrides for light theme */
+[data-theme="light"] .hljs {
+  background: var(--code-block-bg);
+  color: #24292e;
+}
+[data-theme="light"] .hljs-comment,
+[data-theme="light"] .hljs-quote {
+  color: #6a737d;
+}
+[data-theme="light"] .hljs-keyword,
+[data-theme="light"] .hljs-selector-tag,
+[data-theme="light"] .hljs-type {
+  color: #d73a49;
+}
+[data-theme="light"] .hljs-string,
+[data-theme="light"] .hljs-addition {
+  color: #032f62;
+}
+[data-theme="light"] .hljs-number,
+[data-theme="light"] .hljs-literal,
+[data-theme="light"] .hljs-built_in {
+  color: #005cc5;
+}
+[data-theme="light"] .hljs-title,
+[data-theme="light"] .hljs-section,
+[data-theme="light"] .hljs-attr {
+  color: #6f42c1;
+}
+[data-theme="light"] .hljs-name,
+[data-theme="light"] .hljs-tag {
+  color: #22863a;
+}
+[data-theme="light"] .hljs-deletion {
+  color: #b31d28;
+}
+[data-theme="light"] .hljs-variable,
+[data-theme="light"] .hljs-template-variable {
+  color: #e36209;
 }

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,3 +1,4 @@
+import "./stores/theme-store";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";

--- a/packages/web/src/stores/theme-store.ts
+++ b/packages/web/src/stores/theme-store.ts
@@ -1,0 +1,51 @@
+import { create } from "zustand";
+
+export type Theme = "dark" | "otter" | "light";
+
+interface ThemeState {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+function getInitialTheme(): Theme {
+  const stored = localStorage.getItem("otterbot-theme") as Theme | null;
+  if (stored && ["dark", "otter", "light"].includes(stored)) return stored;
+
+  if (window.matchMedia("(prefers-color-scheme: light)").matches) return "light";
+  return "dark";
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  root.setAttribute("data-theme", theme);
+
+  if (theme === "light") {
+    root.classList.remove("dark");
+  } else {
+    root.classList.add("dark");
+  }
+
+  localStorage.setItem("otterbot-theme", theme);
+}
+
+// Apply immediately to prevent flash
+const initialTheme = getInitialTheme();
+applyTheme(initialTheme);
+
+export const useThemeStore = create<ThemeState>((set) => ({
+  theme: initialTheme,
+  setTheme: (theme) => {
+    applyTheme(theme);
+    set({ theme });
+  },
+}));
+
+// Listen for OS preference changes when no stored preference
+if (!localStorage.getItem("otterbot-theme")) {
+  window.matchMedia("(prefers-color-scheme: light)").addEventListener("change", (e) => {
+    if (localStorage.getItem("otterbot-theme")) return;
+    const theme: Theme = e.matches ? "light" : "dark";
+    applyTheme(theme);
+    useThemeStore.setState({ theme });
+  });
+}


### PR DESCRIPTION
Add a Zustand-based theme store with localStorage persistence and OS preference detection. Define three CSS theme variants: Dark (existing neutral grays), Otter (navy/cyan brand palette), and Light (inverted brand). Wire up an Appearance tab in Settings with visual theme swatches, and replace hardcoded colors in scrollbar, panel resize, AgentGraph, and MermaidBlock with CSS custom properties.