### PR TITLE
fix: abort tool-call stream when guards fire to prevent spam loops

### DIFF
--- a/packages/server/src/llm/adapter.ts
+++ b/packages/server/src/llm/adapter.ts
@@ -155,6 +155,10 @@ export async function stream(
   config: LLMConfig,
   messages: ChatMessage[],
   tools?: Record<string, unknown>,
+  options?: {
+    abortSignal?: AbortSignal;
+    onStepFinish?: (event: { toolCalls: unknown[] }) => void | Promise<void>;
+  },
 ) {
   const model = resolveModel(config);
   const thinking = isThinkingModel(config);
@@ -164,6 +168,8 @@ export async function stream(
     temperature: config.temperature,
     maxRetries: config.maxRetries ?? 8,
     ...(tools ? { tools: tools as any, maxSteps: config.maxSteps ?? 20 } : {}),
+    ...(options?.abortSignal ? { abortSignal: options.abortSignal } : {}),
+    ...(options?.onStepFinish ? { onStepFinish: options.onStepFinish } : {}),
     ...(thinking
       ? {
           providerOptions: {


### PR DESCRIPTION
## Summary
- Wire an `AbortController` through `stream()` → `streamText()` with an `onStepFinish` callback that checks a `_shouldAbortThink` flag on `BaseAgent`
- Tool guards in TeamLead (`list_tasks` repeat, `spawn_worker` refusal) set the flag so the stream aborts after 1 additional step instead of exhausting all 10 `maxSteps`
- Handles `AbortError` gracefully in `runStream()` — returns accumulated text instead of throwing

## Test plan
- [x] `npx pnpm build` — no type errors
- [x] `npx pnpm test` — all 99 tests pass
- [ ] Manual: run a project with qwen3-coder-next, verify `spawn_worker` refusal aborts after 1 extra step
- [ ] Manual: verify `list_tasks` repeated calls abort after 1 extra step
- [ ] Manual: verify legitimate tool usage (create tasks, search registry, spawn first worker) is unaffected