### PR TITLE
feat: dedicated desks and no agent overlap in main office

### DIFF
--- a/assets/office-templates/default-project-office.json
+++ b/assets/office-templates/default-project-office.json
@@ -13,10 +13,10 @@
     { "asset": "kaykit-prototype-bits/Floor", "position": [4, -0.5, 8], "receiveShadow": true },
     { "asset": "kaykit-prototype-bits/Floor", "position": [8, -0.5, 8], "receiveShadow": true },
 
-    { "asset": "kaykit-prototype-bits/Pallet_Large", "position": [3, 0, 1], "scale": [0.5, 1.6, 0.3], "castShadow": true, "receiveShadow": true },
-    { "asset": "kaykit-prototype-bits/Pallet_Large", "position": [7, 0, 1], "scale": [0.5, 1.6, 0.3], "castShadow": true, "receiveShadow": true },
-    { "asset": "kaykit-prototype-bits/Pallet_Large", "position": [3, 0, 6], "scale": [0.5, 1.6, 0.3], "castShadow": true, "receiveShadow": true },
-    { "asset": "kaykit-prototype-bits/Pallet_Large", "position": [7, 0, 6], "scale": [0.5, 1.6, 0.3], "castShadow": true, "receiveShadow": true }
+    { "asset": "kaykit-prototype-bits/table_medium", "position": [3, 0, 1], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium", "position": [7, 0, 1], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium", "position": [3, 0, 6], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium", "position": [7, 0, 6], "castShadow": true, "receiveShadow": true }
   ],
   "waypoints": [
     { "id": "entrance", "position": [1, 0, -1], "tag": "entrance" },

--- a/assets/scenes/world-base.json
+++ b/assets/scenes/world-base.json
@@ -23,11 +23,14 @@
     { "asset": "kaykit-prototype-bits/Floor", "position": [4, -0.5, -14], "receiveShadow": true },
     { "asset": "kaykit-prototype-bits/Floor", "position": [8, -0.5, -14], "receiveShadow": true },
 
-    { "asset": "kaykit-prototype-bits/Pallet_Large", "position": [-7, 0, -3], "scale": [0.5, 1.6, 0.3], "castShadow": true, "receiveShadow": true },
-    { "asset": "kaykit-prototype-bits/Pallet_Large", "position": [-7, 0, -7], "scale": [0.5, 1.6, 0.3], "castShadow": true, "receiveShadow": true },
-    { "asset": "kaykit-prototype-bits/Pallet_Large", "position": [7, 0, -3], "scale": [0.5, 1.6, 0.3], "castShadow": true, "receiveShadow": true },
-    { "asset": "kaykit-prototype-bits/Pallet_Large", "position": [7, 0, -7], "scale": [0.5, 1.6, 0.3], "castShadow": true, "receiveShadow": true },
-    { "asset": "kaykit-prototype-bits/Pallet_Large", "position": [0, 0, -12], "scale": [0.8, 1.6, 0.4], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium_Decorated", "position": [-7, 0, -3], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium_Decorated", "position": [-7, 0, -7], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium", "position": [7, 0, -3], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium", "position": [7, 0, -7], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium_long", "position": [0, 0, -12], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium", "position": [-4, 0, -12], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium", "position": [4, 0, -12], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium", "position": [0, 0, -4], "castShadow": true, "receiveShadow": true },
 
     { "asset": "kaykit-prototype-bits/Barrel_A", "position": [8.5, 0.5, -1], "castShadow": true },
     { "asset": "kaykit-prototype-bits/Box_A", "position": [-8.5, 0, -1.5], "scale": 2, "castShadow": true },
@@ -68,6 +71,9 @@
       { "id": "mo-desk-admin", "position": [7, 0, -2], "label": "Admin Desk", "zoneId": "main-office", "tag": "desk" },
       { "id": "mo-desk-tl1", "position": [7, 0, -6], "label": "Team Lead Desk 1", "zoneId": "main-office", "tag": "desk" },
       { "id": "mo-desk-meeting", "position": [0, 0, -12], "label": "Meeting Table", "zoneId": "main-office", "tag": "desk" },
+      { "id": "mo-desk-tl2", "position": [-4, 0, -12], "label": "Team Lead Desk 2", "zoneId": "main-office", "tag": "desk" },
+      { "id": "mo-desk-w1", "position": [4, 0, -12], "label": "Worker Desk 1", "zoneId": "main-office", "tag": "desk" },
+      { "id": "mo-desk-w2", "position": [0, 0, -4], "label": "Worker Desk 2", "zoneId": "main-office", "tag": "desk" },
       { "id": "mo-inner-1", "position": [0, 0, -4], "label": "Inner 1", "zoneId": "main-office" },
       { "id": "mo-inner-2", "position": [-4, 0, -8], "label": "Inner Left", "zoneId": "main-office" },
       { "id": "mo-inner-3", "position": [4, 0, -8], "label": "Inner Right", "zoneId": "main-office" },
@@ -91,6 +97,9 @@
       { "from": "mo-inner-3", "to": "mo-desk-tl1" },
       { "from": "mo-inner-3", "to": "mo-desk-admin" },
       { "from": "mo-inner-2", "to": "mo-desk-ceo" },
+      { "from": "mo-center", "to": "mo-desk-tl2" },
+      { "from": "mo-inner-3", "to": "mo-desk-w1" },
+      { "from": "mo-inner-1", "to": "mo-desk-w2" },
 
       { "from": "mo-entrance", "to": "hall-0" },
       { "from": "hall-0", "to": "hall-1" },
@@ -105,10 +114,11 @@
     "coo": [{ "position": [-7, 0, -6], "rotation": 3.14159 }],
     "teamLead": [
       { "position": [7, 0, -6], "rotation": 3.14159 },
-      { "position": [0, 0, -12], "rotation": 3.14159 }
+      { "position": [-4, 0, -12], "rotation": 3.14159 }
     ],
     "worker": [
-      { "position": [7, 0, -2], "rotation": 3.14159 },
+      { "position": [0, 0, -12], "rotation": 3.14159 },
+      { "position": [4, 0, -12], "rotation": 3.14159 },
       { "position": [0, 0, -4], "rotation": 3.14159 }
     ]
   }

--- a/packages/web/src/components/live-view/LiveViewScene.tsx
+++ b/packages/web/src/components/live-view/LiveViewScene.tsx
@@ -59,16 +59,26 @@ export function LiveViewScene({ userProfile }: LiveViewSceneProps) {
         return { x: wp.position[0], z: wp.position[2], rotationY: 0 };
       };
 
-      // Status-aware position: agents go to desk when thinking/acting, center when idle
+      // Status-aware position: agents go to desk when thinking/acting, idle agents spread near center
       const getStatusAwarePos = (agent: Agent | null, zoneId: string | undefined, deskIndex: number): { x: number; z: number; rotationY: number } => {
         const status = agent?.status ?? "idle";
         const isWorking = status === "thinking" || status === "acting";
-        const tag = isWorking ? "desk" : "center";
-        return getZoneWaypointPos(zoneId, tag, deskIndex) ?? getZoneWaypointPos(zoneId, "center", 0) ?? { x: 0, z: 0, rotationY: 0 };
+        if (isWorking) {
+          return getZoneWaypointPos(zoneId, "desk", deskIndex) ?? getZoneWaypointPos(zoneId, "center", 0) ?? { x: 0, z: 0, rotationY: 0 };
+        }
+        // Idle: spread agents around center so they don't stack
+        const centerPos = getZoneWaypointPos(zoneId, "center", 0) ?? { x: 0, z: 0, rotationY: 0 };
+        const angle = (deskIndex / 8) * Math.PI * 2;
+        const radius = 1.5;
+        return { x: centerPos.x + Math.cos(angle) * radius, z: centerPos.z + Math.sin(angle) * radius, rotationY: 0 };
       };
 
-      // CEO at main office center (always center since they don't act)
-      const ceoPos = getZoneWaypointPos(mainZoneId, "center", 0) ?? { x: 0, z: 0, rotationY: 0 };
+      // Global desk index counter — each agent in the main office gets a unique desk
+      let nextDeskIndex = 0;
+
+      // CEO always at its desk (deskIndex 0)
+      const ceoDeskIndex = nextDeskIndex++;
+      const ceoPos = getZoneWaypointPos(mainZoneId, "desk", ceoDeskIndex) ?? { x: 0, z: 0, rotationY: 0 };
       positions.push({
         agent: null,
         role: "ceo",
@@ -80,9 +90,10 @@ export function LiveViewScene({ userProfile }: LiveViewSceneProps) {
         rotationY: ceoPos.rotationY,
       });
 
-      // COOs — status-aware: idle at center, thinking/acting at desk
+      // COOs — status-aware: idle spread near center, thinking/acting at desk
       for (let i = 0; i < coos.length; i++) {
-        const pos = getStatusAwarePos(coos[i], mainZoneId, i);
+        const deskIdx = nextDeskIndex++;
+        const pos = getStatusAwarePos(coos[i], mainZoneId, deskIdx);
         positions.push({
           agent: coos[i],
           role: "coo",
@@ -97,7 +108,8 @@ export function LiveViewScene({ userProfile }: LiveViewSceneProps) {
 
       // Admin Assistants — status-aware
       for (let i = 0; i < adminAssistants.length; i++) {
-        const pos = getStatusAwarePos(adminAssistants[i], mainZoneId, coos.length + i);
+        const deskIdx = nextDeskIndex++;
+        const pos = getStatusAwarePos(adminAssistants[i], mainZoneId, deskIdx);
         positions.push({
           agent: adminAssistants[i],
           role: "admin_assistant",
@@ -117,7 +129,8 @@ export function LiveViewScene({ userProfile }: LiveViewSceneProps) {
           ? activeScene.zones.find((z) => z.projectId === tl.projectId)
           : null;
         const zoneId = projectZone?.id ?? mainZoneId;
-        const pos = getStatusAwarePos(tl, zoneId, 0);
+        const deskIdx = projectZone ? 0 : nextDeskIndex++;
+        const pos = getStatusAwarePos(tl, zoneId, deskIdx);
         positions.push({
           agent: tl,
           role: "team_lead",
@@ -137,7 +150,8 @@ export function LiveViewScene({ userProfile }: LiveViewSceneProps) {
           ? activeScene.zones.find((z) => z.projectId === w.projectId)
           : null;
         const zoneId = projectZone?.id ?? mainZoneId;
-        const pos = getStatusAwarePos(w, zoneId, i);
+        const deskIdx = projectZone ? i : nextDeskIndex++;
+        const pos = getStatusAwarePos(w, zoneId, deskIdx);
         positions.push({
           agent: w,
           role: "worker",


### PR DESCRIPTION
## Summary
- Replace `Pallet_Large` desk props with proper table models (`table_medium_Decorated` for CEO/COO, `table_medium` for others, `table_medium_long` for meeting)
- Add 3 new desk waypoints (`mo-desk-tl2`, `mo-desk-w1`, `mo-desk-w2`) bringing total to 8 desks
- Use a global `nextDeskIndex` counter across all roles so no two agents share a desk
- CEO always stays at its decorated desk (no idle-to-center switching)
- Idle agents spread in a 1.5-unit radius circle around center instead of all stacking on `mo-center`
- Project office desks also swapped from `Pallet_Large` to `table_medium`

## Test plan
- [ ] `npx pnpm dev` — verify each character sits at a unique desk with correct table models
- [ ] Spawn multiple agents — confirm no overlapping positions
- [ ] Toggle agent idle/working states — idle agents spread near center, working agents go to desks
- [ ] `npx pnpm test` — all 74 tests pass