### PR TITLE
feat: tool examples and expanded sandbox globals

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -27,6 +27,7 @@ import { scanSkillContent } from "./skills/skill-scanner.js";
 import { getAvailableToolNames, getToolsWithMeta } from "./tools/tool-factory.js";
 import { CustomToolService } from "./tools/custom-tool-service.js";
 import { executeCustomTool } from "./tools/custom-tool-executor.js";
+import { TOOL_EXAMPLES } from "./tools/tool-examples.js";
 import { COO } from "./agents/coo.js";
 import { AdminAssistant } from "./agents/admin-assistant.js";
 import { closeBrowser } from "./tools/browser-pool.js";
@@ -2547,6 +2548,11 @@ async function main() {
     return getToolsWithMeta();
   });
 
+  // GET /api/tools/examples — curated example tools for custom tool authors
+  app.get("/api/tools/examples", async () => {
+    return TOOL_EXAMPLES;
+  });
+
   // GET /api/tools/:id — get single custom tool
   app.get<{ Params: { id: string } }>("/api/tools/:id", async (req, reply) => {
     const tool = customToolService.get(req.params.id);
@@ -2675,8 +2681,14 @@ async function main() {
           system: `You are a tool generation assistant. Given a description, generate a custom JavaScript tool definition.
 
 The tool will run in a sandboxed environment with these globals available:
-- fetch (for HTTP requests)
+- fetch, Headers, AbortController (for HTTP requests)
 - JSON, Math, Date, URL, URLSearchParams
+- TextEncoder, TextDecoder (UTF-8 encoding/decoding)
+- atob, btoa (Base64 encoding/decoding)
+- setTimeout, setInterval, clearTimeout, clearInterval (timers)
+- crypto.randomUUID() (generate unique IDs)
+- encodeURIComponent, decodeURIComponent (URL encoding)
+- structuredClone (deep object cloning)
 - console.log (for debugging)
 
 NOT available: fs, child_process, require, process, Buffer, import

--- a/packages/server/src/skills/seed-skills.ts
+++ b/packages/server/src/skills/seed-skills.ts
@@ -338,7 +338,7 @@ Your responsibilities:
 Sandbox constraints for custom tool code:
 - The code is an async function body that receives a \`params\` object
 - Must return a string (the tool's output)
-- Available globals: fetch, JSON, Math, Date, URL, URLSearchParams, console.log
+- Available globals: fetch, Headers, AbortController, JSON, Math, Date, URL, URLSearchParams, TextEncoder, TextDecoder, atob, btoa, setTimeout, setInterval, clearTimeout, clearInterval, crypto.randomUUID(), encodeURIComponent, decodeURIComponent, structuredClone, console.log
 - NOT available: fs, child_process, require, process, Buffer, import
 - Use fetch() for any HTTP/API interactions
 - Default timeout is 30 seconds

--- a/packages/server/src/tools/custom-tool-executor.ts
+++ b/packages/server/src/tools/custom-tool-executor.ts
@@ -4,7 +4,10 @@ import type { CustomTool } from "@otterbot/shared";
 /**
  * Execute a custom tool's JavaScript code in a sandboxed VM context.
  * The code receives a `params` object and must return a string.
- * Available globals: fetch, JSON, Math, Date, console.log, URL, URLSearchParams.
+ * Available globals: fetch, JSON, Math, Date, console.log, URL, URLSearchParams,
+ * TextEncoder, TextDecoder, atob, btoa, setTimeout, setInterval, clearTimeout,
+ * clearInterval, crypto.randomUUID, encodeURIComponent, decodeURIComponent,
+ * AbortController, Headers, structuredClone.
  * No access to: fs, child_process, require, process, Buffer, etc.
  */
 export async function executeCustomTool(
@@ -26,6 +29,27 @@ export async function executeCustomTool(
         logs.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
       },
     },
+    // Text encoding/decoding
+    TextEncoder,
+    TextDecoder,
+    // Base64
+    atob,
+    btoa,
+    // Timers
+    setTimeout,
+    setInterval,
+    clearTimeout,
+    clearInterval,
+    // Crypto (limited to randomUUID)
+    crypto: { randomUUID: () => globalThis.crypto.randomUUID() },
+    // URL encoding
+    encodeURIComponent,
+    decodeURIComponent,
+    // Fetch helpers
+    AbortController,
+    Headers,
+    // Deep cloning
+    structuredClone,
     // Provide a way to set the result from async code
     __result: undefined as string | undefined,
   };

--- a/packages/server/src/tools/tool-examples.ts
+++ b/packages/server/src/tools/tool-examples.ts
@@ -1,0 +1,258 @@
+/**
+ * Curated example tools for custom tool authors.
+ * Each example is a complete, working tool definition that runs within the sandbox.
+ */
+
+export interface ToolExample {
+  name: string;
+  description: string;
+  category: string;
+  parameters: Array<{
+    name: string;
+    type: "string" | "number" | "boolean";
+    required: boolean;
+    description: string;
+  }>;
+  code: string;
+  timeout: number;
+}
+
+export const TOOL_EXAMPLES: ToolExample[] = [
+  {
+    name: "fetch_json_api",
+    description: "Fetch data from a public JSON API and return formatted results",
+    category: "HTTP & APIs",
+    parameters: [
+      { name: "query", type: "string", required: true, description: "Search query or keyword" },
+    ],
+    code: `// Fetch data from a public JSON API with error handling
+const url = \`https://api.github.com/search/repositories?q=\${encodeURIComponent(params.query)}&per_page=5\`;
+
+const response = await fetch(url, {
+  headers: new Headers({ "Accept": "application/vnd.github.v3+json" }),
+});
+
+if (!response.ok) {
+  return \`Error: API returned \${response.status} \${response.statusText}\`;
+}
+
+const data = await response.json();
+const repos = data.items.map(r => ({
+  name: r.full_name,
+  stars: r.stargazers_count,
+  description: r.description || "(no description)",
+  url: r.html_url,
+}));
+
+return JSON.stringify(repos, null, 2);`,
+    timeout: 15000,
+  },
+  {
+    name: "url_shortener_lookup",
+    description: "Expand a shortened URL by following redirects to find the final destination",
+    category: "HTTP & APIs",
+    parameters: [
+      { name: "url", type: "string", required: true, description: "Shortened URL to expand" },
+    ],
+    code: `// Follow redirects to expand a shortened URL
+const controller = new AbortController();
+const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+try {
+  const response = await fetch(params.url, {
+    method: "HEAD",
+    redirect: "follow",
+    signal: controller.signal,
+  });
+  clearTimeout(timeoutId);
+
+  const finalUrl = response.url;
+  const statusCode = response.status;
+
+  return JSON.stringify({
+    originalUrl: params.url,
+    expandedUrl: finalUrl,
+    statusCode,
+    redirected: params.url !== finalUrl,
+  }, null, 2);
+} catch (err) {
+  clearTimeout(timeoutId);
+  return \`Error expanding URL: \${err.message}\`;
+}`,
+    timeout: 15000,
+  },
+  {
+    name: "calculate_time_between",
+    description: "Calculate the duration between two dates in various units",
+    category: "Utilities",
+    parameters: [
+      { name: "start_date", type: "string", required: true, description: "Start date (e.g. 2024-01-15 or Jan 15, 2024)" },
+      { name: "end_date", type: "string", required: true, description: "End date (e.g. 2024-12-31 or Dec 31, 2024)" },
+    ],
+    code: `// Calculate the duration between two dates
+const start = new Date(params.start_date);
+const end = new Date(params.end_date);
+
+if (isNaN(start.getTime())) return \`Error: Invalid start date "\${params.start_date}"\`;
+if (isNaN(end.getTime())) return \`Error: Invalid end date "\${params.end_date}"\`;
+
+const diffMs = Math.abs(end.getTime() - start.getTime());
+const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+const diffWeeks = Math.floor(diffDays / 7);
+const diffMonths = Math.round(diffDays / 30.44);
+const diffYears = Math.round((diffDays / 365.25) * 100) / 100;
+
+const hours = Math.floor(diffMs / (1000 * 60 * 60));
+const minutes = Math.floor(diffMs / (1000 * 60));
+
+return JSON.stringify({
+  from: start.toISOString().split("T")[0],
+  to: end.toISOString().split("T")[0],
+  duration: {
+    years: diffYears,
+    months: diffMonths,
+    weeks: diffWeeks,
+    days: diffDays,
+    hours,
+    minutes,
+  },
+  direction: end >= start ? "forward" : "backward",
+}, null, 2);`,
+    timeout: 5000,
+  },
+  {
+    name: "text_summarizer",
+    description: "Analyze text to count words, sentences, paragraphs, and extract key statistics",
+    category: "Text Processing",
+    parameters: [
+      { name: "text", type: "string", required: true, description: "The text to analyze" },
+    ],
+    code: `// Analyze text for word count, sentences, and key stats
+const text = params.text.trim();
+if (!text) return "Error: No text provided";
+
+const words = text.split(/\\s+/).filter(w => w.length > 0);
+const sentences = text.split(/[.!?]+/).filter(s => s.trim().length > 0);
+const paragraphs = text.split(/\\n\\s*\\n/).filter(p => p.trim().length > 0);
+const characters = text.length;
+const charactersNoSpaces = text.replace(/\\s/g, "").length;
+
+// Find most common words (excluding short words)
+const wordFreq = {};
+for (const w of words) {
+  const lower = w.toLowerCase().replace(/[^a-z0-9]/g, "");
+  if (lower.length > 3) {
+    wordFreq[lower] = (wordFreq[lower] || 0) + 1;
+  }
+}
+const topWords = Object.entries(wordFreq)
+  .sort((a, b) => b[1] - a[1])
+  .slice(0, 5)
+  .map(([word, count]) => ({ word, count }));
+
+// Avg word length
+const avgWordLength = Math.round(
+  (words.reduce((sum, w) => sum + w.replace(/[^a-z0-9]/gi, "").length, 0) / words.length) * 10
+) / 10;
+
+// Reading time (~200 wpm)
+const readingTimeMin = Math.ceil(words.length / 200);
+
+return JSON.stringify({
+  words: words.length,
+  sentences: sentences.length,
+  paragraphs: paragraphs.length,
+  characters,
+  charactersNoSpaces,
+  avgWordLength,
+  readingTimeMinutes: readingTimeMin,
+  topWords,
+}, null, 2);`,
+    timeout: 5000,
+  },
+  {
+    name: "multi_api_aggregator",
+    description: "Query multiple API endpoints in parallel and merge the results",
+    category: "HTTP & APIs",
+    parameters: [
+      { name: "username", type: "string", required: true, description: "GitHub username to look up" },
+    ],
+    code: `// Query multiple GitHub API endpoints in parallel
+const base = "https://api.github.com";
+const headers = new Headers({ "Accept": "application/vnd.github.v3+json" });
+
+const [userRes, reposRes] = await Promise.all([
+  fetch(\`\${base}/users/\${encodeURIComponent(params.username)}\`, { headers }),
+  fetch(\`\${base}/users/\${encodeURIComponent(params.username)}/repos?per_page=5&sort=stars\`, { headers }),
+]);
+
+if (!userRes.ok) {
+  return \`Error: User "\${params.username}" not found (\${userRes.status})\`;
+}
+
+const user = await userRes.json();
+const repos = reposRes.ok ? await reposRes.json() : [];
+
+return JSON.stringify({
+  profile: {
+    name: user.name || user.login,
+    bio: user.bio || "(none)",
+    publicRepos: user.public_repos,
+    followers: user.followers,
+    following: user.following,
+    createdAt: user.created_at,
+  },
+  topRepos: repos.map(r => ({
+    name: r.name,
+    stars: r.stargazers_count,
+    language: r.language,
+    description: r.description || "(none)",
+  })),
+}, null, 2);`,
+    timeout: 15000,
+  },
+  {
+    name: "json_transformer",
+    description: "Convert CSV text to JSON format with automatic header detection",
+    category: "Text Processing",
+    parameters: [
+      { name: "csv_text", type: "string", required: true, description: "CSV text to convert (first row = headers)" },
+      { name: "delimiter", type: "string", required: false, description: "Column delimiter (default: comma)" },
+    ],
+    code: `// Convert CSV text to JSON with automatic header detection
+const delimiter = params.delimiter || ",";
+const lines = params.csv_text.trim().split("\\n").map(l => l.trim()).filter(l => l.length > 0);
+
+if (lines.length === 0) return "Error: No CSV data provided";
+if (lines.length === 1) return "Error: CSV must have at least a header row and one data row";
+
+// Parse header row
+const headers = lines[0].split(delimiter).map(h => h.trim().replace(/^"|"$/g, ""));
+
+// Parse data rows
+const rows = [];
+for (let i = 1; i < lines.length; i++) {
+  const values = lines[i].split(delimiter).map(v => v.trim().replace(/^"|"$/g, ""));
+  const row = {};
+  for (let j = 0; j < headers.length; j++) {
+    const val = values[j] || "";
+    // Auto-detect numbers and booleans
+    if (/^\\d+(\\.\\d+)?$/.test(val)) {
+      row[headers[j]] = parseFloat(val);
+    } else if (val.toLowerCase() === "true" || val.toLowerCase() === "false") {
+      row[headers[j]] = val.toLowerCase() === "true";
+    } else {
+      row[headers[j]] = val;
+    }
+  }
+  rows.push(row);
+}
+
+return JSON.stringify({
+  headers,
+  rowCount: rows.length,
+  data: rows,
+}, null, 2);`,
+    timeout: 5000,
+  },
+];

--- a/packages/web/src/components/settings/tools/ToolEditorForm.tsx
+++ b/packages/web/src/components/settings/tools/ToolEditorForm.tsx
@@ -1,3 +1,7 @@
+import { useState } from "react";
+import { ToolExamples } from "./ToolExamples";
+import type { ToolExample } from "../../../stores/tools-store";
+
 interface ToolParameter {
   name: string;
   type: "string" | "number" | "boolean";
@@ -30,6 +34,8 @@ export function ToolEditorForm({
   onCodeChange,
   onTimeoutChange,
 }: ToolEditorFormProps) {
+  const [showExamples, setShowExamples] = useState(false);
+
   const addParameter = () => {
     onParametersChange([...parameters, { name: "", type: "string", required: true, description: "" }]);
   };
@@ -44,8 +50,32 @@ export function ToolEditorForm({
     );
   };
 
+  const handleExampleSelect = (example: ToolExample) => {
+    onNameChange(example.name);
+    onDescriptionChange(example.description);
+    onParametersChange([...example.parameters]);
+    onCodeChange(example.code);
+    onTimeoutChange(example.timeout);
+    setShowExamples(false);
+  };
+
   return (
     <div className="space-y-4">
+      {/* Load Example */}
+      <div>
+        <button
+          onClick={() => setShowExamples(!showExamples)}
+          className="text-xs text-primary hover:text-primary/80 transition-colors"
+        >
+          {showExamples ? "Hide Examples" : "Load Example"}
+        </button>
+        {showExamples && (
+          <div className="mt-2">
+            <ToolExamples onSelect={handleExampleSelect} onClose={() => setShowExamples(false)} />
+          </div>
+        )}
+      </div>
+
       {/* Name */}
       <div>
         <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
@@ -143,7 +173,8 @@ export function ToolEditorForm({
         </label>
         <p className="text-[10px] text-muted-foreground mb-1">
           Async function body. Receives <code className="font-mono">params</code> object. Must return a string.
-          Available globals: fetch, JSON, Math, Date, console.log.
+          Available globals: fetch, Headers, AbortController, JSON, Math, Date, URL, URLSearchParams,
+          TextEncoder/Decoder, atob/btoa, setTimeout/setInterval, crypto.randomUUID(), structuredClone, console.log.
         </p>
         <textarea
           value={code}

--- a/packages/web/src/components/settings/tools/ToolExamples.tsx
+++ b/packages/web/src/components/settings/tools/ToolExamples.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useMemo } from "react";
+import { useToolsStore } from "../../../stores/tools-store";
+import type { ToolExample } from "../../../stores/tools-store";
+
+interface ToolExamplesProps {
+  onSelect: (example: ToolExample) => void;
+  onClose: () => void;
+}
+
+export function ToolExamples({ onSelect, onClose }: ToolExamplesProps) {
+  const examples = useToolsStore((s) => s.examples);
+  const loadExamples = useToolsStore((s) => s.loadExamples);
+
+  useEffect(() => {
+    if (examples.length === 0) loadExamples();
+  }, []);
+
+  const grouped = useMemo(() => {
+    const groups: Record<string, ToolExample[]> = {};
+    for (const ex of examples) {
+      if (!groups[ex.category]) groups[ex.category] = [];
+      groups[ex.category].push(ex);
+    }
+    return groups;
+  }, [examples]);
+
+  return (
+    <div className="border border-border rounded-md bg-secondary/30 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-medium">
+          Load Example
+        </span>
+        <button
+          onClick={onClose}
+          className="text-muted-foreground hover:text-foreground transition-colors p-0.5"
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      {examples.length === 0 ? (
+        <p className="text-xs text-muted-foreground">Loading examples...</p>
+      ) : (
+        Object.entries(grouped).map(([category, items]) => (
+          <div key={category}>
+            <div className="text-[9px] uppercase tracking-wider text-muted-foreground font-medium mb-1">
+              {category}
+            </div>
+            <div className="space-y-1">
+              {items.map((ex) => (
+                <button
+                  key={ex.name}
+                  onClick={() => onSelect(ex)}
+                  className="w-full text-left px-2.5 py-1.5 rounded-md hover:bg-secondary transition-colors"
+                >
+                  <div className="text-xs font-mono font-medium">{ex.name}</div>
+                  <div className="text-[10px] text-muted-foreground">{ex.description}</div>
+                </button>
+              ))}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/stores/tools-store.ts
+++ b/packages/web/src/stores/tools-store.ts
@@ -8,14 +8,30 @@ interface ToolMeta {
   category?: string;
 }
 
+export interface ToolExample {
+  name: string;
+  description: string;
+  category: string;
+  parameters: Array<{
+    name: string;
+    type: "string" | "number" | "boolean";
+    required: boolean;
+    description: string;
+  }>;
+  code: string;
+  timeout: number;
+}
+
 interface ToolsState {
   customTools: CustomTool[];
   builtInTools: string[];
   toolMeta: Record<string, ToolMeta>;
+  examples: ToolExample[];
   loading: boolean;
   error: string | null;
 
   loadTools: () => Promise<void>;
+  loadExamples: () => Promise<void>;
   getCustomTool: (id: string) => Promise<CustomTool | null>;
   createTool: (data: CustomToolCreate) => Promise<CustomTool | null>;
   updateTool: (id: string, data: CustomToolUpdate) => Promise<CustomTool | null>;
@@ -28,8 +44,20 @@ export const useToolsStore = create<ToolsState>((set, get) => ({
   customTools: [],
   builtInTools: [],
   toolMeta: {},
+  examples: [],
   loading: false,
   error: null,
+
+  loadExamples: async () => {
+    try {
+      const res = await fetch("/api/tools/examples");
+      if (!res.ok) return;
+      const data = await res.json();
+      set({ examples: data });
+    } catch {
+      // silently ignore — examples are optional
+    }
+  },
 
   loadTools: async () => {
     set({ loading: true, error: null });


### PR DESCRIPTION
## Summary

- **Expanded sandbox globals**: Added TextEncoder/Decoder, atob/btoa, setTimeout/setInterval/clearTimeout/clearInterval, crypto.randomUUID(), encodeURIComponent/decodeURIComponent, AbortController, Headers, and structuredClone to the custom tool VM sandbox
- **Curated example library**: 6 working example tools (fetch_json_api, url_shortener_lookup, calculate_time_between, text_summarizer, multi_api_aggregator, json_transformer) served via `GET /api/tools/examples`
- **Load Example UI**: New "Load Example" button in the tool editor form with a categorized picker that populates all form fields
- **Updated documentation**: AI generation prompt and Tool Builder skill body now reference all available sandbox globals

## Test plan

- [ ] Create a custom tool using new globals (atob, crypto.randomUUID, setTimeout, etc.) — executes successfully
- [ ] `GET /api/tools/examples` returns the 6 curated examples
- [ ] "Load Example" button appears in tool editor when creating/editing a tool
- [ ] Selecting an example populates name, description, parameters, code, and timeout
- [ ] Each example can be saved and tested via the Test button
- [ ] `npx pnpm build` — clean
- [ ] `npx pnpm test` — all 99 tests pass