### PR TITLE
fix: detect silent worker timeouts and add debug logging

### DIFF
--- a/packages/server/src/utils/debug.ts
+++ b/packages/server/src/utils/debug.ts
@@ -1,0 +1,7 @@
+const DEBUG =
+  process.env.OTTERBOT_DEBUG === "1" ||
+  process.env.OTTERBOT_DEBUG === "true";
+
+export function debug(tag: string, ...args: unknown[]): void {
+  if (DEBUG) console.log(`[DEBUG:${tag}]`, ...args);
+}


### PR DESCRIPTION
## Summary
- Workers that timed out produced empty text which bypassed `isFailureReport()`, causing tasks to silently disappear as "done" with no retry
- Adds `timedOut` flag to `runStream()`/`think()` return types using a timeout sentinel to distinguish real timeouts from empty streams
- Worker now detects timed-out or empty results and emits `WORKER ERROR:` so the team lead retries the task
- Hardens `isFailureReport()` with an empty-string safety net
- Adds `OTTERBOT_DEBUG=1` env-gated `debug()` utility with logging in key paths (worker task handling, team lead report evaluation, continuation loop)

## Test plan
- [x] `npx pnpm build` — no type errors
- [x] `npx pnpm test` — 99/99 tests pass
- [ ] Manual: set `OTTERBOT_DEBUG=1`, start a project, verify verbose logging appears
- [ ] Manual: simulate a timeout — worker should report `WORKER ERROR:` and task should be retried (moved to backlog)