### PR TITLE
fix: add undici as explicit dependency for OpenCode client

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,6 +36,7 @@
     "playwright": "^1.50.0",
     "puppeteer": "^24.2.0",
     "socket.io": "^4.8.1",
+    "undici": "^7.22.0",
     "ws": "^8.18.0",
     "zod": "^3.24.1",
     "zod-to-json-schema": "^3.25.1"

--- a/packages/server/src/tools/opencode-client.ts
+++ b/packages/server/src/tools/opencode-client.ts
@@ -6,9 +6,7 @@
  */
 
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/client";
-import { createRequire } from "node:module";
-
-const require = createRequire(import.meta.url);
+import { Agent } from "undici";
 
 export interface OpenCodeConfig {
   apiUrl: string;
@@ -62,7 +60,6 @@ export class OpenCodeClient {
     // Disable undici's default headers/body timeouts — session.prompt() blocks
     // until OpenCode finishes which can take many minutes. Our activity monitor
     // handles idle detection instead.
-    const { Agent } = require("undici") as { Agent: new (opts: Record<string, unknown>) => unknown };
     const dispatcher = new Agent({
       headersTimeout: 0,
       bodyTimeout: 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       socket.io:
         specifier: ^4.8.1
         version: 4.8.3
+      undici:
+        specifier: ^7.22.0
+        version: 7.22.0
       ws:
         specifier: ^8.18.0
         version: 8.18.3
@@ -4248,6 +4251,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -8733,6 +8740,8 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.22.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## Summary
- **Add `undici` as explicit dependency**: Node 22 bundles undici but `createRequire()` can't resolve it (not in `node_modules`). Adding it as a real dependency fixes the "Cannot find module 'undici'" error in Docker.
- **Clean ESM import**: Replace `createRequire` + `require("undici")` hack with a proper `import { Agent } from "undici"` at the top of the file.

## Test plan
- [x] `npx pnpm build` — no type errors
- [x] `npx pnpm test` — all 99 tests pass
- [ ] Manual: `docker build --no-cache` then spawn OpenCode coder worker — no module errors