### PR TITLE
fix: ESM require fix, pipeline reliability, and direct OpenCode delegation

### DIFF
--- a/packages/server/src/tools/opencode-client.ts
+++ b/packages/server/src/tools/opencode-client.ts
@@ -6,6 +6,9 @@
  */
 
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/client";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
 
 export interface OpenCodeConfig {
   apiUrl: string;
@@ -59,7 +62,6 @@ export class OpenCodeClient {
     // Disable undici's default headers/body timeouts — session.prompt() blocks
     // until OpenCode finishes which can take many minutes. Our activity monitor
     // handles idle detection instead.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { Agent } = require("undici") as { Agent: new (opts: Record<string, unknown>) => unknown };
     const dispatcher = new Agent({
       headersTimeout: 0,


### PR DESCRIPTION
## Summary
- **Fix `require is not defined`**: Use `createRequire(import.meta.url)` for the undici import in `opencode-client.ts` — bare `require()` fails in ESM context
- **Direct OpenCode delegation**: `builtin-opencode-coder` workers bypass `think()` and call OpenCode directly, saving tokens and latency
- **Prevent task reversion**: Guard against LLM moving completed tasks back to backlog
- **Fix retry double-count**: `ensureTaskMoved` no longer double-increments retryCount
- **Programmatic orphan cleanup**: Orphaned tasks auto-move to backlog without relying on LLM
- **Auto-spawn fallback**: When LLM fails to spawn workers for unblocked tasks, system does it programmatically (bounded by MAX_TASK_RETRIES + single-coder rule)

## Test plan
- [x] `npx pnpm build` — no type errors
- [x] `npx pnpm test` — all 99 tests pass
- [ ] Manual: verify no "require is not defined" crash on worker spawn
- [ ] Manual: verify direct OpenCode call (log: "Sending task directly to OpenCode")
- [ ] Manual: verify orphan auto-cleanup and auto-spawn fallback