### PR TITLE
fix: move passphrase to first setup step for early authentication

### DIFF
--- a/packages/server/src/auth/auth.ts
+++ b/packages/server/src/auth/auth.ts
@@ -132,3 +132,7 @@ export function isSetupComplete(): boolean {
     getConfig("coo_model") !== undefined
   );
 }
+
+export function isPassphraseSet(): boolean {
+  return getConfig("passphrase_hash") !== undefined;
+}

--- a/packages/web/src/stores/auth-store.ts
+++ b/packages/web/src/stores/auth-store.ts
@@ -10,8 +10,8 @@ interface AuthState {
 
   checkStatus: () => Promise<void>;
   login: (passphrase: string) => Promise<boolean>;
+  setSetupPassphrase: (passphrase: string) => Promise<boolean>;
   completeSetup: (data: {
-    passphrase: string;
     provider: string;
     providerName?: string;
     model: string;
@@ -81,6 +81,28 @@ export const useAuthStore = create<AuthState>((set) => ({
 
       const data = await res.json();
       set({ error: data.error || "Invalid passphrase" });
+      return false;
+    } catch {
+      set({ error: "Failed to connect to server" });
+      return false;
+    }
+  },
+
+  setSetupPassphrase: async (passphrase) => {
+    set({ error: null });
+    try {
+      const res = await fetch("/api/setup/passphrase", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ passphrase }),
+      });
+
+      if (res.ok) {
+        return true;
+      }
+
+      const data = await res.json();
+      set({ error: data.error || "Failed to set passphrase" });
       return false;
     } catch {
       set({ error: "Failed to connect to server" });


### PR DESCRIPTION
- Add POST /api/setup/passphrase endpoint (public, creates session)
- Shrink PUBLIC_PATHS to 3 endpoints for improved security
- Update auth middleware to allow setup sessions access to wizard endpoints
- Remove passphrase from /api/setup/complete (handled earlier)
- Reorder SetupWizard: passphrase step 1, provider/model step 2
- Add setSetupPassphrase to auth store, remove from completeSetup

This fixes model pricing not saving during setup wizard (was 401 due to missing auth) and reduces attack surface by protecting probe-models, model-packs, environment-packs, and scenes endpoints.