### PR TITLE
fix: correct OpenCode config format and install binary in Docker

### DIFF
--- a/packages/server/src/opencode/opencode-manager.ts
+++ b/packages/server/src/opencode/opencode-manager.ts
@@ -45,22 +45,29 @@ export function writeOpenCodeConfig(opts: OpenCodeConfigOptions): void {
 
   const openCodeProvider = PROVIDER_TYPE_MAP[opts.providerType] ?? "openai";
 
-  // Build provider config — use env var reference to avoid writing raw keys to disk
-  const providerConfig: Record<string, unknown> = {};
+  // Build provider options — use env var reference to avoid writing raw keys to disk
+  const providerOptions: Record<string, unknown> = {};
   if (opts.apiKey) {
-    providerConfig.apiKey = "{env:OPENCODE_PROVIDER_API_KEY}";
+    providerOptions.apiKey = "{env:OPENCODE_PROVIDER_API_KEY}";
   }
   if (opts.baseUrl) {
-    providerConfig.baseUrl = opts.baseUrl;
+    providerOptions.baseURL = opts.baseUrl;
   }
 
-  const config = {
+  // For ollama, use the openai-compatible SDK adapter
+  const providerEntry: Record<string, unknown> = {
+    options: providerOptions,
+  };
+  if (openCodeProvider === "ollama") {
+    providerEntry.npm = "@ai-sdk/openai-compatible";
+  }
+
+  const config: Record<string, unknown> = {
+    $schema: "https://opencode.ai/config.json",
     provider: {
-      [openCodeProvider]: providerConfig,
+      [openCodeProvider]: providerEntry,
     },
-    model: {
-      default: `${openCodeProvider}/${opts.model}`,
-    },
+    model: `${openCodeProvider}/${opts.model}`,
     server: {
       port: 4096,
       hostname: "127.0.0.1",


### PR DESCRIPTION
## Summary
- Fix `opencode.json` config format to match [OpenCode schema](https://opencode.ai/docs/config/):
  - `model` is a flat string (`"anthropic/claude-sonnet-4-5"`), not `{ default: "..." }`
  - Provider API key/baseURL go under an `options` key
  - Base URL key is `baseURL` (not `baseUrl`)
  - Add `$schema` reference
- Add ollama `npm` adapter field (`@ai-sdk/openai-compatible`)
- Install `opencode-ai` globally in the Docker image so `opencode` is on PATH

## Test plan
- [ ] Docker build succeeds
- [ ] After container restart with OpenCode enabled, config file is valid and `opencode serve` starts without schema errors
- [ ] OpenCode Coder workers can successfully delegate tasks