### PR TITLE
feat: live project recovery without deletion

### DIFF
--- a/packages/server/src/socket/handlers.ts
+++ b/packages/server/src/socket/handlers.ts
@@ -253,6 +253,12 @@ export function setupSocketHandlers(
       callback(conversations as Conversation[]);
     });
 
+    // Recover a stuck project (tear down old TL + workers, spawn fresh one)
+    socket.on("project:recover", async (data, callback) => {
+      const result = await coo.recoverLiveProject(data.projectId);
+      callback?.(result);
+    });
+
     // Delete a project (cascading cleanup)
     socket.on("project:delete", (data, callback) => {
       const db = getDb();

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -66,6 +66,10 @@ export interface ClientToServerEvents {
     data: { projectId: string },
     callback?: (ack: { ok: boolean; error?: string }) => void,
   ) => void;
+  "project:recover": (
+    data: { projectId: string },
+    callback?: (ack: { ok: boolean; error?: string }) => void,
+  ) => void;
   "project:conversations": (
     data: { projectId: string },
     callback: (conversations: Conversation[]) => void,


### PR DESCRIPTION
## Summary
- Add `recoverLiveProject()` to COO that tears down existing TeamLead + workers and spawns a fresh TL with recovery directive, preserving all project data (tasks, files, history)
- Expose via `project:recover` socket event and `POST /api/projects/:projectId/recover` REST endpoint
- Wire `onAgentDestroyed` callback so the UI receives `agent:destroyed` events during both recovery and project deletion

## Test plan
- [x] `npx pnpm build` — no type errors
- [x] `npx pnpm test` — all 99 tests pass
- [ ] Manual: with a running project, call `POST /api/projects/:id/recover` — old TL + workers destroyed, new TL spawned, orphaned tasks reset to backlog, recovery directive sent