### PR TITLE
feat: OpenCode SDK integration with activity-based timeout and orchestration fixes

### DIFF
--- a/packages/server/src/tools/opencode-client.ts
+++ b/packages/server/src/tools/opencode-client.ts
@@ -45,7 +45,7 @@ export class OpenCodeClient {
   constructor(config: OpenCodeConfig) {
     const baseUrl = config.apiUrl.replace(/\/+$/, "");
     this.apiUrl = baseUrl;
-    this.idleTimeoutMs = config.timeoutMs ?? 180_000;
+    this.idleTimeoutMs = config.timeoutMs ?? 1_200_000;
     this.maxIterations = config.maxIterations ?? 50;
 
     // Build auth header for HTTP Basic

--- a/packages/server/src/tools/opencode-task.ts
+++ b/packages/server/src/tools/opencode-task.ts
@@ -4,7 +4,7 @@ import type { ToolContext } from "./tool-context.js";
 import { OpenCodeClient } from "./opencode-client.js";
 import { getConfig } from "../auth/auth.js";
 
-const DEFAULT_TIMEOUT = 180_000; // 3 minutes
+const DEFAULT_TIMEOUT = 1_200_000; // 20 minutes idle timeout
 const DEFAULT_MAX_ITERATIONS = 50;
 
 export function createOpenCodeTaskTool(ctx: ToolContext) {


### PR DESCRIPTION
## Summary

Complete OpenCode integration as the primary autonomous coding agent, with extensive task orchestration fixes.

### OpenCode Client
- **SDK refactor**: Replaced raw `fetch` with typed `@opencode-ai/sdk` client
- **Activity-based idle timeout**: Monitors session via SSE event stream instead of fixed timeout. Aborts after 20 min of inactivity (configurable). Hard cap at 30 min total.
- **Undici timeout disabled**: Custom `Agent` with `headersTimeout: 0` to prevent premature connection kills on long-running tasks
- **Auto-approve permissions**: `permission: "allow"` in config prevents stalling on approval prompts
- **Workspace path injection**: Tasks include correct directory so OpenCode writes files in the right place

### Task Orchestration
- **blockedBy validation**: Rejects symbolic IDs like "task-1", returns real task IDs
- **Safety net continuation**: Force-moved tasks trigger `thinkWithContinuation` to spawn workers for newly unblocked tasks
- **Serialized coding workers**: One coder at a time per project
- **Spawn refusal tracking**: Prevents LLM from spam-retrying refused spawns
- **delete_task tool**: Cleans up `blockedBy` references automatically
- **Unit test requirements**: Coding workers must write and run tests

### Setup & Settings
- Wizard step for OpenCode model/provider selection
- Settings UI for model/provider with config auto-regeneration
- Custom provider support with compat adapter

## Test plan
- [x] Build succeeds, all 99 tests pass
- [ ] End-to-end: multi-task project executes in dependency order
- [ ] Long-running OpenCode tasks survive during npm install / builds
- [ ] Permission prompts no longer stall execution