### PR TITLE
fix: project office zone outline, desk spawning, and movement teleporting

### DIFF
--- a/assets/office-templates/default-project-office.json
+++ b/assets/office-templates/default-project-office.json
@@ -21,10 +21,10 @@
   "waypoints": [
     { "id": "entrance", "position": [1, 0, -1], "tag": "entrance" },
     { "id": "center", "position": [5, 0, 4], "tag": "center" },
-    { "id": "desk-1", "position": [3, 0, 1], "tag": "desk" },
-    { "id": "desk-2", "position": [7, 0, 1], "tag": "desk" },
-    { "id": "desk-3", "position": [3, 0, 6], "tag": "desk" },
-    { "id": "desk-4", "position": [7, 0, 6], "tag": "desk" }
+    { "id": "desk-1", "position": [3, 0, 2], "tag": "desk" },
+    { "id": "desk-2", "position": [7, 0, 2], "tag": "desk" },
+    { "id": "desk-3", "position": [3, 0, 7], "tag": "desk" },
+    { "id": "desk-4", "position": [7, 0, 7], "tag": "desk" }
   ],
   "edges": [
     { "from": "entrance", "to": "center" },

--- a/packages/server/src/models3d/world-layout.ts
+++ b/packages/server/src/models3d/world-layout.ts
@@ -147,7 +147,11 @@ export class WorldLayoutManager {
       id: zoneId,
       name: `Project Office`,
       projectId,
-      position,
+      position: [
+        position[0] + template.size[0] / 2,
+        position[1],
+        position[2] + template.size[2] / 2,
+      ] as [number, number, number],
       size: template.size,
     };
 


### PR DESCRIPTION
## Summary
- **Zone outline misalignment**: Center zone position on floor coverage so the glowing outline wraps the actual floor tiles instead of being offset
- **Characters inside desks**: Offset project office desk waypoints +1 Z so characters sit in front of desks, not inside them
- **Walk-then-teleport bug**: Route zone-change movements to the final destination (desk/center), not just the zone entrance; spawn agents from main office entrance and walk to actual target; detect projectId changes to trigger zone-change movement

## Test plan
- [ ] `npx pnpm dev` — create a project, verify glowing outline wraps the floor tiles
- [ ] Characters in project offices stand in front of desks, not inside them
- [ ] Characters walk from main office entrance through hallway to their project office desk (no teleporting)
- [ ] `npx pnpm test` — existing tests pass