### PR TITLE
feat: unify Skills Center with Agent Templates

### DIFF
--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -283,6 +283,12 @@ export const skills = sqliteTable("skills", {
     .notNull()
     .default([]),
   body: text("body").notNull().default(""),
+  source: text("source", {
+    enum: ["built-in", "created", "imported", "cloned"],
+  })
+    .notNull()
+    .default("created"),
+  clonedFromId: text("cloned_from_id"),
   scanStatus: text("scan_status", {
     enum: ["clean", "warnings", "errors", "unscanned"],
   })

--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -9,10 +9,10 @@ const SEED_ENTRIES = [
     description:
       "Chief Operating Officer. Receives goals from the CEO and delegates to Team Leads.",
     systemPrompt: COO_SYSTEM_PROMPT,
-    capabilities: ["management", "delegation", "coordination"],
+    capabilities: [] as string[],
     defaultModel: "claude-sonnet-4-5-20250929",
     defaultProvider: "anthropic",
-    tools: [],
+    tools: [] as string[],
     builtIn: true,
     role: "coo" as const,
   },
@@ -22,10 +22,10 @@ const SEED_ENTRIES = [
     description:
       "Manages a team of workers for a project. Breaks directives into tasks and assigns them.",
     systemPrompt: TEAM_LEAD_PROMPT,
-    capabilities: ["management", "planning", "coordination"],
+    capabilities: [] as string[],
     defaultModel: "claude-sonnet-4-5-20250929",
     defaultProvider: "anthropic",
-    tools: [],
+    tools: [] as string[],
     builtIn: true,
     role: "team_lead" as const,
   },
@@ -34,19 +34,11 @@ const SEED_ENTRIES = [
     name: "Coder",
     description:
       "Writes and edits code. Proficient in multiple languages with a focus on clean, well-structured implementations.",
-    systemPrompt: `You are a skilled software developer. You write clean, well-tested code.
-
-Your responsibilities:
-- Write code based on specifications provided by your Team Lead
-- Follow existing patterns and conventions in the codebase
-- Write tests for your code when appropriate
-- Report progress and blockers to your Team Lead
-
-Be concise in your communication. Focus on delivering working code.`,
-    capabilities: ["code", "typescript", "python", "debugging"],
+    systemPrompt: "See assigned skills for instructions.",
+    capabilities: [] as string[],
     defaultModel: "claude-sonnet-4-5-20250929",
     defaultProvider: "anthropic",
-    tools: ["file_read", "file_write", "shell_exec", "install_package"],
+    tools: [] as string[],
     builtIn: true,
     role: "worker" as const,
   },
@@ -55,19 +47,11 @@ Be concise in your communication. Focus on delivering working code.`,
     name: "Researcher",
     description:
       "Gathers information, analyzes options, and provides well-structured findings and recommendations.",
-    systemPrompt: `You are a thorough researcher. You gather information, analyze options, and provide clear recommendations.
-
-Your responsibilities:
-- Research topics as directed by your Team Lead
-- Provide structured findings with sources and reasoning
-- Compare options with pros/cons when relevant
-- Be objective and flag uncertainties
-
-Present findings clearly and concisely. Lead with the key takeaway.`,
-    capabilities: ["research", "analysis", "summarization"],
+    systemPrompt: "See assigned skills for instructions.",
+    capabilities: [] as string[],
     defaultModel: "claude-sonnet-4-5-20250929",
     defaultProvider: "anthropic",
-    tools: ["web_search", "web_browse", "file_read"],
+    tools: [] as string[],
     builtIn: true,
     role: "worker" as const,
   },
@@ -76,19 +60,11 @@ Present findings clearly and concisely. Lead with the key takeaway.`,
     name: "Reviewer",
     description:
       "Reviews code and plans for quality, correctness, and potential issues.",
-    systemPrompt: `You are a meticulous code and plan reviewer. You catch bugs, suggest improvements, and ensure quality.
-
-Your responsibilities:
-- Review code for bugs, security issues, and style problems
-- Review plans for feasibility and completeness
-- Provide specific, actionable feedback
-- Approve or request changes with clear reasoning
-
-Be constructive but honest. Prioritize issues by severity.`,
-    capabilities: ["code-review", "testing", "quality"],
+    systemPrompt: "See assigned skills for instructions.",
+    capabilities: [] as string[],
     defaultModel: "claude-sonnet-4-5-20250929",
     defaultProvider: "anthropic",
-    tools: ["file_read"],
+    tools: [] as string[],
     builtIn: true,
     role: "worker" as const,
   },
@@ -97,19 +73,11 @@ Be constructive but honest. Prioritize issues by severity.`,
     name: "Writer",
     description:
       "Writes documentation, specifications, and prose. Clear, well-structured technical writing.",
-    systemPrompt: `You are a clear technical writer. You produce well-structured documentation and specifications.
-
-Your responsibilities:
-- Write documentation, specs, and prose as directed
-- Ensure clarity and accuracy
-- Follow the project's existing documentation style
-- Keep documentation concise and useful
-
-Write for your audience. Avoid jargon unless the audience expects it.`,
-    capabilities: ["writing", "documentation", "specs"],
+    systemPrompt: "See assigned skills for instructions.",
+    capabilities: [] as string[],
     defaultModel: "claude-sonnet-4-5-20250929",
     defaultProvider: "anthropic",
-    tools: ["file_read", "file_write"],
+    tools: [] as string[],
     builtIn: true,
     role: "worker" as const,
   },
@@ -118,19 +86,11 @@ Write for your audience. Avoid jargon unless the audience expects it.`,
     name: "Planner",
     description:
       "Breaks down goals into tasks and milestones. Designs project architecture and task dependencies.",
-    systemPrompt: `You are a project planner and architect. You break down complex goals into actionable tasks.
-
-Your responsibilities:
-- Decompose high-level goals into specific, actionable tasks
-- Identify dependencies between tasks
-- Estimate relative complexity
-- Design system architecture when needed
-
-Focus on clarity and completeness. Every task should be actionable by a single agent.`,
-    capabilities: ["planning", "architecture", "decomposition"],
+    systemPrompt: "See assigned skills for instructions.",
+    capabilities: [] as string[],
     defaultModel: "claude-sonnet-4-5-20250929",
     defaultProvider: "anthropic",
-    tools: ["file_read", "file_write"],
+    tools: [] as string[],
     builtIn: true,
     role: "worker" as const,
   },
@@ -139,19 +99,11 @@ Focus on clarity and completeness. Every task should be actionable by a single a
     name: "Security Reviewer",
     description:
       "Audits code for vulnerabilities, OWASP top 10 issues, and dependency risks.",
-    systemPrompt: `You are a security specialist. You audit code and systems for vulnerabilities.
-
-Your responsibilities:
-- Review code for security vulnerabilities (OWASP top 10, injection, auth issues)
-- Assess dependency risks
-- Recommend security improvements
-- Verify fixes address the identified vulnerabilities
-
-Be specific about risks and provide concrete remediation steps. Rate severity.`,
-    capabilities: ["security", "code-review", "vulnerability-analysis"],
+    systemPrompt: "See assigned skills for instructions.",
+    capabilities: [] as string[],
     defaultModel: "claude-sonnet-4-5-20250929",
     defaultProvider: "anthropic",
-    tools: ["file_read", "shell_exec"],
+    tools: [] as string[],
     builtIn: true,
     role: "worker" as const,
   },
@@ -160,19 +112,11 @@ Be specific about risks and provide concrete remediation steps. Rate severity.`,
     name: "Tester",
     description:
       "Writes and runs tests, identifies edge cases, and validates behavior against specifications.",
-    systemPrompt: `You are a quality assurance specialist. You write tests and validate behavior.
-
-Your responsibilities:
-- Write unit, integration, and e2e tests as needed
-- Identify edge cases and boundary conditions
-- Validate behavior against specifications
-- Report test results clearly
-
-Focus on meaningful test coverage. Test behavior, not implementation details.`,
-    capabilities: ["testing", "test-writing", "qa", "edge-cases"],
+    systemPrompt: "See assigned skills for instructions.",
+    capabilities: [] as string[],
     defaultModel: "claude-sonnet-4-5-20250929",
     defaultProvider: "anthropic",
-    tools: ["file_read", "file_write", "shell_exec", "install_package"],
+    tools: [] as string[],
     builtIn: true,
     role: "worker" as const,
   },
@@ -182,31 +126,11 @@ Focus on meaningful test coverage. Test behavior, not implementation details.`,
     description:
       "Delegates complex coding tasks to OpenCode, an autonomous AI coding agent. " +
       "Ideal for multi-file implementations, refactoring, and large code changes.",
-    systemPrompt: `You are a coding specialist that delegates implementation work to OpenCode, an autonomous AI coding agent.
-
-Your responsibilities:
-- Inspect the codebase with file_read to understand context before delegating
-- Formulate clear, detailed coding directives for OpenCode
-- Delegate implementation via opencode_task with precise instructions
-- Verify the results by reading key files after OpenCode completes
-- If the result is incorrect or incomplete, refine your instructions and retry
-- Report results (what was changed, files modified, any issues) to your Team Lead
-
-When delegating to OpenCode:
-- Be specific: include file paths, function names, and expected behavior
-- Provide context: mention relevant patterns, conventions, or constraints
-- One task at a time: break large changes into focused, sequential tasks
-- Verify after each task: read modified files to confirm correctness
-
-If OpenCode fails or produces incorrect results:
-- Read the error output carefully
-- Adjust your instructions to address the specific issue
-- Retry with more explicit guidance
-- If repeated failures occur, report the issue to your Team Lead with details`,
-    capabilities: ["code", "opencode", "autonomous-coding", "refactoring"],
+    systemPrompt: "See assigned skills for instructions.",
+    capabilities: [] as string[],
     defaultModel: "claude-sonnet-4-5-20250929",
     defaultProvider: "anthropic",
-    tools: ["opencode_task", "file_read"],
+    tools: [] as string[],
     builtIn: true,
     role: "worker" as const,
   },
@@ -215,29 +139,11 @@ If OpenCode fails or produces incorrect results:
     name: "Browser Agent",
     description:
       "Interacts with web pages using a headless browser. Can navigate, fill forms, click buttons, extract text, and evaluate JavaScript.",
-    systemPrompt: `You are a browser automation specialist. You interact with web pages using a headless browser.
-
-Your responsibilities:
-- Navigate to URLs and extract information
-- Fill out forms and click buttons as directed
-- Extract structured data from web pages
-- Report findings clearly and concisely
-
-When browsing:
-- Always start by navigating to the URL
-- Use get_text to read page content
-- Use CSS selectors for click and fill actions
-- Close the browser session when done
-- Report what you found, not the raw HTML`,
-    capabilities: [
-      "browser",
-      "web-scraping",
-      "form-filling",
-      "web-interaction",
-    ],
+    systemPrompt: "See assigned skills for instructions.",
+    capabilities: [] as string[],
     defaultModel: "claude-sonnet-4-5-20250929",
     defaultProvider: "anthropic",
-    tools: ["web_browse", "file_read", "file_write"],
+    tools: [] as string[],
     builtIn: true,
     role: "worker" as const,
   },

--- a/packages/server/src/skills/seed-skills.ts
+++ b/packages/server/src/skills/seed-skills.ts
@@ -1,0 +1,346 @@
+import { SkillService } from "./skill-service.js";
+import type { SkillCreate } from "@otterbot/shared";
+
+/**
+ * Built-in seed skill definitions.
+ * Each maps to a unique toolset + capability set extracted from the original seed registry entries.
+ */
+const SEED_SKILLS: Array<{ id: string; data: SkillCreate }> = [
+  {
+    id: "builtin-skill-coo-operations",
+    data: {
+      meta: {
+        name: "COO Operations",
+        description:
+          "Management tools for the COO: project creation, directives, model/search/package management, and shell commands.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: [
+          "run_command",
+          "create_project",
+          "send_directive",
+          "update_charter",
+          "update_project_status",
+          "get_project_status",
+          "manage_models",
+          "manage_search",
+          "web_search",
+          "manage_packages",
+        ],
+        capabilities: ["management", "delegation", "coordination"],
+        parameters: {},
+        tags: ["built-in", "coo"],
+      },
+      body: "",
+    },
+  },
+  {
+    id: "builtin-skill-team-lead-operations",
+    data: {
+      meta: {
+        name: "Team Lead Operations",
+        description:
+          "Management tools for Team Leads: registry search, worker spawning, task management, and reporting.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: [
+          "search_registry",
+          "spawn_worker",
+          "web_search",
+          "report_to_coo",
+          "create_task",
+          "update_task",
+          "list_tasks",
+        ],
+        capabilities: ["management", "planning", "coordination"],
+        parameters: {},
+        tags: ["built-in", "team-lead"],
+      },
+      body: "",
+    },
+  },
+  {
+    id: "builtin-skill-coding-tools",
+    data: {
+      meta: {
+        name: "Coding Tools",
+        description:
+          "File read/write, shell execution, and package installation for software development.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: ["file_read", "file_write", "shell_exec", "install_package"],
+        capabilities: ["code", "typescript", "python", "debugging"],
+        parameters: {},
+        tags: ["built-in", "coding"],
+      },
+      body: `You are a skilled software developer. You write clean, well-tested code.
+
+Your responsibilities:
+- Write code based on specifications provided by your Team Lead
+- Follow existing patterns and conventions in the codebase
+- Write tests for your code when appropriate
+- Report progress and blockers to your Team Lead
+
+Be concise in your communication. Focus on delivering working code.`,
+    },
+  },
+  {
+    id: "builtin-skill-research-tools",
+    data: {
+      meta: {
+        name: "Research Tools",
+        description:
+          "Web search, web browsing, and file reading for research and analysis.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: ["web_search", "web_browse", "file_read"],
+        capabilities: ["research", "analysis", "summarization"],
+        parameters: {},
+        tags: ["built-in", "research"],
+      },
+      body: `You are a thorough researcher. You gather information, analyze options, and provide clear recommendations.
+
+Your responsibilities:
+- Research topics as directed by your Team Lead
+- Provide structured findings with sources and reasoning
+- Compare options with pros/cons when relevant
+- Be objective and flag uncertainties
+
+Present findings clearly and concisely. Lead with the key takeaway.`,
+    },
+  },
+  {
+    id: "builtin-skill-review-tools",
+    data: {
+      meta: {
+        name: "Review Tools",
+        description:
+          "File reading for code and plan review, quality assurance, and testing.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: ["file_read"],
+        capabilities: ["code-review", "testing", "quality"],
+        parameters: {},
+        tags: ["built-in", "review"],
+      },
+      body: `You are a meticulous code and plan reviewer. You catch bugs, suggest improvements, and ensure quality.
+
+Your responsibilities:
+- Review code for bugs, security issues, and style problems
+- Review plans for feasibility and completeness
+- Provide specific, actionable feedback
+- Approve or request changes with clear reasoning
+
+Be constructive but honest. Prioritize issues by severity.`,
+    },
+  },
+  {
+    id: "builtin-skill-writing-tools",
+    data: {
+      meta: {
+        name: "Writing Tools",
+        description:
+          "File read/write for documentation, specifications, and technical writing.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: ["file_read", "file_write"],
+        capabilities: ["writing", "documentation", "specs"],
+        parameters: {},
+        tags: ["built-in", "writing"],
+      },
+      body: `You are a clear technical writer. You produce well-structured documentation and specifications.
+
+Your responsibilities:
+- Write documentation, specs, and prose as directed
+- Ensure clarity and accuracy
+- Follow the project's existing documentation style
+- Keep documentation concise and useful
+
+Write for your audience. Avoid jargon unless the audience expects it.`,
+    },
+  },
+  {
+    id: "builtin-skill-planning-tools",
+    data: {
+      meta: {
+        name: "Planning Tools",
+        description:
+          "File read/write for project planning, architecture design, and task decomposition.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: ["file_read", "file_write"],
+        capabilities: ["planning", "architecture", "decomposition"],
+        parameters: {},
+        tags: ["built-in", "planning"],
+      },
+      body: `You are a project planner and architect. You break down complex goals into actionable tasks.
+
+Your responsibilities:
+- Decompose high-level goals into specific, actionable tasks
+- Identify dependencies between tasks
+- Estimate relative complexity
+- Design system architecture when needed
+
+Focus on clarity and completeness. Every task should be actionable by a single agent.`,
+    },
+  },
+  {
+    id: "builtin-skill-security-review-tools",
+    data: {
+      meta: {
+        name: "Security Review Tools",
+        description:
+          "File reading and shell execution for security auditing and vulnerability analysis.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: ["file_read", "shell_exec"],
+        capabilities: ["security", "code-review", "vulnerability-analysis"],
+        parameters: {},
+        tags: ["built-in", "security"],
+      },
+      body: `You are a security specialist. You audit code and systems for vulnerabilities.
+
+Your responsibilities:
+- Review code for security vulnerabilities (OWASP top 10, injection, auth issues)
+- Assess dependency risks
+- Recommend security improvements
+- Verify fixes address the identified vulnerabilities
+
+Be specific about risks and provide concrete remediation steps. Rate severity.`,
+    },
+  },
+  {
+    id: "builtin-skill-testing-tools",
+    data: {
+      meta: {
+        name: "Testing Tools",
+        description:
+          "File read/write, shell execution, and package installation for test writing and QA.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: ["file_read", "file_write", "shell_exec", "install_package"],
+        capabilities: ["testing", "test-writing", "qa", "edge-cases"],
+        parameters: {},
+        tags: ["built-in", "testing"],
+      },
+      body: `You are a quality assurance specialist. You write tests and validate behavior.
+
+Your responsibilities:
+- Write unit, integration, and e2e tests as needed
+- Identify edge cases and boundary conditions
+- Validate behavior against specifications
+- Report test results clearly
+
+Focus on meaningful test coverage. Test behavior, not implementation details.`,
+    },
+  },
+  {
+    id: "builtin-skill-opencode-delegation",
+    data: {
+      meta: {
+        name: "OpenCode Delegation",
+        description:
+          "Delegates complex coding tasks to OpenCode, an autonomous AI coding agent.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: ["opencode_task", "file_read"],
+        capabilities: ["code", "opencode", "autonomous-coding", "refactoring"],
+        parameters: {},
+        tags: ["built-in", "opencode"],
+      },
+      body: `You are a coding specialist that delegates implementation work to OpenCode, an autonomous AI coding agent.
+
+Your responsibilities:
+- Inspect the codebase with file_read to understand context before delegating
+- Formulate clear, detailed coding directives for OpenCode
+- Delegate implementation via opencode_task with precise instructions
+- Verify the results by reading key files after OpenCode completes
+- If the result is incorrect or incomplete, refine your instructions and retry
+- Report results (what was changed, files modified, any issues) to your Team Lead
+
+When delegating to OpenCode:
+- Be specific: include file paths, function names, and expected behavior
+- Provide context: mention relevant patterns, conventions, or constraints
+- One task at a time: break large changes into focused, sequential tasks
+- Verify after each task: read modified files to confirm correctness
+
+If OpenCode fails or produces incorrect results:
+- Read the error output carefully
+- Adjust your instructions to address the specific issue
+- Retry with more explicit guidance
+- If repeated failures occur, report the issue to your Team Lead with details`,
+    },
+  },
+  {
+    id: "builtin-skill-browser-automation",
+    data: {
+      meta: {
+        name: "Browser Automation",
+        description:
+          "Headless browser interaction for web scraping, form filling, and web automation.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: ["web_browse", "file_read", "file_write"],
+        capabilities: [
+          "browser",
+          "web-scraping",
+          "form-filling",
+          "web-interaction",
+        ],
+        parameters: {},
+        tags: ["built-in", "browser"],
+      },
+      body: `You are a browser automation specialist. You interact with web pages using a headless browser.
+
+Your responsibilities:
+- Navigate to URLs and extract information
+- Fill out forms and click buttons as directed
+- Extract structured data from web pages
+- Report findings clearly and concisely
+
+When browsing:
+- Always start by navigating to the URL
+- Use get_text to read page content
+- Use CSS selectors for click and fill actions
+- Close the browser session when done
+- Report what you found, not the raw HTML`,
+    },
+  },
+];
+
+/**
+ * Mapping from built-in registry entry IDs to their assigned skill IDs.
+ */
+const ENTRY_SKILL_ASSIGNMENTS: Record<string, string[]> = {
+  "builtin-coo": ["builtin-skill-coo-operations"],
+  "builtin-team-lead": ["builtin-skill-team-lead-operations"],
+  "builtin-coder": ["builtin-skill-coding-tools"],
+  "builtin-researcher": ["builtin-skill-research-tools"],
+  "builtin-reviewer": ["builtin-skill-review-tools"],
+  "builtin-writer": ["builtin-skill-writing-tools"],
+  "builtin-planner": ["builtin-skill-planning-tools"],
+  "builtin-security-reviewer": ["builtin-skill-security-review-tools"],
+  "builtin-tester": ["builtin-skill-testing-tools"],
+  "builtin-opencode-coder": ["builtin-skill-opencode-delegation"],
+  "builtin-browser-agent": ["builtin-skill-browser-automation"],
+};
+
+/**
+ * Seed all built-in skills and their registry entry assignments.
+ * Safe to call on every startup (idempotent upsert).
+ */
+export function seedBuiltInSkills(): void {
+  const skillService = new SkillService();
+
+  // Upsert all built-in skills
+  for (const { id, data } of SEED_SKILLS) {
+    skillService.upsert(id, data, "built-in");
+  }
+
+  // Seed skill assignments for built-in entries
+  for (const [entryId, skillIds] of Object.entries(ENTRY_SKILL_ASSIGNMENTS)) {
+    skillService.setAgentSkills(entryId, skillIds);
+  }
+}
+
+export { SEED_SKILLS, ENTRY_SKILL_ASSIGNMENTS };

--- a/packages/shared/src/types/registry.ts
+++ b/packages/shared/src/types/registry.ts
@@ -6,9 +6,11 @@ export interface RegistryEntry {
   description: string;
   systemPrompt: string;
   promptAddendum: string | null;
+  /** Derived from assigned skills — not stored on the entry directly */
   capabilities: string[];
   defaultModel: string;
   defaultProvider: string;
+  /** Derived from assigned skills — not stored on the entry directly */
   tools: string[];
   builtIn: boolean;
   role: "coo" | "team_lead" | "worker";
@@ -23,14 +25,14 @@ export interface RegistryEntryCreate {
   description: string;
   systemPrompt: string;
   promptAddendum?: string | null;
-  capabilities: string[];
   defaultModel: string;
   defaultProvider: string;
-  tools: string[];
   role?: "coo" | "team_lead" | "worker";
   clonedFromId?: string | null;
   modelPackId?: string | null;
   gearConfig?: GearConfig | null;
+  /** Optional skill IDs to assign after creation */
+  skillIds?: string[];
 }
 
 export interface RegistryEntryUpdate {
@@ -38,10 +40,8 @@ export interface RegistryEntryUpdate {
   description?: string;
   systemPrompt?: string;
   promptAddendum?: string | null;
-  capabilities?: string[];
   defaultModel?: string;
   defaultProvider?: string;
-  tools?: string[];
   modelPackId?: string | null;
   gearConfig?: GearConfig | null;
 }

--- a/packages/shared/src/types/skill.ts
+++ b/packages/shared/src/types/skill.ts
@@ -32,10 +32,14 @@ export interface ScanReport {
 
 export type SkillScanStatus = "clean" | "warnings" | "errors" | "unscanned";
 
+export type SkillSource = "built-in" | "created" | "imported" | "cloned";
+
 export interface Skill {
   id: string;
   meta: SkillMeta;
   body: string;
+  source: SkillSource;
+  clonedFromId: string | null;
   scanStatus: SkillScanStatus;
   scanFindings: ScanFinding[];
   createdAt: string;

--- a/packages/web/src/components/settings/SkillsCenterSection.tsx
+++ b/packages/web/src/components/settings/SkillsCenterSection.tsx
@@ -14,6 +14,7 @@ export function SkillsCenterSection() {
   const createSkill = useSkillsStore((s) => s.createSkill);
   const updateSkill = useSkillsStore((s) => s.updateSkill);
   const deleteSkill = useSkillsStore((s) => s.deleteSkill);
+  const cloneSkill = useSkillsStore((s) => s.cloneSkill);
   const importSkill = useSkillsStore((s) => s.importSkill);
   const exportSkill = useSkillsStore((s) => s.exportSkill);
   const availableTools = useSkillsStore((s) => s.availableTools);
@@ -54,6 +55,10 @@ export function SkillsCenterSection() {
     } else {
       await createSkill({ meta, body });
     }
+  };
+
+  const handleClone = async (id: string) => {
+    await cloneSkill(id);
   };
 
   const handleDelete = async (id: string) => {
@@ -152,6 +157,7 @@ export function SkillsCenterSection() {
               onEdit={handleEditSkill}
               onExport={exportSkill}
               onDelete={handleDelete}
+              onClone={handleClone}
               onViewScan={setScanViewSkill}
             />
           ))}

--- a/packages/web/src/components/settings/skills/SkillCard.tsx
+++ b/packages/web/src/components/settings/skills/SkillCard.tsx
@@ -15,15 +15,30 @@ const SCAN_STATUS_LABELS: Record<string, string> = {
   unscanned: "Not Scanned",
 };
 
+const SOURCE_STYLES: Record<string, string> = {
+  "built-in": "bg-blue-500/15 text-blue-400",
+  created: "bg-secondary text-muted-foreground",
+  imported: "bg-purple-500/15 text-purple-400",
+  cloned: "bg-orange-500/15 text-orange-400",
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  "built-in": "Built-in",
+  created: "Created",
+  imported: "Imported",
+  cloned: "Cloned",
+};
+
 interface SkillCardProps {
   skill: Skill;
   onEdit: (skill: Skill) => void;
   onExport: (id: string) => void;
   onDelete: (id: string) => void;
+  onClone: (id: string) => void;
   onViewScan: (skill: Skill) => void;
 }
 
-export function SkillCard({ skill, onEdit, onExport, onDelete, onViewScan }: SkillCardProps) {
+export function SkillCard({ skill, onEdit, onExport, onDelete, onClone, onViewScan }: SkillCardProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -44,6 +59,11 @@ export function SkillCard({ skill, onEdit, onExport, onDelete, onViewScan }: Ski
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <h4 className="text-sm font-medium truncate">{skill.meta.name}</h4>
+            <span
+              className={`text-[9px] px-1.5 py-0.5 rounded font-medium ${SOURCE_STYLES[skill.source] ?? SOURCE_STYLES.created}`}
+            >
+              {SOURCE_LABELS[skill.source] ?? "Created"}
+            </span>
             <span
               className={`text-[9px] px-1.5 py-0.5 rounded font-medium ${SCAN_STATUS_STYLES[skill.scanStatus]}`}
             >
@@ -71,11 +91,19 @@ export function SkillCard({ skill, onEdit, onExport, onDelete, onViewScan }: Ski
           </button>
           {menuOpen && (
             <div className="absolute right-0 top-full mt-1 w-32 rounded-md border border-border bg-popover shadow-lg z-10">
+              {skill.source !== "built-in" && (
+                <button
+                  onClick={() => { onEdit(skill); setMenuOpen(false); }}
+                  className="w-full text-left text-xs px-3 py-1.5 hover:bg-secondary transition-colors"
+                >
+                  Edit
+                </button>
+              )}
               <button
-                onClick={() => { onEdit(skill); setMenuOpen(false); }}
+                onClick={() => { onClone(skill.id); setMenuOpen(false); }}
                 className="w-full text-left text-xs px-3 py-1.5 hover:bg-secondary transition-colors"
               >
-                Edit
+                Clone
               </button>
               <button
                 onClick={() => { onExport(skill.id); setMenuOpen(false); }}
@@ -89,12 +117,14 @@ export function SkillCard({ skill, onEdit, onExport, onDelete, onViewScan }: Ski
               >
                 View Scan
               </button>
-              <button
-                onClick={() => { onDelete(skill.id); setMenuOpen(false); }}
-                className="w-full text-left text-xs px-3 py-1.5 hover:bg-secondary text-red-400 transition-colors"
-              >
-                Delete
-              </button>
+              {skill.source !== "built-in" && (
+                <button
+                  onClick={() => { onDelete(skill.id); setMenuOpen(false); }}
+                  className="w-full text-left text-xs px-3 py-1.5 hover:bg-secondary text-red-400 transition-colors"
+                >
+                  Delete
+                </button>
+              )}
             </div>
           )}
         </div>

--- a/packages/web/src/stores/skills-store.ts
+++ b/packages/web/src/stores/skills-store.ts
@@ -13,6 +13,7 @@ interface SkillsState {
   createSkill: (data: SkillCreate) => Promise<Skill | null>;
   updateSkill: (id: string, data: SkillUpdate) => Promise<Skill | null>;
   deleteSkill: (id: string) => Promise<boolean>;
+  cloneSkill: (id: string) => Promise<Skill | null>;
   importSkill: (file: File) => Promise<{ skill: Skill; scanReport: ScanReport } | null>;
   exportSkill: (id: string) => Promise<void>;
   scanContent: (content: string) => Promise<ScanReport | null>;
@@ -97,6 +98,23 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
     } catch (err) {
       set({ error: err instanceof Error ? err.message : "Unknown error" });
       return false;
+    }
+  },
+
+  cloneSkill: async (id) => {
+    set({ error: null });
+    try {
+      const res = await fetch(`/api/skills/${id}/clone`, { method: "POST" });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to clone skill");
+      }
+      const skill = await res.json();
+      await get().loadSkills();
+      return skill as Skill;
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+      return null;
     }
   },
 


### PR DESCRIPTION
## Summary

- **Skills become the single source of truth** for tools, capabilities, and specialized instructions. Agent templates reference skills instead of directly listing tools/capabilities.
- **11 built-in seed skills** are auto-created on startup (e.g., "Coding Tools", "Research Tools", "COO Operations"), each mapped to their corresponding built-in registry entry.
- **COO, TeamLead, and Worker** all resolve their tools from assigned skills at runtime, enabling custom skill assignments per agent clone.
- **Frontend updated**: tools/capabilities input fields removed from Agent Templates; derived read-only badges shown instead. SkillCard gains source badges (Built-in/Created/Imported/Cloned) and a Clone action. Built-in skills are protected from edit/delete.

## Key changes

| Area | Change |
|---|---|
| `packages/shared/src/types/skill.ts` | Added `SkillSource` type, `source` and `clonedFromId` fields |
| `packages/shared/src/types/registry.ts` | Removed `tools`/`capabilities` from Create/Update types |
| `packages/server/src/skills/seed-skills.ts` | New file: 11 built-in skill definitions + assignment mapping |
| `packages/server/src/registry/registry.ts` | Derives tools/caps from skills; clone copies skill assignments |
| `packages/server/src/agents/coo.ts` | Filters tools via assigned skills |
| `packages/server/src/agents/team-lead.ts` | Filters tools via skills; spawnWorker derives tools from skills |
| `packages/server/src/index.ts` | Clone endpoint, built-in protection, import sets source |
| `packages/web/` | Removed tools/caps fields, added derived badges, source badges, clone action |

## Migration

Safe and automatic — on first startup:
1. New `source` and `cloned_from_id` columns added to `skills` table
2. Built-in skills are seeded with `source: "built-in"`
3. Existing user-created skills default to `source: "created"`
4. `agentSkills` assignments link built-in entries to their skills
5. DB `tools`/`capabilities` columns on `registry_entries` remain (unused) for backward compat

## Test plan

- [x] `npx pnpm test` — all 99 tests pass
- [x] Type-check clean for shared, server, web (pre-existing google/admin-assistant errors excluded)
- [ ] Manual: start dev server, verify built-in skills appear in Skills Center with "Built-in" badge
- [ ] Manual: verify Agent Templates show skills + derived tools/capabilities badges
- [ ] Manual: create a project via chat, verify workers get correct tools from skills
- [ ] Manual: clone a built-in skill, verify it's editable with "Cloned" badge