### PR TITLE
feat: add Admin Assistant to setup wizard

### DIFF
--- a/packages/server/src/agents/admin-assistant.ts
+++ b/packages/server/src/agents/admin-assistant.ts
@@ -7,7 +7,7 @@ import {
 import { BaseAgent, type AgentOptions } from "./agent.js";
 import type { MessageBus } from "../bus/message-bus.js";
 import { createAdminTools } from "../tools/tool-factory.js";
-import { ADMIN_ASSISTANT_PROMPT } from "./prompts/admin-assistant.js";
+import { buildAdminAssistantPrompt } from "./prompts/admin-assistant.js";
 import { getConfig } from "../auth/auth.js";
 
 const ADMIN_ASSISTANT_ID = "admin-assistant";
@@ -35,7 +35,8 @@ export class AdminAssistant extends BaseAgent {
       day: "numeric",
     });
 
-    let systemPrompt = ADMIN_ASSISTANT_PROMPT;
+    const agentName = getConfig("admin_assistant_name") ?? "Admin Assistant";
+    let systemPrompt = buildAdminAssistantPrompt(agentName);
     systemPrompt += `\n\n## Current Date\nToday is ${dateStr}. Current time: ${now.toISOString()}.`;
 
     // Inject user profile context
@@ -47,6 +48,11 @@ export class AdminAssistant extends BaseAgent {
       systemPrompt = lines.join("\n") + "\n\n" + systemPrompt;
     }
 
+    // Read optional 3D character config
+    const modelPackId = getConfig("admin_assistant_model_pack_id") ?? null;
+    const gearConfigRaw = getConfig("admin_assistant_gear_config");
+    const gearConfig = gearConfigRaw ? JSON.parse(gearConfigRaw) : null;
+
     const options: AgentOptions = {
       id: ADMIN_ASSISTANT_ID,
       role: AgentRole.AdminAssistant,
@@ -55,8 +61,8 @@ export class AdminAssistant extends BaseAgent {
       model: getConfig("coo_model") ?? "claude-sonnet-4-5-20250929",
       provider: getConfig("coo_provider") ?? "anthropic",
       systemPrompt,
-      modelPackId: null,
-      gearConfig: null,
+      modelPackId,
+      gearConfig,
       onStatusChange: deps.onStatusChange,
     };
 

--- a/packages/server/src/agents/prompts/admin-assistant.ts
+++ b/packages/server/src/agents/prompts/admin-assistant.ts
@@ -1,4 +1,9 @@
-export const ADMIN_ASSISTANT_PROMPT = `You are the Admin Assistant in Otterbot. You help the CEO (the human user) with personal productivity tasks — managing emails, calendars, and todos.
+export function buildAdminAssistantPrompt(name: string): string {
+  return `You are ${name}, the Admin Assistant in Otterbot. You help the CEO (the human user) with personal productivity tasks — managing emails, calendars, and todos.
+${ADMIN_ASSISTANT_PROMPT_BODY}`;
+}
+
+const ADMIN_ASSISTANT_PROMPT_BODY = `
 
 ## Your Personality
 - Friendly, efficient, and proactive

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -613,6 +613,9 @@ async function main() {
       searchProvider?: string;
       searchApiKey?: string;
       searchBaseUrl?: string;
+      adminName: string;
+      adminModelPackId?: string;
+      adminGearConfig?: Record<string, boolean> | null;
     };
   }>("/api/setup/complete", async (req, reply) => {
     if (isSetupComplete()) {
@@ -625,7 +628,7 @@ async function main() {
       return { error: "Passphrase not set. Start setup from the beginning." };
     }
 
-    const { provider, providerName, model, apiKey, baseUrl, userName, userAvatar, userBio, userTimezone, ttsVoice, ttsProvider, userModelPackId, userGearConfig, cooName, cooModelPackId, cooGearConfig, searchProvider, searchApiKey, searchBaseUrl } = req.body;
+    const { provider, providerName, model, apiKey, baseUrl, userName, userAvatar, userBio, userTimezone, ttsVoice, ttsProvider, userModelPackId, userGearConfig, cooName, cooModelPackId, cooGearConfig, searchProvider, searchApiKey, searchBaseUrl, adminName, adminModelPackId, adminGearConfig } = req.body;
 
     if (!provider || !model) {
       reply.code(400);
@@ -642,6 +645,10 @@ async function main() {
     if (!cooName || !cooName.trim()) {
       reply.code(400);
       return { error: "COO name is required" };
+    }
+    if (!adminName || !adminName.trim()) {
+      reply.code(400);
+      return { error: "Admin Assistant name is required" };
     }
 
     const typeMeta = PROVIDER_TYPE_META.find((m) => m.type === provider);
@@ -702,6 +709,15 @@ async function main() {
         skillIds: sourceSkills.map((s) => s.id),
       });
       setConfig("coo_registry_id", cooClone.id);
+    }
+
+    // Admin Assistant config
+    setConfig("admin_assistant_name", adminName.trim());
+    if (adminModelPackId) {
+      setConfig("admin_assistant_model_pack_id", adminModelPackId);
+    }
+    if (adminGearConfig) {
+      setConfig("admin_assistant_gear_config", JSON.stringify(adminGearConfig));
     }
 
     startCoo();
@@ -1535,6 +1551,7 @@ async function main() {
       modelPackId: getConfig("user_model_pack_id") ?? null,
       gearConfig: gearConfigRaw ? JSON.parse(gearConfigRaw) : null,
       cooName: cooEntry?.name ?? "COO",
+      adminName: getConfig("admin_assistant_name") ?? "Admin Assistant",
     };
   });
 

--- a/packages/web/src/components/character-select/CharacterSelect.tsx
+++ b/packages/web/src/components/character-select/CharacterSelect.tsx
@@ -15,9 +15,14 @@ interface CharacterSelectProps {
   loading?: boolean;
   gearConfig?: GearConfig | null;
   onGearConfigChange?: (config: GearConfig | null) => void;
+  excludeIds?: string[];
 }
 
-export function CharacterSelect({ packs, selected, onSelect, loading, gearConfig, onGearConfigChange }: CharacterSelectProps) {
+export function CharacterSelect({ packs, selected, onSelect, loading, gearConfig, onGearConfigChange, excludeIds }: CharacterSelectProps) {
+  const filteredPacks = useMemo(
+    () => excludeIds?.length ? packs.filter((p) => !excludeIds.includes(p.id)) : packs,
+    [packs, excludeIds],
+  );
   const selectedPack = packs.find((p) => p.id === selected);
   const [discoveredGear, setDiscoveredGear] = useState<string[]>([]);
 
@@ -149,7 +154,7 @@ export function CharacterSelect({ packs, selected, onSelect, loading, gearConfig
         )}
 
         {/* Character cards */}
-        {packs.map((pack) => (
+        {filteredPacks.map((pack) => (
           <CharacterCard
             key={pack.id}
             pack={pack}

--- a/packages/web/src/components/setup/SetupWizard.tsx
+++ b/packages/web/src/components/setup/SetupWizard.tsx
@@ -138,6 +138,11 @@ export function SetupWizard() {
   const [cooName, setCooName] = useState("");
   const [cooModelPackId, setCooModelPackId] = useState<string | null>(null);
   const [cooGearConfig, setCooGearConfig] = useState<GearConfig | null>(null);
+
+  // Step 6: Admin Assistant customization
+  const [adminName, setAdminName] = useState("");
+  const [adminModelPackId, setAdminModelPackId] = useState<string | null>(null);
+  const [adminGearConfig, setAdminGearConfig] = useState<GearConfig | null>(null);
   const modelPacks = useModelPackStore((s) => s.packs);
   const modelPacksLoading = useModelPackStore((s) => s.loading);
   const loadPacks = useModelPackStore((s) => s.loadPacks);
@@ -306,7 +311,7 @@ export function SetupWizard() {
     setStep(5);
   };
 
-  const handleNextToSearch = () => {
+  const handleNextToAdmin = () => {
     if (!cooName.trim()) {
       setError("A name for your COO is required");
       return;
@@ -315,9 +320,18 @@ export function SetupWizard() {
     setStep(6);
   };
 
-  const handleNextToVoice = () => {
+  const handleNextToSearch = () => {
+    if (!adminName.trim()) {
+      setError("A name for your Admin Assistant is required");
+      return;
+    }
     setError(null);
     setStep(7);
+  };
+
+  const handleNextToVoice = () => {
+    setError(null);
+    setStep(8);
   };
 
   const handleComplete = async () => {
@@ -342,6 +356,9 @@ export function SetupWizard() {
       searchProvider: searchProvider || undefined,
       searchApiKey: searchApiKey || undefined,
       searchBaseUrl: searchBaseUrl || undefined,
+      adminName: adminName.trim(),
+      adminModelPackId: adminModelPackId || undefined,
+      adminGearConfig: adminGearConfig || undefined,
     });
     setSubmitting(false);
   };
@@ -405,7 +422,7 @@ export function SetupWizard() {
 
           {/* Step indicator */}
           <div className="flex items-center justify-center gap-2 mb-6">
-            {[1, 2, 3, 4, 5, 6, 7].map((s, i) => (
+            {[1, 2, 3, 4, 5, 6, 7, 8].map((s, i) => (
               <div key={s} className="flex items-center gap-2">
                 {i > 0 && (
                   <div className={`w-6 h-px ${step >= s ? "bg-primary" : "bg-muted"}`} />
@@ -915,6 +932,7 @@ export function SetupWizard() {
                 loading={modelPacksLoading}
                 gearConfig={cooGearConfig}
                 onGearConfigChange={setCooGearConfig}
+                excludeIds={[characterPackId].filter(Boolean) as string[]}
               />
 
               {error && <p className="text-sm text-destructive">{error}</p>}
@@ -930,7 +948,7 @@ export function SetupWizard() {
                   Back
                 </button>
                 <button
-                  onClick={handleNextToSearch}
+                  onClick={handleNextToAdmin}
                   disabled={!cooName.trim()}
                   className="flex-1 px-4 py-2 bg-primary text-primary-foreground text-sm font-medium rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
@@ -943,7 +961,65 @@ export function SetupWizard() {
           {step === 6 && (
             <div className="space-y-4">
               <h2 className="text-sm font-medium">
-                6. Set up web search
+                6. Customize your Admin Assistant
+              </h2>
+              <p className="text-xs text-muted-foreground">
+                Your Admin Assistant handles personal productivity — managing your todos, email (Gmail), and calendar. Give them a name and optionally pick a 3D character.
+              </p>
+
+              {/* Admin Assistant Name */}
+              <div>
+                <label className="block text-sm text-muted-foreground mb-1.5">
+                  Name <span className="text-destructive">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={adminName}
+                  onChange={(e) => setAdminName(e.target.value)}
+                  placeholder="e.g. Pepper, Friday, Sage..."
+                  autoFocus
+                  className="w-full px-3 py-2 bg-background border border-input rounded-md text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+
+              {/* Admin Assistant 3D Character */}
+              <CharacterSelect
+                packs={modelPacks}
+                selected={adminModelPackId}
+                onSelect={(id) => { setAdminModelPackId(id); setAdminGearConfig(null); }}
+                loading={modelPacksLoading}
+                gearConfig={adminGearConfig}
+                onGearConfigChange={setAdminGearConfig}
+                excludeIds={[characterPackId, cooModelPackId].filter(Boolean) as string[]}
+              />
+
+              {error && <p className="text-sm text-destructive">{error}</p>}
+
+              <div className="flex gap-2">
+                <button
+                  onClick={() => {
+                    setStep(5);
+                    setError(null);
+                  }}
+                  className="px-4 py-2 bg-secondary text-secondary-foreground text-sm font-medium rounded-md hover:bg-secondary/80 transition-colors"
+                >
+                  Back
+                </button>
+                <button
+                  onClick={handleNextToSearch}
+                  disabled={!adminName.trim()}
+                  className="flex-1 px-4 py-2 bg-primary text-primary-foreground text-sm font-medium rounded-md hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 7 && (
+            <div className="space-y-4">
+              <h2 className="text-sm font-medium">
+                7. Set up web search
               </h2>
               <p className="text-xs text-muted-foreground">
                 Give your agents the ability to search the web. DuckDuckGo works
@@ -1015,7 +1091,7 @@ export function SetupWizard() {
               <div className="flex gap-2">
                 <button
                   onClick={() => {
-                    setStep(5);
+                    setStep(6);
                     setError(null);
                   }}
                   className="px-4 py-2 bg-secondary text-secondary-foreground text-sm font-medium rounded-md hover:bg-secondary/80 transition-colors"
@@ -1042,10 +1118,10 @@ export function SetupWizard() {
             </div>
           )}
 
-          {step === 7 && (
+          {step === 8 && (
             <div className="space-y-4">
               <h2 className="text-sm font-medium">
-                7. Choose a voice for your assistant
+                8. Choose a voice for your assistant
               </h2>
               <p className="text-xs text-muted-foreground">
                 Your assistant can speak its responses aloud. Pick a TTS
@@ -1197,7 +1273,7 @@ export function SetupWizard() {
               <div className="flex gap-2">
                 <button
                   onClick={() => {
-                    setStep(6);
+                    setStep(7);
                     setError(null);
                   }}
                   className="px-4 py-2 bg-secondary text-secondary-foreground text-sm font-medium rounded-md hover:bg-secondary/80 transition-colors"

--- a/packages/web/src/stores/auth-store.ts
+++ b/packages/web/src/stores/auth-store.ts
@@ -32,6 +32,9 @@ interface AuthState {
     searchProvider?: string;
     searchApiKey?: string;
     searchBaseUrl?: string;
+    adminName: string;
+    adminModelPackId?: string;
+    adminGearConfig?: Record<string, boolean> | null;
   }) => Promise<boolean>;
   logout: () => Promise<void>;
   setError: (error: string | null) => void;


### PR DESCRIPTION
## Summary

- Adds a new setup wizard step (step 6) for customizing the Admin Assistant agent
- Users can name their Admin Assistant, see a description of its capabilities (todos, Gmail, calendar), and pick a unique 3D character
- New `excludeIds` prop on `CharacterSelect` ensures each agent gets a distinct 3D character
- Server persists `admin_assistant_name`, `admin_assistant_model_pack_id`, and `admin_assistant_gear_config`
- Admin Assistant agent reads its name and 3D config from stored settings at startup
- `/api/profile` now returns `adminName`

## Test plan

- [ ] Run setup wizard — step 6 shows Admin Assistant name input, description, and character select
- [ ] Characters chosen in steps 4 (user) and 5 (COO) are excluded from step 6
- [ ] Complete setup — verify config keys saved in DB
- [ ] `/api/profile` returns `adminName`
- [ ] Admin Assistant system prompt includes the configured name
- [ ] `npx pnpm build` — clean
- [ ] `npx pnpm test` — all 99 tests pass