### PR TITLE
feat: unified Agent Workshop with custom tools

### DIFF
--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -315,6 +315,17 @@ export async function migrateDb() {
     PRIMARY KEY (registry_entry_id, skill_id)
   )`);
 
+  db.run(sql`CREATE TABLE IF NOT EXISTS custom_tools (
+    id TEXT PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    description TEXT NOT NULL,
+    parameters TEXT NOT NULL DEFAULT '[]',
+    code TEXT NOT NULL,
+    timeout INTEGER NOT NULL DEFAULT 30000,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`);
+
   // Idempotent migration: add source column to skills
   try {
     db.run(sql`ALTER TABLE skills ADD COLUMN source TEXT NOT NULL DEFAULT 'created'`);

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -307,6 +307,24 @@ export const skills = sqliteTable("skills", {
     .$defaultFn(() => new Date().toISOString()),
 });
 
+export const customTools = sqliteTable("custom_tools", {
+  id: text("id").primaryKey(),
+  name: text("name").unique().notNull(),
+  description: text("description").notNull(),
+  parameters: text("parameters", { mode: "json" })
+    .$type<{ name: string; type: string; required: boolean; description: string }[]>()
+    .notNull()
+    .default([]),
+  code: text("code").notNull(),
+  timeout: integer("timeout").notNull().default(30000),
+  createdAt: text("created_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+  updatedAt: text("updated_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+});
+
 export const agentSkills = sqliteTable(
   "agent_skills",
   {

--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -147,6 +147,19 @@ const SEED_ENTRIES = [
     builtIn: true,
     role: "worker" as const,
   },
+  {
+    id: "builtin-tool-builder",
+    name: "Tool Builder",
+    description:
+      "Creates custom JavaScript tools that extend agent capabilities. Can design, implement, and test new tools.",
+    systemPrompt: "See assigned skills for instructions.",
+    capabilities: [] as string[],
+    defaultModel: "claude-sonnet-4-5-20250929",
+    defaultProvider: "anthropic",
+    tools: [] as string[],
+    builtIn: true,
+    role: "worker" as const,
+  },
 ];
 
 /** Upsert all built-in registry entries. Safe to call on every startup. */

--- a/packages/server/src/skills/seed-skills.ts
+++ b/packages/server/src/skills/seed-skills.ts
@@ -306,6 +306,58 @@ When browsing:
 - Report what you found, not the raw HTML`,
     },
   },
+  {
+    id: "builtin-skill-tool-building",
+    data: {
+      meta: {
+        name: "Tool Building",
+        description:
+          "Create, list, update, and test custom JavaScript tools that extend agent capabilities.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: [
+          "file_read",
+          "shell_exec",
+          "create_custom_tool",
+          "list_custom_tools",
+          "update_custom_tool",
+          "test_custom_tool",
+        ],
+        capabilities: ["tool-building", "javascript", "api-integration"],
+        parameters: {},
+        tags: ["built-in", "tool-building"],
+      },
+      body: `You are a tool building specialist. You create custom JavaScript tools that extend agent capabilities.
+
+Your responsibilities:
+- Design tools with clear parameter schemas and descriptions
+- Write JavaScript code that runs in a sandboxed environment
+- Test tools thoroughly before finalizing
+- Create tools that are reliable, well-documented, and reusable
+
+Sandbox constraints for custom tool code:
+- The code is an async function body that receives a \`params\` object
+- Must return a string (the tool's output)
+- Available globals: fetch, JSON, Math, Date, URL, URLSearchParams, console.log
+- NOT available: fs, child_process, require, process, Buffer, import
+- Use fetch() for any HTTP/API interactions
+- Default timeout is 30 seconds
+
+Example tool code:
+\`\`\`javascript
+const response = await fetch(\`https://api.example.com/data?q=\${params.query}\`);
+const data = await response.json();
+return JSON.stringify(data, null, 2);
+\`\`\`
+
+When creating tools:
+1. Use descriptive snake_case names
+2. Write clear parameter descriptions
+3. Handle errors gracefully
+4. Test with various inputs
+5. Return structured JSON strings when appropriate`,
+    },
+  },
 ];
 
 /**
@@ -323,6 +375,7 @@ const ENTRY_SKILL_ASSIGNMENTS: Record<string, string[]> = {
   "builtin-tester": ["builtin-skill-testing-tools"],
   "builtin-opencode-coder": ["builtin-skill-opencode-delegation"],
   "builtin-browser-agent": ["builtin-skill-browser-automation"],
+  "builtin-tool-builder": ["builtin-skill-tool-building"],
 };
 
 /**

--- a/packages/server/src/tools/custom-tool-executor.ts
+++ b/packages/server/src/tools/custom-tool-executor.ts
@@ -1,0 +1,71 @@
+import vm from "node:vm";
+import type { CustomTool } from "@otterbot/shared";
+
+/**
+ * Execute a custom tool's JavaScript code in a sandboxed VM context.
+ * The code receives a `params` object and must return a string.
+ * Available globals: fetch, JSON, Math, Date, console.log, URL, URLSearchParams.
+ * No access to: fs, child_process, require, process, Buffer, etc.
+ */
+export async function executeCustomTool(
+  tool: CustomTool,
+  params: Record<string, unknown>,
+): Promise<string> {
+  const logs: string[] = [];
+
+  const sandbox = {
+    params,
+    fetch: globalThis.fetch,
+    JSON,
+    Math,
+    Date,
+    URL,
+    URLSearchParams,
+    console: {
+      log: (...args: unknown[]) => {
+        logs.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+      },
+    },
+    // Provide a way to set the result from async code
+    __result: undefined as string | undefined,
+  };
+
+  // Wrap the code in an async IIFE so the user can use await
+  const wrappedCode = `
+(async () => {
+  ${tool.code}
+})().then(r => { __result = typeof r === 'string' ? r : JSON.stringify(r); })
+   .catch(e => { __result = 'Error: ' + (e.message || String(e)); });
+`;
+
+  const context = vm.createContext(sandbox);
+  const script = new vm.Script(wrappedCode, { filename: `custom-tool:${tool.name}` });
+
+  // Execute the script, which returns a Promise
+  script.runInContext(context, { timeout: tool.timeout });
+
+  // The script is async, so we need to wait for the microtask queue to flush.
+  // We do this by awaiting the promise that was assigned.
+  // Since vm doesn't directly await, we re-run a small script that returns the internal promise.
+  const awaitScript = new vm.Script(
+    `(async () => { ${tool.code} })()`,
+    { filename: `custom-tool:${tool.name}:await` },
+  );
+
+  try {
+    const promise = awaitScript.runInContext(context, { timeout: tool.timeout });
+    const result = await promise;
+    const output = typeof result === "string" ? result : JSON.stringify(result);
+
+    if (logs.length > 0) {
+      return `${output}\n\n[Console output]\n${logs.join("\n")}`;
+    }
+    return output;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (logs.length > 0) {
+      return `Error: ${message}\n\n[Console output]\n${logs.join("\n")}`;
+    }
+    return `Error: ${message}`;
+  }
+}

--- a/packages/server/src/tools/custom-tool-service.ts
+++ b/packages/server/src/tools/custom-tool-service.ts
@@ -1,0 +1,109 @@
+import { nanoid } from "nanoid";
+import { eq } from "drizzle-orm";
+import { getDb, schema } from "../db/index.js";
+import type {
+  CustomTool,
+  CustomToolCreate,
+  CustomToolUpdate,
+  CustomToolParameter,
+} from "@otterbot/shared";
+
+export class CustomToolService {
+  list(): CustomTool[] {
+    const db = getDb();
+    const rows = db.select().from(schema.customTools).all();
+    return rows.map(this.toCustomTool);
+  }
+
+  get(id: string): CustomTool | null {
+    const db = getDb();
+    const row = db
+      .select()
+      .from(schema.customTools)
+      .where(eq(schema.customTools.id, id))
+      .get();
+    return row ? this.toCustomTool(row) : null;
+  }
+
+  getByName(name: string): CustomTool | null {
+    const db = getDb();
+    const row = db
+      .select()
+      .from(schema.customTools)
+      .where(eq(schema.customTools.name, name))
+      .get();
+    return row ? this.toCustomTool(row) : null;
+  }
+
+  create(data: CustomToolCreate): CustomTool {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const id = nanoid();
+
+    const row = {
+      id,
+      name: data.name,
+      description: data.description,
+      parameters: data.parameters as any,
+      code: data.code,
+      timeout: data.timeout ?? 30000,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    db.insert(schema.customTools).values(row).run();
+    return this.toCustomTool(row);
+  }
+
+  update(id: string, data: CustomToolUpdate): CustomTool | null {
+    const db = getDb();
+    const existing = this.get(id);
+    if (!existing) return null;
+
+    const updates: Record<string, unknown> = {
+      updatedAt: new Date().toISOString(),
+    };
+
+    if (data.name !== undefined) updates.name = data.name;
+    if (data.description !== undefined) updates.description = data.description;
+    if (data.parameters !== undefined) updates.parameters = data.parameters;
+    if (data.code !== undefined) updates.code = data.code;
+    if (data.timeout !== undefined) updates.timeout = data.timeout;
+
+    db.update(schema.customTools)
+      .set(updates)
+      .where(eq(schema.customTools.id, id))
+      .run();
+
+    return this.get(id);
+  }
+
+  delete(id: string): boolean {
+    const db = getDb();
+    const result = db
+      .delete(schema.customTools)
+      .where(eq(schema.customTools.id, id))
+      .run();
+    return result.changes > 0;
+  }
+
+  /** Check if a name is available (not used by any built-in or custom tool) */
+  isNameAvailable(name: string, excludeId?: string): boolean {
+    const existing = this.getByName(name);
+    if (existing && existing.id !== excludeId) return false;
+    return true;
+  }
+
+  private toCustomTool(row: any): CustomTool {
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      parameters: row.parameters as CustomToolParameter[],
+      code: row.code,
+      timeout: row.timeout,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+}

--- a/packages/server/src/tools/tool-factory.ts
+++ b/packages/server/src/tools/tool-factory.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+import { tool } from "ai";
 import type { ToolContext } from "./tool-context.js";
 import { createFileReadTool } from "./file-read.js";
 import { createFileWriteTool } from "./file-write.js";
@@ -22,6 +24,8 @@ import { createCalendarUpdateEventTool } from "./calendar-update-event.js";
 import { createCalendarDeleteEventTool } from "./calendar-delete-event.js";
 import { createCalendarListCalendarsTool } from "./calendar-list-calendars.js";
 import { SkillService } from "../skills/skill-service.js";
+import { CustomToolService } from "./custom-tool-service.js";
+import { executeCustomTool } from "./custom-tool-executor.js";
 
 type ToolCreator = (ctx: ToolContext) => unknown;
 
@@ -53,6 +57,11 @@ const CONTEXTLESS_TOOL_REGISTRY: Record<string, () => unknown> = {
   calendar_update_event: createCalendarUpdateEventTool,
   calendar_delete_event: createCalendarDeleteEventTool,
   calendar_list_calendars: createCalendarListCalendarsTool,
+  // Tool Builder agent tools
+  create_custom_tool: createCreateCustomToolTool,
+  list_custom_tools: createListCustomToolsTool,
+  update_custom_tool: createUpdateCustomToolTool,
+  test_custom_tool: createTestCustomToolTool,
 };
 
 /**
@@ -64,6 +73,8 @@ export function createTools(
   ctx: ToolContext,
 ): Record<string, unknown> {
   const tools: Record<string, unknown> = {};
+  const customToolService = new CustomToolService();
+
   for (const name of toolNames) {
     const creator = TOOL_REGISTRY[name];
     if (creator) {
@@ -73,6 +84,12 @@ export function createTools(
     const contextlessCreator = CONTEXTLESS_TOOL_REGISTRY[name];
     if (contextlessCreator) {
       tools[name] = contextlessCreator();
+      continue;
+    }
+    // Check custom tools
+    const customTool = customToolService.getByName(name);
+    if (customTool) {
+      tools[name] = createCustomToolWrapper(customTool);
       continue;
     }
     console.warn(`[tool-factory] Unknown tool "${name}" requested — skipping.`);
@@ -131,7 +148,194 @@ export function createToolsForAgent(
   return { tools, skillPromptContent };
 }
 
-/** List all available tool names */
+/** List all available tool names (built-in + contextless + custom) */
 export function getAvailableToolNames(): string[] {
-  return [...Object.keys(TOOL_REGISTRY), ...Object.keys(CONTEXTLESS_TOOL_REGISTRY)];
+  const customToolService = new CustomToolService();
+  const customNames = customToolService.list().map((t) => t.name);
+  return [
+    ...Object.keys(TOOL_REGISTRY),
+    ...Object.keys(CONTEXTLESS_TOOL_REGISTRY),
+    ...customNames,
+  ];
+}
+
+/**
+ * Get metadata for all tools: built-in and custom.
+ * Returns tool names grouped by type, plus metadata for each.
+ */
+export function getToolsWithMeta(): {
+  builtInTools: string[];
+  customTools: import("@otterbot/shared").CustomTool[];
+  toolMeta: Record<string, { description: string; builtIn: boolean }>;
+} {
+  const builtInNames = [...Object.keys(TOOL_REGISTRY), ...Object.keys(CONTEXTLESS_TOOL_REGISTRY)];
+  const customToolService = new CustomToolService();
+  const customs = customToolService.list();
+
+  const toolMeta: Record<string, { description: string; builtIn: boolean }> = {};
+
+  // Built-in tool descriptions (basic since they don't expose detailed metadata)
+  const BUILTIN_DESCRIPTIONS: Record<string, string> = {
+    file_read: "Read file contents from the workspace",
+    file_write: "Write or create files in the workspace",
+    shell_exec: "Execute shell commands in the workspace",
+    web_search: "Search the web for information",
+    web_browse: "Browse and interact with web pages",
+    install_package: "Install packages via npm/pip/etc",
+    opencode_task: "Delegate coding tasks to OpenCode agent",
+    todo_list: "List all todos",
+    todo_create: "Create a new todo item",
+    todo_update: "Update an existing todo",
+    todo_delete: "Delete a todo item",
+    gmail_list: "List Gmail messages",
+    gmail_read: "Read a specific Gmail message",
+    gmail_send: "Send a new email via Gmail",
+    gmail_reply: "Reply to a Gmail message",
+    gmail_label: "Add/remove labels on Gmail messages",
+    gmail_archive: "Archive Gmail messages",
+    calendar_list_events: "List calendar events",
+    calendar_create_event: "Create a new calendar event",
+    calendar_update_event: "Update a calendar event",
+    calendar_delete_event: "Delete a calendar event",
+    calendar_list_calendars: "List available calendars",
+    create_custom_tool: "Create a new custom JavaScript tool",
+    list_custom_tools: "List all custom tools",
+    update_custom_tool: "Update an existing custom tool",
+    test_custom_tool: "Test a custom tool with parameters",
+  };
+
+  for (const name of builtInNames) {
+    toolMeta[name] = {
+      description: BUILTIN_DESCRIPTIONS[name] ?? "",
+      builtIn: true,
+    };
+  }
+
+  for (const ct of customs) {
+    toolMeta[ct.name] = {
+      description: ct.description,
+      builtIn: false,
+    };
+  }
+
+  return { builtInTools: builtInNames, customTools: customs, toolMeta };
+}
+
+/** Create a Vercel AI SDK tool wrapper for a custom tool */
+function createCustomToolWrapper(customTool: import("@otterbot/shared").CustomTool) {
+  // Build the zod schema from the custom tool's parameters
+  const shape: Record<string, z.ZodTypeAny> = {};
+  for (const param of customTool.parameters) {
+    let schema: z.ZodTypeAny;
+    switch (param.type) {
+      case "number":
+        schema = z.number().describe(param.description);
+        break;
+      case "boolean":
+        schema = z.boolean().describe(param.description);
+        break;
+      default:
+        schema = z.string().describe(param.description);
+    }
+    shape[param.name] = param.required ? schema : schema.optional();
+  }
+
+  return tool({
+    description: customTool.description,
+    parameters: z.object(shape),
+    execute: async (params: Record<string, unknown>) => {
+      return executeCustomTool(customTool, params);
+    },
+  });
+}
+
+// =========================================================================
+// Tool Builder Agent Tools (contextless)
+// =========================================================================
+
+function createCreateCustomToolTool() {
+  return tool({
+    description: "Create a new custom JavaScript tool that agents can use. Returns the created tool.",
+    parameters: z.object({
+      name: z.string().describe("Unique snake_case name for the tool"),
+      description: z.string().describe("What the tool does"),
+      parameters: z.array(z.object({
+        name: z.string(),
+        type: z.enum(["string", "number", "boolean"]),
+        required: z.boolean(),
+        description: z.string(),
+      })).describe("Tool parameters"),
+      code: z.string().describe("JavaScript async function body. Receives params object, must return a string. Available globals: fetch, JSON, Math, Date, console.log."),
+      timeout: z.number().optional().describe("Execution timeout in ms (default 30000)"),
+    }),
+    execute: async (params) => {
+      const svc = new CustomToolService();
+      if (!svc.isNameAvailable(params.name)) {
+        return JSON.stringify({ error: `Tool name "${params.name}" already exists` });
+      }
+      const created = svc.create(params);
+      return JSON.stringify(created);
+    },
+  });
+}
+
+function createListCustomToolsTool() {
+  return tool({
+    description: "List all custom tools.",
+    parameters: z.object({}),
+    execute: async () => {
+      const svc = new CustomToolService();
+      return JSON.stringify(svc.list());
+    },
+  });
+}
+
+function createUpdateCustomToolTool() {
+  return tool({
+    description: "Update an existing custom tool by ID.",
+    parameters: z.object({
+      id: z.string().describe("The tool ID to update"),
+      name: z.string().optional().describe("New name"),
+      description: z.string().optional().describe("New description"),
+      parameters: z.array(z.object({
+        name: z.string(),
+        type: z.enum(["string", "number", "boolean"]),
+        required: z.boolean(),
+        description: z.string(),
+      })).optional().describe("New parameters"),
+      code: z.string().optional().describe("New code"),
+      timeout: z.number().optional().describe("New timeout"),
+    }),
+    execute: async ({ id, ...data }) => {
+      const svc = new CustomToolService();
+      if (data.name && !svc.isNameAvailable(data.name, id)) {
+        return JSON.stringify({ error: `Tool name "${data.name}" already exists` });
+      }
+      const updated = svc.update(id, data);
+      if (!updated) return JSON.stringify({ error: "Tool not found" });
+      return JSON.stringify(updated);
+    },
+  });
+}
+
+function createTestCustomToolTool() {
+  return tool({
+    description: "Test a custom tool by executing it with the given parameters and returning the result.",
+    parameters: z.object({
+      id: z.string().describe("The tool ID to test"),
+      params: z.record(z.unknown()).describe("Parameters to pass to the tool"),
+    }),
+    execute: async ({ id, params }) => {
+      const svc = new CustomToolService();
+      const customTool = svc.get(id);
+      if (!customTool) return JSON.stringify({ error: "Tool not found" });
+      try {
+        const result = await executeCustomTool(customTool, params);
+        return JSON.stringify({ result });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return JSON.stringify({ error: message });
+      }
+    },
+  });
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,3 +12,4 @@ export * from "./types/todo.js";
 export * from "./types/gmail.js";
 export * from "./types/calendar.js";
 export * from "./types/skill.js";
+export * from "./types/custom-tool.js";

--- a/packages/shared/src/types/custom-tool.ts
+++ b/packages/shared/src/types/custom-tool.ts
@@ -1,0 +1,33 @@
+export interface CustomToolParameter {
+  name: string;
+  type: "string" | "number" | "boolean";
+  required: boolean;
+  description: string;
+}
+
+export interface CustomTool {
+  id: string;
+  name: string;
+  description: string;
+  parameters: CustomToolParameter[];
+  code: string;
+  timeout: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomToolCreate {
+  name: string;
+  description: string;
+  parameters: CustomToolParameter[];
+  code: string;
+  timeout?: number;
+}
+
+export interface CustomToolUpdate {
+  name?: string;
+  description?: string;
+  parameters?: CustomToolParameter[];
+  code?: string;
+  timeout?: number;
+}

--- a/packages/web/src/components/settings/AgentTemplatesTab.tsx
+++ b/packages/web/src/components/settings/AgentTemplatesTab.tsx
@@ -7,7 +7,11 @@ import type { RegistryEntry, GearConfig } from "@otterbot/shared";
 import { CharacterSelect } from "../character-select/CharacterSelect";
 import { ModelCombobox } from "./ModelCombobox";
 
-export function AgentTemplatesTab() {
+interface AgentTemplatesTabProps {
+  onNavigateToSkill?: (skillId: string) => void;
+}
+
+export function AgentTemplatesTab({ onNavigateToSkill }: AgentTemplatesTabProps) {
   const [entries, setEntries] = useState<RegistryEntry[]>([]);
   const [selected, setSelected] = useState<RegistryEntry | null>(null);
   const [editing, setEditing] = useState(false);
@@ -459,12 +463,14 @@ export function AgentTemplatesTab() {
                     assignedSkillIds.map((skillId) => {
                       const skill = allSkills.find((s) => s.id === skillId);
                       return (
-                        <span
+                        <button
                           key={skillId}
-                          className="text-[10px] bg-primary/10 text-primary px-2 py-0.5 rounded"
+                          type="button"
+                          onClick={() => onNavigateToSkill?.(skillId)}
+                          className="text-[10px] bg-primary/10 text-primary px-2 py-0.5 rounded hover:bg-primary/20 transition-colors cursor-pointer"
                         >
                           {skill?.meta.name ?? skillId}
-                        </span>
+                        </button>
                       );
                     })
                   )}

--- a/packages/web/src/components/settings/AgentWorkshopTab.tsx
+++ b/packages/web/src/components/settings/AgentWorkshopTab.tsx
@@ -1,0 +1,78 @@
+import { useState, useCallback } from "react";
+import { cn } from "../../lib/utils";
+import { AgentTemplatesTab } from "./AgentTemplatesTab";
+import { SkillsSubView } from "./SkillsSubView";
+import { ToolsSubView } from "./tools/ToolsSubView";
+
+type WorkshopScope = "agents" | "skills" | "tools";
+
+const SCOPE_TABS: { id: WorkshopScope; label: string }[] = [
+  { id: "agents", label: "Agents" },
+  { id: "skills", label: "Skills" },
+  { id: "tools", label: "Tools" },
+];
+
+export function AgentWorkshopTab() {
+  const [activeScope, setActiveScope] = useState<WorkshopScope>("agents");
+  const [navigateToSkillId, setNavigateToSkillId] = useState<string | null>(null);
+  const [navigateToTool, setNavigateToTool] = useState<string | null>(null);
+
+  const handleNavigateToSkill = useCallback((skillId: string) => {
+    setNavigateToSkillId(skillId);
+    setActiveScope("skills");
+  }, []);
+
+  const handleNavigateToTool = useCallback((toolName: string) => {
+    setNavigateToTool(toolName);
+    setActiveScope("tools");
+  }, []);
+
+  // Clear navigation targets when the user manually switches tabs
+  const handleScopeChange = useCallback((scope: WorkshopScope) => {
+    setActiveScope(scope);
+    if (scope !== "skills") setNavigateToSkillId(null);
+    if (scope !== "tools") setNavigateToTool(null);
+  }, []);
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Scope tab bar */}
+      <div className="flex items-center gap-1 px-5 pt-4 pb-2">
+        {SCOPE_TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => handleScopeChange(tab.id)}
+            className={cn(
+              "px-4 py-1.5 text-xs font-medium rounded-full transition-colors",
+              activeScope === tab.id
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground hover:bg-secondary",
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Sub-view */}
+      <div className="flex-1 overflow-hidden">
+        {activeScope === "agents" && (
+          <AgentTemplatesTab onNavigateToSkill={handleNavigateToSkill} />
+        )}
+        {activeScope === "skills" && (
+          <SkillsSubView
+            navigateToId={navigateToSkillId}
+            onNavigatedTo={() => setNavigateToSkillId(null)}
+            onNavigateToTool={handleNavigateToTool}
+          />
+        )}
+        {activeScope === "tools" && (
+          <ToolsSubView
+            navigateToName={navigateToTool}
+            onNavigatedTo={() => setNavigateToTool(null)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -4,7 +4,7 @@ import { SettingsNav } from "./SettingsNav";
 import { AppearanceTab } from "./AppearanceTab";
 import { ProvidersTab } from "./ProvidersTab";
 import { ModelsTab } from "./ModelsTab";
-import { AgentTemplatesTab } from "./AgentTemplatesTab";
+import { AgentWorkshopTab } from "./AgentWorkshopTab";
 import { SearchTab } from "./SearchTab";
 import { SpeechTab } from "./SpeechTab";
 import { LiveViewTab } from "./LiveViewTab";
@@ -15,7 +15,6 @@ import { SystemSection } from "./SystemSection";
 import { ChannelsSection } from "./ChannelsSection";
 import { ScheduledTasksSection } from "./ScheduledTasksSection";
 import { EmailSection } from "./EmailSection";
-import { SkillsCenterSection } from "./SkillsCenterSection";
 import { GitHubTab } from "./GitHubTab";
 import { GoogleSection } from "./GoogleSection";
 import { SecuritySection } from "./SecuritySection";
@@ -48,7 +47,6 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
     if (activeSection === "scheduled") return <ScheduledTasksSection />;
     if (activeSection === "email") return <EmailSection />;
     if (activeSection === "google") return <GoogleSection />;
-    if (activeSection === "skills") return <SkillsCenterSection />;
     if (activeSection === "github") return <GitHubTab />;
     if (activeSection === "security") return <SecuritySection />;
 
@@ -66,8 +64,8 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
         return <ProvidersTab />;
       case "models":
         return <ModelsTab />;
-      case "templates":
-        return <AgentTemplatesTab />;
+      case "workshop":
+        return <AgentWorkshopTab />;
       case "pricing":
         return <PricingTab />;
       case "search":

--- a/packages/web/src/components/settings/SettingsPanel.tsx
+++ b/packages/web/src/components/settings/SettingsPanel.tsx
@@ -3,7 +3,7 @@ import { cn } from "../../lib/utils";
 import { useSettingsStore } from "../../stores/settings-store";
 import { ProvidersTab } from "./ProvidersTab";
 import { ModelsTab } from "./ModelsTab";
-import { AgentTemplatesTab } from "./AgentTemplatesTab";
+import { AgentWorkshopTab } from "./AgentWorkshopTab";
 import { SearchTab } from "./SearchTab";
 import { SpeechTab } from "./SpeechTab";
 import { LiveViewTab } from "./LiveViewTab";
@@ -11,13 +11,13 @@ import { OpenCodeTab } from "./OpenCodeTab";
 import { GitHubTab } from "./GitHubTab";
 import { AppearanceTab } from "./AppearanceTab";
 
-type Tab = "appearance" | "providers" | "models" | "templates" | "search" | "speech" | "liveview" | "opencode" | "github";
+type Tab = "appearance" | "providers" | "models" | "workshop" | "search" | "speech" | "liveview" | "opencode" | "github";
 
 const TABS: { id: Tab; label: string }[] = [
   { id: "appearance", label: "Appearance" },
   { id: "providers", label: "Providers" },
   { id: "models", label: "Models" },
-  { id: "templates", label: "Agent Templates" },
+  { id: "workshop", label: "Agent Workshop" },
   { id: "search", label: "Search" },
   { id: "speech", label: "Speech" },
   { id: "liveview", label: "Live View" },
@@ -81,7 +81,7 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
             <>
               {activeTab === "providers" && <ProvidersTab />}
               {activeTab === "models" && <ModelsTab />}
-              {activeTab === "templates" && <AgentTemplatesTab />}
+              {activeTab === "workshop" && <AgentWorkshopTab />}
               {activeTab === "search" && <SearchTab />}
               {activeTab === "speech" && <SpeechTab />}
               {activeTab === "liveview" && <LiveViewTab />}

--- a/packages/web/src/components/settings/SkillsSubView.tsx
+++ b/packages/web/src/components/settings/SkillsSubView.tsx
@@ -1,0 +1,792 @@
+import { useEffect, useState, useMemo, useCallback } from "react";
+import { cn } from "../../lib/utils";
+import { useSkillsStore } from "../../stores/skills-store";
+import { ImportSkillDialog } from "./skills/ImportSkillDialog";
+import { ScanReportDisplay } from "./skills/ScanReportDisplay";
+import type { Skill, SkillMeta, ScanReport } from "@otterbot/shared";
+import matter from "gray-matter";
+
+interface SkillsSubViewProps {
+  navigateToId?: string | null;
+  onNavigatedTo?: () => void;
+  onNavigateToTool?: (toolName: string) => void;
+}
+
+export function SkillsSubView({
+  navigateToId,
+  onNavigatedTo,
+  onNavigateToTool,
+}: SkillsSubViewProps) {
+  const skills = useSkillsStore((s) => s.skills);
+  const loading = useSkillsStore((s) => s.loading);
+  const loadSkills = useSkillsStore((s) => s.loadSkills);
+  const createSkill = useSkillsStore((s) => s.createSkill);
+  const updateSkill = useSkillsStore((s) => s.updateSkill);
+  const deleteSkill = useSkillsStore((s) => s.deleteSkill);
+  const cloneSkill = useSkillsStore((s) => s.cloneSkill);
+  const importSkill = useSkillsStore((s) => s.importSkill);
+  const exportSkill = useSkillsStore((s) => s.exportSkill);
+  const availableTools = useSkillsStore((s) => s.availableTools);
+  const loadAvailableTools = useSkillsStore((s) => s.loadAvailableTools);
+
+  const [selected, setSelected] = useState<Skill | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  // Editor form state
+  const [tab, setTab] = useState<"form" | "raw">("form");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [version, setVersion] = useState("1.0.0");
+  const [author, setAuthor] = useState("");
+  const [tools, setTools] = useState<string[]>([]);
+  const [capabilities, setCapabilities] = useState("");
+  const [tags, setTags] = useState("");
+  const [parameters, setParameters] = useState<{ key: string; type: string; default: string; description: string }[]>([]);
+  const [body, setBody] = useState("");
+  const [rawContent, setRawContent] = useState("");
+
+  useEffect(() => {
+    loadSkills();
+    loadAvailableTools();
+  }, []);
+
+  // Navigate to a specific skill when cross-referencing
+  useEffect(() => {
+    if (navigateToId && skills.length > 0) {
+      const target = skills.find((s) => s.id === navigateToId);
+      if (target) {
+        selectSkill(target);
+        onNavigatedTo?.();
+      }
+    }
+  }, [navigateToId, skills]);
+
+  const grouped = useMemo(() => {
+    const builtIn = skills.filter((s) => s.source === "built-in");
+    const custom = skills.filter((s) => s.source !== "built-in");
+    return { builtIn, custom };
+  }, [skills]);
+
+  // Agents that use the selected skill
+  const [usedByAgents, setUsedByAgents] = useState<{ id: string; name: string }[]>([]);
+  useEffect(() => {
+    if (!selected) {
+      setUsedByAgents([]);
+      return;
+    }
+    (async () => {
+      try {
+        const res = await fetch("/api/registry");
+        if (!res.ok) return;
+        const entries = await res.json();
+        const using: { id: string; name: string }[] = [];
+        for (const entry of entries) {
+          const skillsRes = await fetch(`/api/registry/${entry.id}/skills`);
+          if (!skillsRes.ok) continue;
+          const agentSkills = await skillsRes.json();
+          if (agentSkills.some((s: { id: string }) => s.id === selected.id)) {
+            using.push({ id: entry.id, name: entry.name });
+          }
+        }
+        setUsedByAgents(using);
+      } catch {
+        setUsedByAgents([]);
+      }
+    })();
+  }, [selected?.id]);
+
+  const selectSkill = (skill: Skill) => {
+    setSelected(skill);
+    setEditing(false);
+    setConfirmDelete(false);
+    loadFormFromSkill(skill);
+  };
+
+  const loadFormFromSkill = (skill: Skill) => {
+    setName(skill.meta.name);
+    setDescription(skill.meta.description);
+    setVersion(skill.meta.version);
+    setAuthor(skill.meta.author);
+    setTools([...skill.meta.tools]);
+    setCapabilities(skill.meta.capabilities.join(", "));
+    setTags(skill.meta.tags.join(", "));
+    setParameters(
+      Object.entries(skill.meta.parameters).map(([key, def]) => ({
+        key,
+        type: def.type,
+        default: String(def.default ?? ""),
+        description: def.description ?? "",
+      })),
+    );
+    setBody(skill.body);
+    setTab("form");
+  };
+
+  const resetFormForNew = () => {
+    setSelected(null);
+    setName("");
+    setDescription("");
+    setVersion("1.0.0");
+    setAuthor("");
+    setTools([]);
+    setCapabilities("");
+    setTags("");
+    setParameters([]);
+    setBody("");
+    setTab("form");
+    setEditing(true);
+    setConfirmDelete(false);
+  };
+
+  const buildMeta = useCallback((): SkillMeta => {
+    const params: Record<string, { type: string; default?: string; description?: string }> = {};
+    for (const p of parameters) {
+      if (p.key.trim()) {
+        params[p.key.trim()] = {
+          type: p.type || "string",
+          ...(p.default ? { default: p.default } : {}),
+          ...(p.description ? { description: p.description } : {}),
+        };
+      }
+    }
+    return {
+      name,
+      description,
+      version,
+      author,
+      tools,
+      capabilities: capabilities.split(",").map((s) => s.trim()).filter(Boolean),
+      parameters: params,
+      tags: tags.split(",").map((s) => s.trim()).filter(Boolean),
+    };
+  }, [name, description, version, author, tools, capabilities, tags, parameters]);
+
+  const serializeSkillFile = (meta: SkillMeta, bodyStr: string): string => {
+    const frontmatter: Record<string, unknown> = {
+      name: meta.name,
+      description: meta.description,
+      version: meta.version,
+      author: meta.author,
+    };
+    if (meta.tools.length > 0) frontmatter.tools = meta.tools;
+    if (meta.capabilities.length > 0) frontmatter.capabilities = meta.capabilities;
+    if (Object.keys(meta.parameters).length > 0) frontmatter.parameters = meta.parameters;
+    if (meta.tags.length > 0) frontmatter.tags = meta.tags;
+    return matter.stringify(bodyStr, frontmatter);
+  };
+
+  const parseSkillFile = (raw: string): { meta: SkillMeta; body: string } => {
+    const { data, content } = matter(raw);
+    return {
+      meta: {
+        name: data.name ?? "Untitled Skill",
+        description: data.description ?? "",
+        version: data.version ?? "1.0.0",
+        author: data.author ?? "",
+        tools: Array.isArray(data.tools) ? data.tools : [],
+        capabilities: Array.isArray(data.capabilities) ? data.capabilities : [],
+        parameters: (data.parameters && typeof data.parameters === "object") ? data.parameters : {},
+        tags: Array.isArray(data.tags) ? data.tags : [],
+      },
+      body: content.trim(),
+    };
+  };
+
+  // Sync form → raw when switching to raw tab
+  useEffect(() => {
+    if (tab === "raw" && editing) {
+      setRawContent(serializeSkillFile(buildMeta(), body));
+    }
+  }, [tab]);
+
+  const handleTabSwitch = (newTab: "form" | "raw") => {
+    if (newTab === "form" && tab === "raw") {
+      try {
+        const { meta, body: parsedBody } = parseSkillFile(rawContent);
+        setName(meta.name);
+        setDescription(meta.description);
+        setVersion(meta.version);
+        setAuthor(meta.author);
+        setTools([...meta.tools]);
+        setCapabilities(meta.capabilities.join(", "));
+        setTags(meta.tags.join(", "));
+        setParameters(
+          Object.entries(meta.parameters).map(([key, def]) => ({
+            key,
+            type: def.type,
+            default: String(def.default ?? ""),
+            description: def.description ?? "",
+          })),
+        );
+        setBody(parsedBody);
+      } catch {
+        // Invalid format, stay on raw tab
+      }
+    }
+    setTab(newTab);
+  };
+
+  const handleSave = async () => {
+    const meta = tab === "raw" ? parseSkillFile(rawContent).meta : buildMeta();
+    const finalBody = tab === "raw" ? parseSkillFile(rawContent).body : body;
+
+    if (selected) {
+      const updated = await updateSkill(selected.id, { meta, body: finalBody });
+      if (updated) {
+        selectSkill(updated);
+      }
+    } else {
+      const created = await createSkill({ meta, body: finalBody });
+      if (created) {
+        selectSkill(created);
+      }
+    }
+    setEditing(false);
+  };
+
+  const handleDelete = async () => {
+    if (!selected) return;
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      setTimeout(() => setConfirmDelete(false), 3000);
+      return;
+    }
+    await deleteSkill(selected.id);
+    setSelected(null);
+    setConfirmDelete(false);
+  };
+
+  const handleClone = async () => {
+    if (!selected) return;
+    const cloned = await cloneSkill(selected.id);
+    if (cloned) {
+      selectSkill(cloned);
+      setEditing(true);
+    }
+  };
+
+  const handleExport = async () => {
+    if (!selected) return;
+    await exportSkill(selected.id);
+  };
+
+  const handleImport = async (file: File) => {
+    const result = await importSkill(file);
+    if (result) {
+      selectSkill(result.skill);
+      return { scanReport: result.scanReport };
+    }
+    return null;
+  };
+
+  const toggleTool = (tool: string) => {
+    setTools((prev) =>
+      prev.includes(tool) ? prev.filter((t) => t !== tool) : [...prev, tool],
+    );
+  };
+
+  const addParameter = () => {
+    setParameters((prev) => [...prev, { key: "", type: "string", default: "", description: "" }]);
+  };
+
+  const removeParameter = (index: number) => {
+    setParameters((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const updateParameter = (index: number, field: string, value: string) => {
+    setParameters((prev) =>
+      prev.map((p, i) => (i === index ? { ...p, [field]: value } : p)),
+    );
+  };
+
+  const SOURCE_STYLES: Record<string, string> = {
+    "built-in": "text-blue-400",
+    created: "text-muted-foreground",
+    imported: "text-purple-400",
+    cloned: "text-orange-400",
+  };
+
+  return (
+    <div className="flex flex-1 overflow-hidden" style={{ minHeight: "400px" }}>
+      {/* Sidebar */}
+      <div className="w-[240px] border-r border-border overflow-y-auto">
+        <div className="p-2 space-y-1">
+          <button
+            onClick={resetFormForNew}
+            className="w-full text-xs text-center py-1.5 rounded-md border border-dashed border-border hover:border-primary/50 hover:text-primary transition-colors"
+          >
+            + New Skill
+          </button>
+          <button
+            onClick={() => setImportOpen(true)}
+            className="w-full text-xs text-center py-1.5 rounded-md border border-dashed border-border hover:border-primary/50 hover:text-primary transition-colors"
+          >
+            Import
+          </button>
+        </div>
+
+        {loading && (
+          <div className="px-3 py-4 text-xs text-muted-foreground text-center">Loading...</div>
+        )}
+
+        {grouped.builtIn.length > 0 && (
+          <SidebarGroup label="Built-in">
+            {grouped.builtIn.map((skill) => (
+              <SkillSidebarItem
+                key={skill.id}
+                skill={skill}
+                selected={selected?.id === skill.id}
+                onClick={() => selectSkill(skill)}
+              />
+            ))}
+          </SidebarGroup>
+        )}
+
+        {grouped.custom.length > 0 && (
+          <SidebarGroup label="Custom">
+            {grouped.custom.map((skill) => (
+              <SkillSidebarItem
+                key={skill.id}
+                skill={skill}
+                selected={selected?.id === skill.id}
+                onClick={() => selectSkill(skill)}
+              />
+            ))}
+          </SidebarGroup>
+        )}
+      </div>
+
+      {/* Detail panel */}
+      <div className="flex-1 overflow-y-auto p-5">
+        {!selected && !editing ? (
+          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+            Select a skill to view or edit
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {/* Header */}
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <h3 className="text-sm font-semibold">
+                  {editing ? (selected ? "Edit Skill" : "New Skill") : name}
+                </h3>
+                {selected && (
+                  <span className={`text-[9px] uppercase tracking-wider ${SOURCE_STYLES[selected.source] ?? ""}`}>
+                    {selected.source}
+                  </span>
+                )}
+              </div>
+              <div className="flex gap-2">
+                {editing ? (
+                  <>
+                    <button
+                      onClick={handleSave}
+                      disabled={!name.trim()}
+                      className="text-xs bg-primary text-primary-foreground px-3 py-1 rounded-md hover:bg-primary/90 disabled:opacity-50"
+                    >
+                      Save
+                    </button>
+                    <button
+                      onClick={() => {
+                        if (selected) {
+                          selectSkill(selected);
+                        } else {
+                          setEditing(false);
+                        }
+                      }}
+                      className="text-xs text-muted-foreground px-3 py-1 rounded-md hover:bg-secondary"
+                    >
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    {selected?.source !== "built-in" && (
+                      <button
+                        onClick={() => setEditing(true)}
+                        className="text-xs bg-secondary text-foreground px-3 py-1 rounded-md hover:bg-secondary/80"
+                      >
+                        Edit
+                      </button>
+                    )}
+                    <button
+                      onClick={handleClone}
+                      className="text-xs bg-secondary text-foreground px-3 py-1 rounded-md hover:bg-secondary/80"
+                    >
+                      Clone
+                    </button>
+                    <button
+                      onClick={handleExport}
+                      className="text-xs bg-secondary text-foreground px-3 py-1 rounded-md hover:bg-secondary/80"
+                    >
+                      Export
+                    </button>
+                    {selected?.source !== "built-in" && (
+                      <button
+                        onClick={handleDelete}
+                        className={cn(
+                          "text-xs px-3 py-1 rounded-md",
+                          confirmDelete
+                            ? "bg-destructive text-destructive-foreground"
+                            : "text-destructive hover:bg-destructive/10",
+                        )}
+                      >
+                        {confirmDelete ? "Confirm Delete" : "Delete"}
+                      </button>
+                    )}
+                  </>
+                )}
+              </div>
+            </div>
+
+            {/* Form/Raw tab switcher (when editing) */}
+            {editing && (
+              <div className="flex bg-secondary rounded-md w-fit">
+                <button
+                  onClick={() => handleTabSwitch("form")}
+                  className={`text-xs px-3 py-1 rounded-md transition-colors ${
+                    tab === "form" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  Form
+                </button>
+                <button
+                  onClick={() => handleTabSwitch("raw")}
+                  className={`text-xs px-3 py-1 rounded-md transition-colors ${
+                    tab === "raw" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  Raw
+                </button>
+              </div>
+            )}
+
+            {editing && tab === "raw" ? (
+              <textarea
+                value={rawContent}
+                onChange={(e) => setRawContent(e.target.value)}
+                className="w-full h-[60vh] bg-secondary rounded-md px-3 py-2 text-sm outline-none focus:ring-1 ring-primary resize-none font-mono"
+                spellCheck={false}
+              />
+            ) : editing ? (
+              /* Edit form */
+              <>
+                <Field label="Name">
+                  <input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Skill name"
+                    className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary"
+                  />
+                </Field>
+
+                <Field label="Description">
+                  <input
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="What does this skill do?"
+                    className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary"
+                  />
+                </Field>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <Field label="Version">
+                    <input
+                      value={version}
+                      onChange={(e) => setVersion(e.target.value)}
+                      placeholder="1.0.0"
+                      className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary"
+                    />
+                  </Field>
+                  <Field label="Author">
+                    <input
+                      value={author}
+                      onChange={(e) => setAuthor(e.target.value)}
+                      placeholder="Your name"
+                      className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary"
+                    />
+                  </Field>
+                </div>
+
+                <Field label="Tools">
+                  <div className="flex flex-wrap gap-1.5">
+                    {availableTools.map((tool) => (
+                      <button
+                        key={tool}
+                        onClick={() => toggleTool(tool)}
+                        className={`text-[10px] font-mono px-2 py-1 rounded-md border transition-colors ${
+                          tools.includes(tool)
+                            ? "bg-primary/15 text-primary border-primary/30"
+                            : "bg-secondary text-muted-foreground border-transparent hover:border-border"
+                        }`}
+                      >
+                        {tool}
+                      </button>
+                    ))}
+                  </div>
+                </Field>
+
+                <Field label="Capabilities (comma-separated)">
+                  <input
+                    value={capabilities}
+                    onChange={(e) => setCapabilities(e.target.value)}
+                    placeholder="code-review, security-audit"
+                    className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary"
+                  />
+                </Field>
+
+                <Field label="Tags (comma-separated)">
+                  <input
+                    value={tags}
+                    onChange={(e) => setTags(e.target.value)}
+                    placeholder="code, review"
+                    className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary"
+                  />
+                </Field>
+
+                <Field label="Parameters">
+                  <div className="space-y-2">
+                    {parameters.length === 0 && (
+                      <p className="text-xs text-muted-foreground">No parameters defined.</p>
+                    )}
+                    {parameters.map((param, i) => (
+                      <div key={i} className="flex gap-2 items-start">
+                        <input
+                          value={param.key}
+                          onChange={(e) => updateParameter(i, "key", e.target.value)}
+                          placeholder="name"
+                          className="flex-1 bg-secondary rounded-md px-2 py-1 text-xs outline-none focus:ring-1 ring-primary font-mono"
+                        />
+                        <select
+                          value={param.type}
+                          onChange={(e) => updateParameter(i, "type", e.target.value)}
+                          className="bg-secondary rounded-md px-2 py-1 text-xs outline-none focus:ring-1 ring-primary"
+                        >
+                          <option value="string">string</option>
+                          <option value="number">number</option>
+                          <option value="boolean">boolean</option>
+                        </select>
+                        <input
+                          value={param.default}
+                          onChange={(e) => updateParameter(i, "default", e.target.value)}
+                          placeholder="default"
+                          className="w-24 bg-secondary rounded-md px-2 py-1 text-xs outline-none focus:ring-1 ring-primary"
+                        />
+                        <input
+                          value={param.description}
+                          onChange={(e) => updateParameter(i, "description", e.target.value)}
+                          placeholder="description"
+                          className="flex-1 bg-secondary rounded-md px-2 py-1 text-xs outline-none focus:ring-1 ring-primary"
+                        />
+                        <button
+                          onClick={() => removeParameter(i)}
+                          className="text-muted-foreground hover:text-red-400 transition-colors p-1"
+                        >
+                          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                            <path d="M18 6 6 18M6 6l12 12" />
+                          </svg>
+                        </button>
+                      </div>
+                    ))}
+                    <button
+                      onClick={addParameter}
+                      className="text-[10px] text-primary hover:text-primary/80 transition-colors"
+                    >
+                      + Add Parameter
+                    </button>
+                  </div>
+                </Field>
+
+                <Field label="System Prompt">
+                  <textarea
+                    value={body}
+                    onChange={(e) => setBody(e.target.value)}
+                    rows={8}
+                    placeholder="You are a helpful assistant that..."
+                    className="w-full bg-secondary rounded-md px-3 py-2 text-sm outline-none focus:ring-1 ring-primary resize-y font-mono"
+                  />
+                </Field>
+              </>
+            ) : (
+              /* Read-only view */
+              <>
+                <Field label="Description">
+                  <p className="text-sm text-muted-foreground">{description || "(none)"}</p>
+                </Field>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <Field label="Version">
+                    <p className="text-xs font-mono bg-secondary inline-block px-2 py-0.5 rounded">{version}</p>
+                  </Field>
+                  <Field label="Author">
+                    <p className="text-xs font-mono bg-secondary inline-block px-2 py-0.5 rounded">{author || "(none)"}</p>
+                  </Field>
+                </div>
+
+                {tools.length > 0 && (
+                  <Field label="Tools">
+                    <div className="flex flex-wrap gap-1">
+                      {tools.map((t) => (
+                        <button
+                          key={t}
+                          type="button"
+                          onClick={() => onNavigateToTool?.(t)}
+                          className="text-[10px] bg-primary/10 text-primary px-2 py-0.5 rounded font-mono hover:bg-primary/20 transition-colors cursor-pointer"
+                        >
+                          {t}
+                        </button>
+                      ))}
+                    </div>
+                  </Field>
+                )}
+
+                {capabilities && (
+                  <Field label="Capabilities">
+                    <div className="flex flex-wrap gap-1">
+                      {capabilities.split(",").map((c) => c.trim()).filter(Boolean).map((c) => (
+                        <span key={c} className="text-[10px] bg-secondary px-2 py-0.5 rounded">{c}</span>
+                      ))}
+                    </div>
+                  </Field>
+                )}
+
+                {tags && (
+                  <Field label="Tags">
+                    <div className="flex flex-wrap gap-1">
+                      {tags.split(",").map((t) => t.trim()).filter(Boolean).map((t) => (
+                        <span key={t} className="text-[10px] bg-secondary px-1.5 py-0.5 rounded text-muted-foreground">{t}</span>
+                      ))}
+                    </div>
+                  </Field>
+                )}
+
+                {Object.keys(selected?.meta.parameters ?? {}).length > 0 && (
+                  <Field label="Parameters">
+                    <div className="space-y-1">
+                      {Object.entries(selected!.meta.parameters).map(([key, def]) => (
+                        <div key={key} className="text-xs">
+                          <span className="font-mono text-primary">{key}</span>
+                          <span className="text-muted-foreground"> ({def.type})</span>
+                          {def.description && <span className="text-muted-foreground"> — {def.description}</span>}
+                        </div>
+                      ))}
+                    </div>
+                  </Field>
+                )}
+
+                {body && (
+                  <Field label="System Prompt">
+                    <pre className="text-xs text-muted-foreground bg-secondary rounded-md p-3 whitespace-pre-wrap font-mono max-h-[200px] overflow-y-auto">
+                      {body}
+                    </pre>
+                  </Field>
+                )}
+
+                {/* Scan status */}
+                {selected && selected.scanStatus !== "unscanned" && (
+                  <Field label="Scan Status">
+                    <ScanReportDisplay
+                      report={{
+                        clean: selected.scanStatus === "clean",
+                        findings: selected.scanFindings,
+                      }}
+                    />
+                  </Field>
+                )}
+
+                {/* Used by Agents */}
+                {usedByAgents.length > 0 && (
+                  <Field label="Used by Agents">
+                    <div className="flex flex-wrap gap-1">
+                      {usedByAgents.map((a) => (
+                        <span key={a.id} className="text-[10px] bg-secondary px-2 py-0.5 rounded">
+                          {a.name}
+                        </span>
+                      ))}
+                    </div>
+                  </Field>
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Import dialog */}
+      <ImportSkillDialog
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onImport={handleImport}
+      />
+    </div>
+  );
+}
+
+function SidebarGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="px-3 py-1.5 text-[9px] uppercase tracking-wider text-muted-foreground font-medium">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function SkillSidebarItem({
+  skill,
+  selected,
+  onClick,
+}: {
+  skill: Skill;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "w-full text-left px-3 py-2 text-sm transition-colors",
+        selected
+          ? "bg-secondary text-foreground"
+          : "hover:bg-secondary/50 text-muted-foreground",
+      )}
+    >
+      <div className="flex items-center gap-1.5">
+        {skill.source === "built-in" && (
+          <svg
+            className="w-3 h-3 text-muted-foreground/50 shrink-0"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+          </svg>
+        )}
+        <span className="font-medium text-xs truncate">{skill.meta.name}</span>
+      </div>
+      <div className="text-[10px] text-muted-foreground truncate">
+        {skill.meta.tools.length > 0
+          ? `${skill.meta.tools.length} tool${skill.meta.tools.length > 1 ? "s" : ""}`
+          : "No tools"}
+      </div>
+    </button>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/settings-nav.ts
+++ b/packages/web/src/components/settings/settings-nav.ts
@@ -4,14 +4,13 @@ export type SettingsSection =
   | "system"
   | "providers"
   | "models"
-  | "templates"
+  | "workshop"
   | "pricing"
   | "search"
   | "speech"
   | "liveview"
   | "opencode"
   | "scheduled"
-  | "skills"
   | "channels"
   | "email"
   | "google"
@@ -45,7 +44,7 @@ export const SETTINGS_NAV: NavGroup[] = [
     items: [
       { id: "providers", label: "Providers" },
       { id: "models", label: "Models" },
-      { id: "templates", label: "Agent Templates" },
+      { id: "workshop", label: "Agent Workshop" },
       { id: "pricing", label: "Pricing" },
     ],
   },
@@ -58,7 +57,6 @@ export const SETTINGS_NAV: NavGroup[] = [
       { id: "liveview", label: "Live View" },
       { id: "opencode", label: "OpenCode" },
       { id: "scheduled", label: "Scheduled Tasks" },
-      { id: "skills", label: "Skills Center" },
     ],
   },
   {

--- a/packages/web/src/components/settings/tools/ToolAiAssist.tsx
+++ b/packages/web/src/components/settings/tools/ToolAiAssist.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { useToolsStore } from "../../../stores/tools-store";
+import type { CustomToolCreate } from "@otterbot/shared";
+
+interface ToolAiAssistProps {
+  onGenerated: (tool: Partial<CustomToolCreate>) => void;
+  onClose: () => void;
+}
+
+export function ToolAiAssist({ onGenerated, onClose }: ToolAiAssistProps) {
+  const generateTool = useToolsStore((s) => s.generateTool);
+  const [description, setDescription] = useState("");
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleGenerate = async () => {
+    if (!description.trim()) return;
+    setGenerating(true);
+    setError(null);
+    const result = await generateTool(description);
+    setGenerating(false);
+    if (result) {
+      onGenerated(result);
+    } else {
+      setError("Failed to generate tool. Make sure an AI provider is configured.");
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-primary/30 bg-primary/5 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-xs font-semibold">AI Assist</h4>
+        <button
+          onClick={onClose}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      <div>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={3}
+          placeholder="Describe what you want this tool to do... e.g. 'Fetch the current weather for a given city using a public API'"
+          className="w-full bg-secondary rounded-md px-3 py-2 text-sm outline-none focus:ring-1 ring-primary resize-y"
+        />
+      </div>
+      {error && (
+        <p className="text-xs text-red-400">{error}</p>
+      )}
+      <button
+        onClick={handleGenerate}
+        disabled={generating || !description.trim()}
+        className="text-xs bg-primary text-primary-foreground px-4 py-1.5 rounded-md hover:bg-primary/90 disabled:opacity-50"
+      >
+        {generating ? "Generating..." : "Generate"}
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/tools/ToolEditorForm.tsx
+++ b/packages/web/src/components/settings/tools/ToolEditorForm.tsx
@@ -1,0 +1,174 @@
+interface ToolParameter {
+  name: string;
+  type: "string" | "number" | "boolean";
+  required: boolean;
+  description: string;
+}
+
+interface ToolEditorFormProps {
+  name: string;
+  description: string;
+  parameters: ToolParameter[];
+  code: string;
+  timeout: number;
+  onNameChange: (v: string) => void;
+  onDescriptionChange: (v: string) => void;
+  onParametersChange: (v: ToolParameter[]) => void;
+  onCodeChange: (v: string) => void;
+  onTimeoutChange: (v: number) => void;
+}
+
+export function ToolEditorForm({
+  name,
+  description,
+  parameters,
+  code,
+  timeout,
+  onNameChange,
+  onDescriptionChange,
+  onParametersChange,
+  onCodeChange,
+  onTimeoutChange,
+}: ToolEditorFormProps) {
+  const addParameter = () => {
+    onParametersChange([...parameters, { name: "", type: "string", required: true, description: "" }]);
+  };
+
+  const removeParameter = (index: number) => {
+    onParametersChange(parameters.filter((_, i) => i !== index));
+  };
+
+  const updateParameter = (index: number, field: keyof ToolParameter, value: unknown) => {
+    onParametersChange(
+      parameters.map((p, i) => (i === index ? { ...p, [field]: value } : p)),
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Name */}
+      <div>
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Name (snake_case)
+        </label>
+        <input
+          value={name}
+          onChange={(e) => onNameChange(e.target.value.replace(/[^a-z0-9_]/g, ""))}
+          placeholder="my_custom_tool"
+          className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+        />
+      </div>
+
+      {/* Description */}
+      <div>
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Description
+        </label>
+        <textarea
+          value={description}
+          onChange={(e) => onDescriptionChange(e.target.value)}
+          rows={2}
+          placeholder="What does this tool do?"
+          className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary resize-y"
+        />
+      </div>
+
+      {/* Parameters */}
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider">
+            Parameters
+          </label>
+          <button
+            onClick={addParameter}
+            className="text-[10px] text-primary hover:text-primary/80 transition-colors"
+          >
+            + Add
+          </button>
+        </div>
+        {parameters.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No parameters defined.</p>
+        ) : (
+          <div className="space-y-2">
+            {parameters.map((param, i) => (
+              <div key={i} className="flex gap-2 items-start">
+                <input
+                  value={param.name}
+                  onChange={(e) => updateParameter(i, "name", e.target.value)}
+                  placeholder="name"
+                  className="flex-1 bg-secondary rounded-md px-2 py-1 text-xs outline-none focus:ring-1 ring-primary font-mono"
+                />
+                <select
+                  value={param.type}
+                  onChange={(e) => updateParameter(i, "type", e.target.value)}
+                  className="bg-secondary rounded-md px-2 py-1 text-xs outline-none focus:ring-1 ring-primary"
+                >
+                  <option value="string">string</option>
+                  <option value="number">number</option>
+                  <option value="boolean">boolean</option>
+                </select>
+                <label className="flex items-center gap-1 text-xs text-muted-foreground whitespace-nowrap">
+                  <input
+                    type="checkbox"
+                    checked={param.required}
+                    onChange={(e) => updateParameter(i, "required", e.target.checked)}
+                    className="accent-primary"
+                  />
+                  req
+                </label>
+                <input
+                  value={param.description}
+                  onChange={(e) => updateParameter(i, "description", e.target.value)}
+                  placeholder="description"
+                  className="flex-1 bg-secondary rounded-md px-2 py-1 text-xs outline-none focus:ring-1 ring-primary"
+                />
+                <button
+                  onClick={() => removeParameter(i)}
+                  className="text-muted-foreground hover:text-red-400 transition-colors p-1"
+                >
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M18 6 6 18M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Code */}
+      <div>
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Code (JavaScript)
+        </label>
+        <p className="text-[10px] text-muted-foreground mb-1">
+          Async function body. Receives <code className="font-mono">params</code> object. Must return a string.
+          Available globals: fetch, JSON, Math, Date, console.log.
+        </p>
+        <textarea
+          value={code}
+          onChange={(e) => onCodeChange(e.target.value)}
+          rows={12}
+          spellCheck={false}
+          className="w-full bg-secondary rounded-md px-3 py-2 text-sm outline-none focus:ring-1 ring-primary resize-y font-mono"
+          style={{ tabSize: 2 }}
+        />
+      </div>
+
+      {/* Timeout */}
+      <div>
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Timeout (ms)
+        </label>
+        <input
+          type="number"
+          value={timeout}
+          onChange={(e) => onTimeoutChange(Number(e.target.value))}
+          min={1000}
+          max={120000}
+          className="w-32 bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/tools/ToolsSubView.tsx
+++ b/packages/web/src/components/settings/tools/ToolsSubView.tsx
@@ -1,0 +1,491 @@
+import { useEffect, useState, useMemo } from "react";
+import { cn } from "../../../lib/utils";
+import { useToolsStore } from "../../../stores/tools-store";
+import { useSkillsStore } from "../../../stores/skills-store";
+import { ToolEditorForm } from "./ToolEditorForm";
+import { ToolAiAssist } from "./ToolAiAssist";
+import type { CustomTool, CustomToolCreate } from "@otterbot/shared";
+
+interface ToolsSubViewProps {
+  navigateToName?: string | null;
+  onNavigatedTo?: () => void;
+}
+
+type SelectedItem =
+  | { kind: "builtin"; name: string }
+  | { kind: "custom"; tool: CustomTool }
+  | null;
+
+export function ToolsSubView({ navigateToName, onNavigatedTo }: ToolsSubViewProps) {
+  const customTools = useToolsStore((s) => s.customTools);
+  const builtInTools = useToolsStore((s) => s.builtInTools);
+  const toolMeta = useToolsStore((s) => s.toolMeta);
+  const loading = useToolsStore((s) => s.loading);
+  const loadTools = useToolsStore((s) => s.loadTools);
+  const createTool = useToolsStore((s) => s.createTool);
+  const updateTool = useToolsStore((s) => s.updateTool);
+  const deleteTool = useToolsStore((s) => s.deleteTool);
+  const testTool = useToolsStore((s) => s.testTool);
+
+  const skills = useSkillsStore((s) => s.skills);
+  const loadSkills = useSkillsStore((s) => s.loadSkills);
+
+  const [selected, setSelected] = useState<SelectedItem>(null);
+  const [editing, setEditing] = useState(false);
+  const [isNew, setIsNew] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [showAiAssist, setShowAiAssist] = useState(false);
+
+  // Editor form state
+  const [formName, setFormName] = useState("");
+  const [formDescription, setFormDescription] = useState("");
+  const [formParameters, setFormParameters] = useState<{ name: string; type: "string" | "number" | "boolean"; required: boolean; description: string }[]>([]);
+  const [formCode, setFormCode] = useState("");
+  const [formTimeout, setFormTimeout] = useState(30000);
+
+  // Test state
+  const [testParams, setTestParams] = useState("{}");
+  const [testResult, setTestResult] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+
+  useEffect(() => {
+    loadTools();
+    loadSkills();
+  }, []);
+
+  // Navigate to a specific tool when cross-referencing
+  useEffect(() => {
+    if (!navigateToName) return;
+    // Check custom tools first
+    const custom = customTools.find((t) => t.name === navigateToName);
+    if (custom) {
+      selectCustom(custom);
+      onNavigatedTo?.();
+      return;
+    }
+    // Check built-in tools
+    if (builtInTools.includes(navigateToName)) {
+      setSelected({ kind: "builtin", name: navigateToName });
+      setEditing(false);
+      setIsNew(false);
+      onNavigatedTo?.();
+    }
+  }, [navigateToName, customTools, builtInTools]);
+
+  const selectCustom = (tool: CustomTool) => {
+    setSelected({ kind: "custom", tool });
+    setEditing(false);
+    setIsNew(false);
+    setConfirmDelete(false);
+    setTestResult(null);
+    loadFormFromTool(tool);
+  };
+
+  const loadFormFromTool = (tool: CustomTool) => {
+    setFormName(tool.name);
+    setFormDescription(tool.description);
+    setFormParameters([...tool.parameters]);
+    setFormCode(tool.code);
+    setFormTimeout(tool.timeout);
+  };
+
+  const resetFormForNew = () => {
+    setSelected(null);
+    setFormName("");
+    setFormDescription("");
+    setFormParameters([]);
+    setFormCode("// Tool code here\n// Receives `params` object, must return a string\nreturn JSON.stringify({ result: 'hello' });");
+    setFormTimeout(30000);
+    setEditing(true);
+    setIsNew(true);
+    setConfirmDelete(false);
+    setTestResult(null);
+  };
+
+  const handleSave = async () => {
+    const data: CustomToolCreate = {
+      name: formName,
+      description: formDescription,
+      parameters: formParameters,
+      code: formCode,
+      timeout: formTimeout,
+    };
+
+    if (isNew) {
+      const created = await createTool(data);
+      if (created) {
+        selectCustom(created);
+      }
+    } else if (selected?.kind === "custom") {
+      const updated = await updateTool(selected.tool.id, data);
+      if (updated) {
+        selectCustom(updated);
+      }
+    }
+    setEditing(false);
+    setIsNew(false);
+  };
+
+  const handleDelete = async () => {
+    if (selected?.kind !== "custom") return;
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      setTimeout(() => setConfirmDelete(false), 3000);
+      return;
+    }
+    await deleteTool(selected.tool.id);
+    setSelected(null);
+    setConfirmDelete(false);
+  };
+
+  const handleTest = async () => {
+    if (selected?.kind !== "custom") return;
+    setTesting(true);
+    try {
+      const params = JSON.parse(testParams);
+      const result = await testTool(selected.tool.id, params);
+      setTestResult(result.error ? `Error: ${result.error}` : result.result ?? "No output");
+    } catch (e) {
+      setTestResult(`Invalid JSON params: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    setTesting(false);
+  };
+
+  const handleAiGenerated = (generated: Partial<CustomToolCreate>) => {
+    if (generated.name) setFormName(generated.name);
+    if (generated.description) setFormDescription(generated.description);
+    if (generated.parameters) setFormParameters(generated.parameters as any);
+    if (generated.code) setFormCode(generated.code);
+    if (generated.timeout) setFormTimeout(generated.timeout);
+    setShowAiAssist(false);
+  };
+
+  // Find which skills use a given tool
+  const usedBySkills = useMemo(() => {
+    const toolName = selected?.kind === "builtin" ? selected.name : selected?.kind === "custom" ? selected.tool.name : null;
+    if (!toolName) return [];
+    return skills.filter((s) => s.meta.tools.includes(toolName));
+  }, [selected, skills]);
+
+  return (
+    <div className="flex flex-1 overflow-hidden" style={{ minHeight: "400px" }}>
+      {/* Sidebar */}
+      <div className="w-[240px] border-r border-border overflow-y-auto">
+        <div className="p-2">
+          <button
+            onClick={resetFormForNew}
+            className="w-full text-xs text-center py-1.5 rounded-md border border-dashed border-border hover:border-primary/50 hover:text-primary transition-colors"
+          >
+            + New Tool
+          </button>
+        </div>
+
+        {loading && (
+          <div className="px-3 py-4 text-xs text-muted-foreground text-center">Loading...</div>
+        )}
+
+        {builtInTools.length > 0 && (
+          <SidebarGroup label="Built-in">
+            {builtInTools.map((name) => (
+              <ToolSidebarItem
+                key={name}
+                name={name}
+                description={toolMeta[name]?.description}
+                builtIn
+                selected={selected?.kind === "builtin" && selected.name === name}
+                onClick={() => {
+                  setSelected({ kind: "builtin", name });
+                  setEditing(false);
+                  setIsNew(false);
+                  setTestResult(null);
+                }}
+              />
+            ))}
+          </SidebarGroup>
+        )}
+
+        {customTools.length > 0 && (
+          <SidebarGroup label="Custom">
+            {customTools.map((tool) => (
+              <ToolSidebarItem
+                key={tool.id}
+                name={tool.name}
+                description={tool.description}
+                builtIn={false}
+                selected={selected?.kind === "custom" && selected.tool.id === tool.id}
+                onClick={() => selectCustom(tool)}
+              />
+            ))}
+          </SidebarGroup>
+        )}
+      </div>
+
+      {/* Detail panel */}
+      <div className="flex-1 overflow-y-auto p-5">
+        {!selected && !editing ? (
+          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+            Select a tool to view details, or create a new custom tool
+          </div>
+        ) : editing ? (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold">{isNew ? "New Tool" : "Edit Tool"}</h3>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setShowAiAssist(!showAiAssist)}
+                  className="text-xs bg-secondary text-foreground px-3 py-1 rounded-md hover:bg-secondary/80"
+                >
+                  AI Assist
+                </button>
+                <button
+                  onClick={handleSave}
+                  disabled={!formName.trim() || !formCode.trim()}
+                  className="text-xs bg-primary text-primary-foreground px-3 py-1 rounded-md hover:bg-primary/90 disabled:opacity-50"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={() => {
+                    if (isNew) {
+                      setEditing(false);
+                      setIsNew(false);
+                    } else if (selected?.kind === "custom") {
+                      selectCustom(selected.tool);
+                    }
+                  }}
+                  className="text-xs text-muted-foreground px-3 py-1 rounded-md hover:bg-secondary"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+
+            {showAiAssist && (
+              <ToolAiAssist onGenerated={handleAiGenerated} onClose={() => setShowAiAssist(false)} />
+            )}
+
+            <ToolEditorForm
+              name={formName}
+              description={formDescription}
+              parameters={formParameters}
+              code={formCode}
+              timeout={formTimeout}
+              onNameChange={setFormName}
+              onDescriptionChange={setFormDescription}
+              onParametersChange={setFormParameters}
+              onCodeChange={setFormCode}
+              onTimeoutChange={setFormTimeout}
+            />
+          </div>
+        ) : selected?.kind === "builtin" ? (
+          /* Built-in tool read-only view */
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-semibold font-mono">{selected.name}</h3>
+              <span className="text-[9px] uppercase tracking-wider text-blue-400">Built-in</span>
+            </div>
+
+            {toolMeta[selected.name]?.description && (
+              <Field label="Description">
+                <p className="text-sm text-muted-foreground">{toolMeta[selected.name].description}</p>
+              </Field>
+            )}
+
+            {toolMeta[selected.name]?.parameters && toolMeta[selected.name].parameters!.length > 0 && (
+              <Field label="Parameters">
+                <div className="space-y-1">
+                  {toolMeta[selected.name].parameters!.map((p) => (
+                    <div key={p.name} className="text-xs">
+                      <span className="font-mono text-primary">{p.name}</span>
+                      <span className="text-muted-foreground"> ({p.type})</span>
+                      {p.required && <span className="text-red-400"> *</span>}
+                      {p.description && <span className="text-muted-foreground"> — {p.description}</span>}
+                    </div>
+                  ))}
+                </div>
+              </Field>
+            )}
+
+            {usedBySkills.length > 0 && (
+              <Field label="Used by Skills">
+                <div className="flex flex-wrap gap-1">
+                  {usedBySkills.map((s) => (
+                    <span key={s.id} className="text-[10px] bg-secondary px-2 py-0.5 rounded">
+                      {s.meta.name}
+                    </span>
+                  ))}
+                </div>
+              </Field>
+            )}
+          </div>
+        ) : selected?.kind === "custom" ? (
+          /* Custom tool read-only view */
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <h3 className="text-sm font-semibold font-mono">{selected.tool.name}</h3>
+                <span className="text-[9px] uppercase tracking-wider text-muted-foreground">Custom</span>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => { setEditing(true); setIsNew(false); }}
+                  className="text-xs bg-secondary text-foreground px-3 py-1 rounded-md hover:bg-secondary/80"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={handleDelete}
+                  className={cn(
+                    "text-xs px-3 py-1 rounded-md",
+                    confirmDelete
+                      ? "bg-destructive text-destructive-foreground"
+                      : "text-destructive hover:bg-destructive/10",
+                  )}
+                >
+                  {confirmDelete ? "Confirm Delete" : "Delete"}
+                </button>
+              </div>
+            </div>
+
+            <Field label="Description">
+              <p className="text-sm text-muted-foreground">{selected.tool.description || "(none)"}</p>
+            </Field>
+
+            {selected.tool.parameters.length > 0 && (
+              <Field label="Parameters">
+                <div className="space-y-1">
+                  {selected.tool.parameters.map((p) => (
+                    <div key={p.name} className="text-xs">
+                      <span className="font-mono text-primary">{p.name}</span>
+                      <span className="text-muted-foreground"> ({p.type})</span>
+                      {p.required && <span className="text-red-400"> *</span>}
+                      {p.description && <span className="text-muted-foreground"> — {p.description}</span>}
+                    </div>
+                  ))}
+                </div>
+              </Field>
+            )}
+
+            <Field label="Code">
+              <pre className="text-xs text-muted-foreground bg-secondary rounded-md p-3 whitespace-pre-wrap font-mono max-h-[300px] overflow-y-auto">
+                {selected.tool.code}
+              </pre>
+            </Field>
+
+            <Field label="Timeout">
+              <p className="text-xs font-mono bg-secondary inline-block px-2 py-0.5 rounded">
+                {selected.tool.timeout}ms
+              </p>
+            </Field>
+
+            {usedBySkills.length > 0 && (
+              <Field label="Used by Skills">
+                <div className="flex flex-wrap gap-1">
+                  {usedBySkills.map((s) => (
+                    <span key={s.id} className="text-[10px] bg-secondary px-2 py-0.5 rounded">
+                      {s.meta.name}
+                    </span>
+                  ))}
+                </div>
+              </Field>
+            )}
+
+            {/* Test runner */}
+            <Field label="Test">
+              <div className="space-y-2">
+                <textarea
+                  value={testParams}
+                  onChange={(e) => setTestParams(e.target.value)}
+                  rows={3}
+                  placeholder='{"param1": "value1"}'
+                  className="w-full bg-secondary rounded-md px-3 py-2 text-xs outline-none focus:ring-1 ring-primary resize-y font-mono"
+                />
+                <button
+                  onClick={handleTest}
+                  disabled={testing}
+                  className="text-xs bg-secondary text-foreground px-3 py-1.5 rounded-md hover:bg-secondary/80 disabled:opacity-50"
+                >
+                  {testing ? "Running..." : "Run Test"}
+                </button>
+                {testResult !== null && (
+                  <pre className="text-xs bg-secondary rounded-md p-3 whitespace-pre-wrap font-mono max-h-[200px] overflow-y-auto">
+                    {testResult}
+                  </pre>
+                )}
+              </div>
+            </Field>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SidebarGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="px-3 py-1.5 text-[9px] uppercase tracking-wider text-muted-foreground font-medium">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function ToolSidebarItem({
+  name,
+  description,
+  builtIn,
+  selected,
+  onClick,
+}: {
+  name: string;
+  description?: string;
+  builtIn: boolean;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "w-full text-left px-3 py-2 text-sm transition-colors",
+        selected
+          ? "bg-secondary text-foreground"
+          : "hover:bg-secondary/50 text-muted-foreground",
+      )}
+    >
+      <div className="flex items-center gap-1.5">
+        {builtIn && (
+          <svg
+            className="w-3 h-3 text-muted-foreground/50 shrink-0"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+          </svg>
+        )}
+        <span className="font-medium text-xs truncate font-mono">{name}</span>
+      </div>
+      {description && (
+        <div className="text-[10px] text-muted-foreground truncate">{description}</div>
+      )}
+    </button>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/packages/web/src/stores/tools-store.ts
+++ b/packages/web/src/stores/tools-store.ts
@@ -1,0 +1,147 @@
+import { create } from "zustand";
+import type { CustomTool, CustomToolCreate, CustomToolUpdate } from "@otterbot/shared";
+
+interface ToolMeta {
+  description: string;
+  parameters?: { name: string; type: string; required: boolean; description: string }[];
+  builtIn: boolean;
+}
+
+interface ToolsState {
+  customTools: CustomTool[];
+  builtInTools: string[];
+  toolMeta: Record<string, ToolMeta>;
+  loading: boolean;
+  error: string | null;
+
+  loadTools: () => Promise<void>;
+  getCustomTool: (id: string) => Promise<CustomTool | null>;
+  createTool: (data: CustomToolCreate) => Promise<CustomTool | null>;
+  updateTool: (id: string, data: CustomToolUpdate) => Promise<CustomTool | null>;
+  deleteTool: (id: string) => Promise<boolean>;
+  testTool: (id: string, params: Record<string, unknown>) => Promise<{ result?: string; error?: string }>;
+  generateTool: (description: string) => Promise<Partial<CustomToolCreate> | null>;
+}
+
+export const useToolsStore = create<ToolsState>((set, get) => ({
+  customTools: [],
+  builtInTools: [],
+  toolMeta: {},
+  loading: false,
+  error: null,
+
+  loadTools: async () => {
+    set({ loading: true, error: null });
+    try {
+      const res = await fetch("/api/tools");
+      if (!res.ok) throw new Error("Failed to load tools");
+      const data = await res.json();
+      set({
+        customTools: data.customTools ?? [],
+        builtInTools: data.builtInTools ?? [],
+        toolMeta: data.toolMeta ?? {},
+        loading: false,
+      });
+    } catch (err) {
+      set({
+        loading: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  },
+
+  getCustomTool: async (id) => {
+    try {
+      const res = await fetch(`/api/tools/${id}`);
+      if (!res.ok) return null;
+      return await res.json();
+    } catch {
+      return null;
+    }
+  },
+
+  createTool: async (data) => {
+    set({ error: null });
+    try {
+      const res = await fetch("/api/tools", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to create tool");
+      }
+      const tool = await res.json();
+      await get().loadTools();
+      return tool as CustomTool;
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+      return null;
+    }
+  },
+
+  updateTool: async (id, data) => {
+    set({ error: null });
+    try {
+      const res = await fetch(`/api/tools/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to update tool");
+      }
+      const tool = await res.json();
+      await get().loadTools();
+      return tool as CustomTool;
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+      return null;
+    }
+  },
+
+  deleteTool: async (id) => {
+    set({ error: null });
+    try {
+      const res = await fetch(`/api/tools/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to delete tool");
+      }
+      await get().loadTools();
+      return true;
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+      return false;
+    }
+  },
+
+  testTool: async (id, params) => {
+    try {
+      const res = await fetch(`/api/tools/${id}/test`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ params }),
+      });
+      return await res.json();
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : "Unknown error" };
+    }
+  },
+
+  generateTool: async (description) => {
+    try {
+      const res = await fetch("/api/tools/ai-generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description }),
+      });
+      if (!res.ok) return null;
+      return await res.json();
+    } catch {
+      return null;
+    }
+  },
+}));


### PR DESCRIPTION
## Summary

- Merges **Agent Templates** and **Skills Center** into a single **"Agent Workshop"** settings page with three scope tabs: **Agents | Skills | Tools**
- Adds the ability to create **custom JavaScript tools** via the UI with sandboxed execution (Node `vm` module)
- Adds **AI-assisted tool generation** from natural language descriptions
- Adds a built-in **Tool Builder** agent template that can create/list/update/test custom tools
- Implements **cross-reference navigation** between tabs (clickable skill chips on agents, clickable tool chips on skills, "Used by" reverse relationships)

### New files
- `packages/shared/src/types/custom-tool.ts` — CustomTool types
- `packages/server/src/tools/custom-tool-service.ts` — CRUD service
- `packages/server/src/tools/custom-tool-executor.ts` — sandboxed JS execution
- `packages/web/src/components/settings/AgentWorkshopTab.tsx` — unified shell with scope tabs
- `packages/web/src/components/settings/SkillsSubView.tsx` — inline sidebar+detail skills view
- `packages/web/src/components/settings/tools/ToolsSubView.tsx` — tools view with test runner
- `packages/web/src/components/settings/tools/ToolEditorForm.tsx` — tool editor
- `packages/web/src/components/settings/tools/ToolAiAssist.tsx` — AI generation UI
- `packages/web/src/stores/tools-store.ts` — Zustand store for tools

### API endpoints added
- `GET /api/tools` — all tools (built-in + custom) with metadata
- `GET/POST /api/tools/:id` — custom tool CRUD
- `PATCH/DELETE /api/tools/:id` — custom tool updates/deletion
- `POST /api/tools/:id/test` — execute tool with test params
- `POST /api/tools/ai-generate` — AI-assisted tool generation

## Test plan
- [ ] Settings nav shows "Agent Workshop" (no separate "Agent Templates" or "Skills Center")
- [ ] Scope tabs switch between Agents / Skills / Tools views
- [ ] Agents tab works identically to before (CRUD, skill assignment, 3D character)
- [ ] Skills tab shows sidebar list with inline editing (no modal)
- [ ] Skills CRUD (create, import, edit, clone, export, delete) all work
- [ ] Tools tab shows built-in tools (read-only) and custom tools
- [ ] Can create a custom JS tool with name, description, params, code
- [ ] Custom tool appears in skill editor's tool picker
- [ ] Tool Builder appears in the Workers group of agent templates
- [ ] AI Assist generates tool code from natural language description
- [ ] Cross-reference navigation works between tabs
- [ ] `npx pnpm build` — clean
- [ ] `npx pnpm test` — 99/99 pass