### PR TITLE
fix: raise zone name label height for better visibility

### DIFF
--- a/packages/web/src/components/live-view/ZoneGroundMarkers.tsx
+++ b/packages/web/src/components/live-view/ZoneGroundMarkers.tsx
@@ -54,7 +54,7 @@ function ZoneBorder({ zone }: { zone: SceneZone }) {
       />
       {/* Zone label */}
       <Text
-        position={[zone.position[0], 0.1, zone.position[2] - zone.size[2] / 2 + 0.5]}
+        position={[zone.position[0], 1.5, zone.position[2] - zone.size[2] / 2 + 0.5]}
         fontSize={0.5}
         color={color}
         anchorX="center"


### PR DESCRIPTION
## Summary
- Raise the zone name label Y position from 0.1 to 1.5 so it floats above the ground for better readability

## Test plan
- [ ] Run `npx pnpm dev` and confirm the "Main Office" label is visibly floating above the ground border

🤖 Generated with [Claude Code](https://claude.com/claude-code)