### PR TITLE
fix: remove decorated table prop overlapping CEO character

### DIFF
--- a/assets/scenes/world-base.json
+++ b/assets/scenes/world-base.json
@@ -31,7 +31,6 @@
     { "asset": "kaykit-prototype-bits/table_medium", "position": [-4, 0, -12], "castShadow": true, "receiveShadow": true },
     { "asset": "kaykit-prototype-bits/table_medium", "position": [4, 0, -12], "castShadow": true, "receiveShadow": true },
     { "asset": "kaykit-prototype-bits/table_medium", "position": [0, 0, -4], "castShadow": true, "receiveShadow": true },
-    { "asset": "kaykit-prototype-bits/table_medium_Decorated", "position": [0, 0, -14], "castShadow": true, "receiveShadow": true },
 
     { "asset": "kaykit-prototype-bits/Barrel_A", "position": [8.5, 0.5, -1], "castShadow": true },
     { "asset": "kaykit-prototype-bits/Box_A", "position": [-8.5, 0, -1.5], "scale": 2, "castShadow": true },


### PR DESCRIPTION
## Summary
- Remove `table_medium_Decorated` prop at `[0, 0, -14]` that was rendering on top of the CEO character
- CEO now sits behind the `table_medium_long` meeting table at `[0, 0, -12]`

## Test plan
- [ ] `npx pnpm dev` — CEO visible without a table clipping through them