### PR TITLE
fix: agent delete, tool import/export, built-in tool details

### DIFF
--- a/packages/web/src/components/settings/AgentTemplatesTab.tsx
+++ b/packages/web/src/components/settings/AgentTemplatesTab.tsx
@@ -306,14 +306,12 @@ export function AgentTemplatesTab({ onNavigateToSkill }: AgentTemplatesTabProps)
                     >
                       Clone
                     </button>
-                    {selected.role !== "coo" && (
-                      <button
-                        onClick={deleteEntry}
-                        className="text-xs text-destructive px-3 py-1 rounded-md hover:bg-destructive/10"
-                      >
-                        Delete
-                      </button>
-                    )}
+                    <button
+                      onClick={deleteEntry}
+                      className="text-xs text-destructive px-3 py-1 rounded-md hover:bg-destructive/10"
+                    >
+                      Delete
+                    </button>
                   </>
                 )}
               </div>

--- a/packages/web/src/stores/tools-store.ts
+++ b/packages/web/src/stores/tools-store.ts
@@ -5,6 +5,7 @@ interface ToolMeta {
   description: string;
   parameters?: { name: string; type: string; required: boolean; description: string }[];
   builtIn: boolean;
+  category?: string;
 }
 
 interface ToolsState {


### PR DESCRIPTION
## Summary

- **Fix agent deletion**: Remove `role !== "coo"` guard that prevented deleting custom COO clones. The server already protects the active COO template, so this client-side restriction was blocking valid deletions.
- **Add tool import/export**: Import button reads `.tool.json` files to create custom tools. Export button on custom tools downloads their definition as JSON.
- **Show built-in tool details**: Replace sparse descriptions with full metadata — detailed descriptions, parameter tables (name, type, required, description), and category badges. Built-in tools are now grouped by category in the sidebar (Workspace, Web, Personal, Email, Calendar, Tool Builder).

## Test plan
- [ ] Can delete a custom agent (including COO clones)
- [ ] Can import a `.tool.json` file from the Tools tab Import button
- [ ] Can export a custom tool via the Export button
- [ ] Clicking a built-in tool shows full description, category badge, and parameter table
- [ ] Built-in tools are grouped by category in the sidebar
- [ ] `npx pnpm build` — clean
- [ ] `npx pnpm test` — 99/99 pass