### PR TITLE
feat: wire OpenCode as primary coding agent

### DIFF
--- a/packages/server/src/agents/prompts/team-lead.ts
+++ b/packages/server/src/agents/prompts/team-lead.ts
@@ -50,6 +50,12 @@ When ALL kanban tasks are in "done":
 4. **Report completion** to the COO via \`report_to_coo\` — include what was built, verification results, deployment URL/port, and the workspace path
 Do NOT consider the project finished until verification passes AND the app is deployed.
 
+## Coding Worker Selection
+When spawning workers for coding tasks, prefer the **OpenCode Coder** (builtin-opencode-coder)
+over the regular Coder when it appears in registry search results. The OpenCode Coder delegates
+to a specialized autonomous coding agent that handles complex multi-file changes more effectively.
+Use the regular Coder only as a fallback if OpenCode is unavailable.
+
 ## Rules
 - **NEVER do work yourself** — always spawn a worker
 - **NEVER poll** — when workers are in progress with no backlog, stop and return immediately

--- a/packages/server/src/agents/team-lead.ts
+++ b/packages/server/src/agents/team-lead.ts
@@ -797,12 +797,24 @@ export class TeamLead extends BaseAgent {
       return `No agents found with capability "${capability}".`;
     }
 
-    return matches
+    let result = matches
       .map(
         (e) =>
           `- ${e.name} (${e.id}): ${e.description} [capabilities: ${e.capabilities.join(", ")}]`,
       )
       .join("\n");
+
+    // If OpenCode is enabled and the search matches coding capabilities, recommend OpenCode Coder
+    const codingKeywords = ["code", "coding", "programming", "develop", "implement", "refactor", "software"];
+    const isCodingSearch = codingKeywords.some((kw) => capability.toLowerCase().includes(kw));
+    const hasOpenCodeCoder = matches.some((e) => e.id === "builtin-opencode-coder");
+    const openCodeEnabled = getConfig("opencode:enabled") === "true";
+
+    if (isCodingSearch && hasOpenCodeCoder && openCodeEnabled) {
+      result += `\n\n**RECOMMENDATION:** Use "OpenCode Coder" (builtin-opencode-coder) for coding tasks. It delegates to a dedicated autonomous coding agent with superior multi-file editing. Only use the regular "Coder" for very simple single-file changes.`;
+    }
+
+    return result;
   }
 
   private async spawnWorker(

--- a/packages/server/src/opencode/opencode-manager.ts
+++ b/packages/server/src/opencode/opencode-manager.ts
@@ -1,0 +1,191 @@
+/**
+ * OpenCode process manager — writes config and manages the `opencode serve` child process.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getConfig } from "../auth/auth.js";
+import { getProviderRow } from "../settings/settings.js";
+
+// ---------------------------------------------------------------------------
+// Provider type mapping: Otterbot provider type -> OpenCode provider ID
+// ---------------------------------------------------------------------------
+
+const PROVIDER_TYPE_MAP: Record<string, string> = {
+  anthropic: "anthropic",
+  openai: "openai",
+  ollama: "ollama",
+  openrouter: "openrouter",
+  "openai-compatible": "openai",
+};
+
+// ---------------------------------------------------------------------------
+// Config writer
+// ---------------------------------------------------------------------------
+
+export interface OpenCodeConfigOptions {
+  providerType: string;
+  model: string;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export function writeOpenCodeConfig(opts: OpenCodeConfigOptions): void {
+  const configDir = join(homedir(), ".config", "opencode");
+  mkdirSync(configDir, { recursive: true });
+
+  const openCodeProvider = PROVIDER_TYPE_MAP[opts.providerType] ?? "openai";
+
+  // Build provider config — use env var reference to avoid writing raw keys to disk
+  const providerConfig: Record<string, unknown> = {};
+  if (opts.apiKey) {
+    providerConfig.apiKey = "{env:OPENCODE_PROVIDER_API_KEY}";
+  }
+  if (opts.baseUrl) {
+    providerConfig.baseUrl = opts.baseUrl;
+  }
+
+  const config = {
+    provider: {
+      [openCodeProvider]: providerConfig,
+    },
+    model: {
+      default: `${openCodeProvider}/${opts.model}`,
+    },
+    server: {
+      port: 4096,
+      hostname: "127.0.0.1",
+    },
+  };
+
+  writeFileSync(
+    join(configDir, "opencode.json"),
+    JSON.stringify(config, null, 2) + "\n",
+    "utf-8",
+  );
+
+  console.log(`[OpenCode] Config written to ${join(configDir, "opencode.json")}`);
+}
+
+// ---------------------------------------------------------------------------
+// Process manager
+// ---------------------------------------------------------------------------
+
+let openCodeProcess: ChildProcess | null = null;
+let restartTimer: ReturnType<typeof setTimeout> | null = null;
+let restartAttempts = 0;
+const MAX_RESTART_ATTEMPTS = 5;
+const BASE_BACKOFF_MS = 2000;
+
+function resolveApiKey(): string | undefined {
+  const providerId = getConfig("opencode:provider_id");
+  if (!providerId) return undefined;
+  const row = getProviderRow(providerId);
+  return row?.apiKey ?? undefined;
+}
+
+export function startOpenCodeServer(): void {
+  if (getConfig("opencode:enabled") !== "true") {
+    console.log("[OpenCode] Not enabled — skipping server start.");
+    return;
+  }
+
+  if (openCodeProcess && !openCodeProcess.killed) {
+    console.log("[OpenCode] Server already running (pid=%d).", openCodeProcess.pid);
+    return;
+  }
+
+  const username = getConfig("opencode:username") ?? "";
+  const password = getConfig("opencode:password") ?? "";
+  const apiKey = resolveApiKey() ?? "";
+
+  const env: Record<string, string> = {
+    ...process.env as Record<string, string>,
+    OPENCODE_SERVER_USERNAME: username,
+    OPENCODE_SERVER_PASSWORD: password,
+    OPENCODE_PROVIDER_API_KEY: apiKey,
+  };
+
+  console.log("[OpenCode] Starting `opencode serve`...");
+
+  const child = spawn("opencode", ["serve"], {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: false,
+  });
+
+  openCodeProcess = child;
+  restartAttempts = 0;
+
+  child.stdout?.on("data", (chunk: Buffer) => {
+    const line = chunk.toString().trim();
+    if (line) console.log(`[OpenCode stdout] ${line}`);
+  });
+
+  child.stderr?.on("data", (chunk: Buffer) => {
+    const line = chunk.toString().trim();
+    if (line) console.error(`[OpenCode stderr] ${line}`);
+  });
+
+  child.on("exit", (code, signal) => {
+    console.warn(`[OpenCode] Process exited (code=${code}, signal=${signal}).`);
+    openCodeProcess = null;
+
+    // Auto-restart with backoff if it wasn't intentionally stopped
+    if (getConfig("opencode:enabled") === "true" && !signal) {
+      scheduleRestart();
+    }
+  });
+
+  child.on("error", (err) => {
+    console.error("[OpenCode] Failed to spawn process:", err.message);
+    openCodeProcess = null;
+  });
+}
+
+function scheduleRestart(): void {
+  if (restartAttempts >= MAX_RESTART_ATTEMPTS) {
+    console.error(
+      `[OpenCode] Reached max restart attempts (${MAX_RESTART_ATTEMPTS}). Giving up.`,
+    );
+    return;
+  }
+
+  restartAttempts++;
+  const delay = BASE_BACKOFF_MS * Math.pow(2, restartAttempts - 1);
+  console.log(
+    `[OpenCode] Scheduling restart attempt ${restartAttempts}/${MAX_RESTART_ATTEMPTS} in ${delay}ms...`,
+  );
+
+  restartTimer = setTimeout(() => {
+    restartTimer = null;
+    startOpenCodeServer();
+  }, delay);
+}
+
+export function stopOpenCodeServer(): void {
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+
+  if (!openCodeProcess) {
+    return;
+  }
+
+  console.log("[OpenCode] Stopping server (pid=%d)...", openCodeProcess.pid);
+
+  try {
+    openCodeProcess.kill("SIGTERM");
+  } catch {
+    // Process may have already exited
+  }
+
+  openCodeProcess = null;
+}
+
+export function isOpenCodeRunning(): boolean {
+  return openCodeProcess !== null && !openCodeProcess.killed;
+}

--- a/packages/web/src/stores/auth-store.ts
+++ b/packages/web/src/stores/auth-store.ts
@@ -35,6 +35,11 @@ interface AuthState {
     adminName: string;
     adminModelPackId?: string;
     adminGearConfig?: Record<string, boolean> | null;
+    openCodeEnabled?: boolean;
+    openCodeProvider?: string;
+    openCodeModel?: string;
+    openCodeApiKey?: string;
+    openCodeBaseUrl?: string;
   }) => Promise<boolean>;
   logout: () => Promise<void>;
   setError: (error: string | null) => void;


### PR DESCRIPTION
## Summary
- Add `opencode-manager.ts` — config writer + background process manager with restart-on-crash backoff
- Add setup wizard step 8 (between Web Search and Voice) for OpenCode coding model selection with toggle, same-provider option, and model probing
- Team lead now recommends OpenCode Coder for coding tasks when enabled
- Server boots/stops OpenCode process on startup/shutdown and settings toggle

## Test plan
- [ ] `npx pnpm build` passes (verified)
- [ ] `npx pnpm test` — all 99 tests pass (verified)
- [ ] Run setup wizard — new OpenCode step appears between Web Search and Voice
- [ ] After setup, verify `~/.config/opencode/opencode.json` has correct config
- [ ] Verify `opencode serve` starts as background process
- [ ] Toggle OpenCode off/on in Settings — verify process stops/starts
- [ ] Ask COO to create a coding project — verify team lead spawns OpenCode Coder workers