### PR TITLE
chore: install opencode-ai in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ruby-full \
     && rm -rf /var/lib/apt/lists/*
 
+# Install OpenCode (AI coding agent — used by the OpenCode Coder worker)
+RUN npm install -g opencode-ai@latest
+
 # Create non-root user with configurable UID/GID
 ARG OTTERBOT_UID=1000
 ARG OTTERBOT_GID=1000


### PR DESCRIPTION
## Summary
- Add `npm install -g opencode-ai@latest` to the Dockerfile so the `opencode` binary is on PATH
- Required for the managed OpenCode server (`opencode serve`) to start in the container

## Test plan
- [ ] Docker build succeeds and `opencode` is available at `/usr/local/bin/opencode`
- [ ] After container restart, OpenCode server starts automatically when enabled