### PR TITLE
fix: move CEO desk to back center of main office

### DIFF
--- a/assets/scenes/world-base.json
+++ b/assets/scenes/world-base.json
@@ -23,7 +23,7 @@
     { "asset": "kaykit-prototype-bits/Floor", "position": [4, -0.5, -14], "receiveShadow": true },
     { "asset": "kaykit-prototype-bits/Floor", "position": [8, -0.5, -14], "receiveShadow": true },
 
-    { "asset": "kaykit-prototype-bits/table_medium_Decorated", "position": [-7, 0, -3], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium", "position": [-7, 0, -3], "castShadow": true, "receiveShadow": true },
     { "asset": "kaykit-prototype-bits/table_medium_Decorated", "position": [-7, 0, -7], "castShadow": true, "receiveShadow": true },
     { "asset": "kaykit-prototype-bits/table_medium", "position": [7, 0, -3], "castShadow": true, "receiveShadow": true },
     { "asset": "kaykit-prototype-bits/table_medium", "position": [7, 0, -7], "castShadow": true, "receiveShadow": true },
@@ -31,6 +31,7 @@
     { "asset": "kaykit-prototype-bits/table_medium", "position": [-4, 0, -12], "castShadow": true, "receiveShadow": true },
     { "asset": "kaykit-prototype-bits/table_medium", "position": [4, 0, -12], "castShadow": true, "receiveShadow": true },
     { "asset": "kaykit-prototype-bits/table_medium", "position": [0, 0, -4], "castShadow": true, "receiveShadow": true },
+    { "asset": "kaykit-prototype-bits/table_medium_Decorated", "position": [0, 0, -14], "castShadow": true, "receiveShadow": true },
 
     { "asset": "kaykit-prototype-bits/Barrel_A", "position": [8.5, 0.5, -1], "castShadow": true },
     { "asset": "kaykit-prototype-bits/Box_A", "position": [-8.5, 0, -1.5], "scale": 2, "castShadow": true },
@@ -66,7 +67,8 @@
     "waypoints": [
       { "id": "mo-entrance", "position": [0, 0, -1], "label": "Main Entrance", "zoneId": "main-office", "tag": "entrance" },
       { "id": "mo-center", "position": [0, 0, -8], "label": "Main Center", "zoneId": "main-office", "tag": "center" },
-      { "id": "mo-desk-ceo", "position": [-7, 0, -2], "label": "CEO Desk", "zoneId": "main-office", "tag": "desk" },
+      { "id": "mo-desk-ceo", "position": [0, 0, -14], "label": "CEO Desk", "zoneId": "main-office", "tag": "desk" },
+      { "id": "mo-desk-w3", "position": [-7, 0, -2], "label": "Worker Desk 3", "zoneId": "main-office", "tag": "desk" },
       { "id": "mo-desk-coo", "position": [-7, 0, -6], "label": "COO Desk", "zoneId": "main-office", "tag": "desk" },
       { "id": "mo-desk-admin", "position": [7, 0, -2], "label": "Admin Desk", "zoneId": "main-office", "tag": "desk" },
       { "id": "mo-desk-tl1", "position": [7, 0, -6], "label": "Team Lead Desk 1", "zoneId": "main-office", "tag": "desk" },
@@ -88,7 +90,7 @@
     "edges": [
       { "from": "mo-entrance", "to": "mo-inner-1" },
       { "from": "mo-inner-1", "to": "mo-center" },
-      { "from": "mo-inner-1", "to": "mo-desk-ceo" },
+      { "from": "mo-inner-1", "to": "mo-desk-w3" },
       { "from": "mo-inner-1", "to": "mo-desk-coo" },
       { "from": "mo-center", "to": "mo-inner-2" },
       { "from": "mo-center", "to": "mo-inner-3" },
@@ -96,7 +98,8 @@
       { "from": "mo-inner-2", "to": "mo-desk-coo" },
       { "from": "mo-inner-3", "to": "mo-desk-tl1" },
       { "from": "mo-inner-3", "to": "mo-desk-admin" },
-      { "from": "mo-inner-2", "to": "mo-desk-ceo" },
+      { "from": "mo-inner-2", "to": "mo-desk-w3" },
+      { "from": "mo-center", "to": "mo-desk-ceo" },
       { "from": "mo-center", "to": "mo-desk-tl2" },
       { "from": "mo-inner-3", "to": "mo-desk-w1" },
       { "from": "mo-inner-1", "to": "mo-desk-w2" },
@@ -110,7 +113,7 @@
     ]
   },
   "agentPositions": {
-    "ceo": { "position": [-7, 0, -2], "rotation": 3.14159 },
+    "ceo": { "position": [0, 0, -14], "rotation": 3.14159 },
     "coo": [{ "position": [-7, 0, -6], "rotation": 3.14159 }],
     "teamLead": [
       { "position": [7, 0, -6], "rotation": 3.14159 },


### PR DESCRIPTION
## Summary
- Move CEO desk from `[-7, 0, -2]` to `[0, 0, -14]` — the back center ("top") of the main office with a `table_medium_Decorated`
- Old CEO spot becomes `mo-desk-w3` (worker desk) with a regular `table_medium`
- Updated edges and fallback agentPositions to match

## Test plan
- [ ] `npx pnpm dev` — CEO sits at the big decorated desk at the back of the room
- [ ] `npx pnpm test` — all 74 tests pass