### PR TITLE
fix: remove within-zone pathfinding to prevent desk teleport

### DIFF
--- a/packages/web/src/lib/movement-triggers.ts
+++ b/packages/web/src/lib/movement-triggers.ts
@@ -89,17 +89,9 @@ export function processAgentMovement(agent: Agent, prevStatus?: string) {
     return;
   }
 
-  // Status change within same zone: move between center and desk
-  if (prevStatus && prevStatus !== agent.status) {
-    const prevTag = getTargetTag(prevStatus);
-    if (prevTag !== targetTag) {
-      const fromWps = findWaypointsByZoneAndTag(graph, targetZoneId, prevTag);
-      const toWps = findWaypointsByZoneAndTag(graph, targetZoneId, targetTag);
-      if (fromWps.length > 0 && toWps.length > 0) {
-        triggerMovement(agent.id, graph, fromWps[0].id, toWps[0].id);
-      }
-    }
-  }
+  // Within-zone status changes (center ↔ desk) are handled by AgentCharacter's
+  // smooth lerp to the correct static position computed by LiveViewScene.
+  // Pathfinding here would require replicating the per-agent desk index assignment.
 
   // Track agent zone
   agentZoneMap.set(agent.id, targetZoneId);


### PR DESCRIPTION
## Summary
- Within-zone status changes (center ↔ desk) always routed to desk[0] (CEO's desk) regardless of which agent was moving, causing a visible teleport when the static position system corrected to the actual assigned desk
- Removed the within-zone pathfinding trigger; AgentCharacter's smooth lerp now handles these transitions directly to the correct position

## Test plan
- [ ] COO transitions between idle and thinking without teleporting
- [ ] Other main office agents also transition smoothly to their correct desks
- [ ] Cross-zone movement (spawn, project assignment) still uses pathfinding correctly