### PR TITLE
test: add unit tests for OpenCode pipeline logic

### DIFF
--- a/packages/server/src/agents/__tests__/team-lead-kanban.test.ts
+++ b/packages/server/src/agents/__tests__/team-lead-kanban.test.ts
@@ -1,0 +1,433 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrateDb, resetDb, getDb, schema } from "../../db/index.js";
+import { eq } from "drizzle-orm";
+
+// --- Mocks ---
+
+// Mock auth — getConfig returns undefined by default; per-test overrides below
+const configStore = new Map<string, string>();
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn((key: string) => configStore.get(key)),
+  setConfig: vi.fn((key: string, value: string) => configStore.set(key, value)),
+  deleteConfig: vi.fn((key: string) => configStore.delete(key)),
+}));
+
+// Mock search providers (imported at module level in team-lead.ts)
+vi.mock("../../tools/search/providers.js", () => ({
+  getConfiguredSearchProvider: vi.fn(() => null),
+}));
+
+// Mock desktop module
+vi.mock("../../desktop/desktop.js", () => ({
+  isDesktopEnabled: vi.fn(() => false),
+  getDesktopConfig: vi.fn(() => ({})),
+}));
+
+// Mock model-packs to return a deterministic value
+vi.mock("../../models3d/model-packs.js", () => ({
+  getRandomModelPackId: vi.fn(() => "pack-1"),
+}));
+
+// Mock LLM adapter
+vi.mock("../../llm/adapter.js", () => ({
+  stream: vi.fn(),
+  resolveProviderCredentials: vi.fn(() => ({ type: "anthropic" })),
+}));
+
+// Mock circuit breaker
+vi.mock("../../llm/circuit-breaker.js", () => ({
+  isProviderAvailable: vi.fn(() => true),
+  getCircuitBreaker: vi.fn(() => ({ recordSuccess: vi.fn(), recordFailure: vi.fn(), remainingCooldownMs: 0 })),
+}));
+
+// Mock settings/model-pricing
+vi.mock("../../settings/model-pricing.js", () => ({
+  calculateCost: vi.fn(() => 0),
+}));
+
+// Mock kimi-tool-parser
+vi.mock("../../llm/kimi-tool-parser.js", () => ({
+  containsKimiToolMarkup: vi.fn(() => false),
+  findToolMarkupStart: vi.fn(() => -1),
+  formatToolsForPrompt: vi.fn(() => ""),
+  parseKimiToolCalls: vi.fn(() => ({ cleanText: "", toolCalls: [] })),
+  usesTextToolCalling: vi.fn(() => false),
+}));
+
+// Mock tool-factory
+vi.mock("../../tools/tool-factory.js", () => ({
+  createTools: vi.fn(() => ({})),
+}));
+
+// Mock opencode-client
+vi.mock("../../tools/opencode-client.js", () => ({
+  OpenCodeClient: vi.fn().mockImplementation(() => ({
+    executeTask: vi.fn().mockResolvedValue({ success: true, sessionId: "s", summary: "Done", diff: null }),
+  })),
+}));
+
+import { TeamLead } from "../team-lead.js";
+import type { MessageBus } from "../../bus/message-bus.js";
+import type { WorkspaceManager } from "../../workspace/workspace.js";
+
+function createMockBus(): MessageBus {
+  return {
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    send: vi.fn(() => ({
+      id: "msg-1",
+      fromAgentId: "",
+      toAgentId: "",
+      type: "report",
+      content: "",
+      timestamp: new Date().toISOString(),
+    })),
+    getHistory: vi.fn(() => ({ messages: [], hasMore: false })),
+    request: vi.fn(),
+    onBroadcast: vi.fn(),
+    offBroadcast: vi.fn(),
+  } as unknown as MessageBus;
+}
+
+function createMockWorkspace(): WorkspaceManager {
+  return {
+    repoPath: vi.fn((projectId: string) => `/workspace/projects/${projectId}/repo`),
+    validateAccess: vi.fn(() => true),
+    ensureProject: vi.fn(),
+  } as unknown as WorkspaceManager;
+}
+
+const PROJECT_ID = "test-project";
+
+function createTeamLead(bus: MessageBus) {
+  return new TeamLead({
+    bus,
+    workspace: createMockWorkspace(),
+    projectId: PROJECT_ID,
+    parentId: "coo-1",
+  });
+}
+
+/** Insert a kanban task directly into the DB */
+function insertTask(overrides: Partial<{
+  id: string;
+  title: string;
+  column: "backlog" | "in_progress" | "done";
+  description: string;
+  assigneeAgentId: string | null;
+  position: number;
+  blockedBy: string[];
+  retryCount: number;
+  completionReport: string | null;
+}> = {}) {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const column = overrides.column ?? "backlog" as const;
+  const task = {
+    id: overrides.id ?? `task-${Math.random().toString(36).slice(2, 8)}`,
+    projectId: PROJECT_ID,
+    title: overrides.title ?? "Test task",
+    description: overrides.description ?? "",
+    column: column as "backlog" | "in_progress" | "done",
+    position: overrides.position ?? 0,
+    assigneeAgentId: overrides.assigneeAgentId ?? null,
+    createdBy: "test",
+    labels: [],
+    blockedBy: overrides.blockedBy ?? [],
+    retryCount: overrides.retryCount ?? 0,
+    completionReport: overrides.completionReport ?? null,
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.insert(schema.kanbanTasks).values(task).run();
+  return task;
+}
+
+function getTask(taskId: string) {
+  return getDb()
+    .select()
+    .from(schema.kanbanTasks)
+    .where(eq(schema.kanbanTasks.id, taskId))
+    .get();
+}
+
+describe("TeamLead — Kanban logic", () => {
+  let tmpDir: string;
+  let bus: MessageBus;
+  let tl: TeamLead;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-tl-test-"));
+    resetDb();
+    configStore.clear();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+    bus = createMockBus();
+    tl = createTeamLead(bus);
+  });
+
+  afterEach(() => {
+    try { tl.destroy(); } catch { /* ignore */ }
+    resetDb();
+    configStore.clear();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ─── updateKanbanTask guards ────────────────────────────────
+
+  describe("updateKanbanTask guards", () => {
+    it("no-op when already in target column with no other changes", () => {
+      const task = insertTask({ column: "done" });
+      const result = (tl as any).updateKanbanTask(task.id, { column: "done" });
+      expect(result).toContain("already in");
+    });
+
+    it("allows done→done with description update", () => {
+      const task = insertTask({ column: "done" });
+      const result = (tl as any).updateKanbanTask(task.id, {
+        column: "done",
+        description: "Updated description",
+      });
+      expect(result).toContain("updated");
+      expect(getTask(task.id)?.description).toBe("Updated description");
+    });
+
+    it("rejects done→backlog", () => {
+      const task = insertTask({ column: "done" });
+      const result = (tl as any).updateKanbanTask(task.id, { column: "backlog" });
+      expect(result).toContain("REJECTED");
+    });
+
+    it("rejects done→in_progress", () => {
+      const task = insertTask({ column: "done" });
+      const result = (tl as any).updateKanbanTask(task.id, { column: "in_progress" });
+      expect(result).toContain("REJECTED");
+    });
+
+    it("allows backlog→in_progress", () => {
+      const task = insertTask({ column: "backlog" });
+      const result = (tl as any).updateKanbanTask(task.id, {
+        column: "in_progress",
+        assigneeAgentId: "worker-1",
+      });
+      expect(result).toContain("updated");
+      expect(getTask(task.id)?.column).toBe("in_progress");
+    });
+
+    it("allows in_progress→done", () => {
+      const task = insertTask({ column: "in_progress" });
+      const result = (tl as any).updateKanbanTask(task.id, { column: "done" });
+      expect(result).toContain("updated");
+      expect(getTask(task.id)?.column).toBe("done");
+    });
+
+    it("increments retryCount on in_progress→backlog", () => {
+      const task = insertTask({ column: "in_progress", retryCount: 0 });
+      (tl as any).updateKanbanTask(task.id, {
+        column: "backlog",
+        assigneeAgentId: "",
+      });
+      const updated = getTask(task.id);
+      expect(updated?.retryCount).toBe(1);
+      expect(updated?.column).toBe("backlog");
+    });
+
+    it("forces task to done when retries exhausted (MAX_TASK_RETRIES=3)", () => {
+      const task = insertTask({ column: "in_progress", retryCount: 2 });
+      (tl as any).updateKanbanTask(task.id, {
+        column: "backlog",
+        assigneeAgentId: "",
+      });
+      const updated = getTask(task.id);
+      // retryCount becomes 3, which >= MAX_TASK_RETRIES, so forced to done
+      expect(updated?.retryCount).toBe(3);
+      expect(updated?.column).toBe("done");
+      expect(updated?.completionReport).toContain("FAILED");
+    });
+  });
+
+  // ─── ensureTaskMoved safety net ─────────────────────────────
+
+  describe("ensureTaskMoved safety net", () => {
+    it("returns false if task already moved (not in in_progress)", () => {
+      const task = insertTask({ column: "done" });
+      const moved = (tl as any).ensureTaskMoved(task.id, "All good");
+      expect(moved).toBe(false);
+    });
+
+    it("moves successful task to done", () => {
+      const task = insertTask({ column: "in_progress", assigneeAgentId: "worker-1" });
+      const moved = (tl as any).ensureTaskMoved(task.id, "Everything works perfectly, feature implemented.");
+      expect(moved).toBe(true);
+      const updated = getTask(task.id);
+      expect(updated?.column).toBe("done");
+    });
+
+    it("moves failed task to backlog with enriched description", () => {
+      const task = insertTask({
+        column: "in_progress",
+        assigneeAgentId: "worker-1",
+        description: "Original description",
+      });
+      const moved = (tl as any).ensureTaskMoved(task.id, "WORKER ERROR: Task failed — compilation error");
+      expect(moved).toBe(true);
+      const updated = getTask(task.id);
+      expect(updated?.column).toBe("backlog");
+      expect(updated?.description).toContain("PREVIOUS ATTEMPT FAILED");
+      expect(updated?.description).toContain("compilation error");
+    });
+
+    it("forces failed task to done when retries exhausted", () => {
+      const task = insertTask({
+        column: "in_progress",
+        assigneeAgentId: "worker-1",
+        retryCount: 2, // next will be 3 = MAX_TASK_RETRIES
+      });
+      const moved = (tl as any).ensureTaskMoved(task.id, "WORKER ERROR: still broken");
+      expect(moved).toBe(true);
+      const updated = getTask(task.id);
+      expect(updated?.column).toBe("done");
+      expect(updated?.completionReport).toContain("FAILED");
+    });
+
+    it("does not double-increment retryCount", () => {
+      // ensureTaskMoved calls updateKanbanTask which increments retryCount.
+      // Verify it only increments once (not ensureTaskMoved + updateKanbanTask separately).
+      const task = insertTask({
+        column: "in_progress",
+        assigneeAgentId: "worker-1",
+        retryCount: 0,
+      });
+      (tl as any).ensureTaskMoved(task.id, "WORKER ERROR: failed");
+      const updated = getTask(task.id);
+      expect(updated?.retryCount).toBe(1); // exactly 1, not 2
+    });
+  });
+
+  // ─── isFailureReport ────────────────────────────────────────
+
+  describe("isFailureReport", () => {
+    it("detects 'WORKER ERROR:' signal", () => {
+      expect((tl as any).isFailureReport("WORKER ERROR: Task failed — timeout")).toBe(true);
+    });
+
+    it("detects 'exit code: 1' signal", () => {
+      expect((tl as any).isFailureReport("Process finished with exit code: 1")).toBe(true);
+    });
+
+    it("detects 'error:' signal", () => {
+      expect((tl as any).isFailureReport("Something caused an error: bad input")).toBe(true);
+    });
+
+    it("detects 'permission denied' signal", () => {
+      expect((tl as any).isFailureReport("Permission denied: /etc/shadow")).toBe(true);
+    });
+
+    it("returns true for empty report", () => {
+      expect((tl as any).isFailureReport("")).toBe(true);
+      expect((tl as any).isFailureReport("   ")).toBe(true);
+    });
+
+    it("returns false for normal success report", () => {
+      expect((tl as any).isFailureReport("Successfully implemented the feature. All tests pass.")).toBe(false);
+    });
+  });
+
+  // ─── Orphan cleanup (getOrphanedTasks) ──────────────────────
+
+  describe("orphan detection", () => {
+    it("identifies in_progress tasks assigned to dead workers as orphans", () => {
+      // Insert a task assigned to a worker that doesn't exist in tl.workers
+      insertTask({
+        id: "orphan-1",
+        column: "in_progress",
+        assigneeAgentId: "dead-worker-123",
+      });
+      const orphans = (tl as any).getOrphanedTasks();
+      expect(orphans).toHaveLength(1);
+      expect(orphans[0].id).toBe("orphan-1");
+    });
+
+    it("does not flag tasks assigned to living workers", () => {
+      // Add a worker to the team lead's worker map
+      const workerId = "living-worker-456";
+      (tl as any).workers.set(workerId, { id: workerId, destroy: vi.fn() });
+
+      insertTask({
+        id: "active-1",
+        column: "in_progress",
+        assigneeAgentId: workerId,
+      });
+      const orphans = (tl as any).getOrphanedTasks();
+      expect(orphans).toHaveLength(0);
+    });
+  });
+
+  // ─── autoSpawnUnblockedTasks ────────────────────────────────
+
+  describe("autoSpawnUnblockedTasks", () => {
+    it("skips when workers are already running", async () => {
+      (tl as any).workers.set("w-1", { id: "w-1", destroy: vi.fn(), registryEntryId: "builtin-coder" });
+      insertTask({ column: "backlog" });
+
+      const spawnSpy = vi.spyOn(tl as any, "spawnWorker");
+      await (tl as any).autoSpawnUnblockedTasks();
+      expect(spawnSpy).not.toHaveBeenCalled();
+    });
+
+    it("skips when no unblocked backlog tasks", async () => {
+      // Only done tasks
+      insertTask({ column: "done" });
+
+      const spawnSpy = vi.spyOn(tl as any, "spawnWorker");
+      await (tl as any).autoSpawnUnblockedTasks();
+      expect(spawnSpy).not.toHaveBeenCalled();
+    });
+
+    it("skips when all backlog tasks are blocked", async () => {
+      const blocker = insertTask({ id: "blocker-1", column: "in_progress" });
+      insertTask({ column: "backlog", blockedBy: ["blocker-1"] });
+
+      const spawnSpy = vi.spyOn(tl as any, "spawnWorker");
+      await (tl as any).autoSpawnUnblockedTasks();
+      expect(spawnSpy).not.toHaveBeenCalled();
+    });
+
+    it("spawns worker for first unblocked backlog task by position", async () => {
+      insertTask({ id: "task-a", title: "Task A", column: "backlog", position: 1 });
+      insertTask({ id: "task-b", title: "Task B", column: "backlog", position: 0 }); // lower position
+
+      const spawnSpy = vi.spyOn(tl as any, "spawnWorker").mockResolvedValue("Spawned");
+      await (tl as any).autoSpawnUnblockedTasks();
+
+      expect(spawnSpy).toHaveBeenCalledOnce();
+      // Should spawn for task-b (position 0), not task-a (position 1)
+      expect(spawnSpy.mock.calls[0][1]).toContain("Task B");
+    });
+
+    it("uses opencode-coder when opencode:enabled is true", async () => {
+      configStore.set("opencode:enabled", "true");
+      insertTask({ id: "task-x", title: "Code task", column: "backlog" });
+
+      const spawnSpy = vi.spyOn(tl as any, "spawnWorker").mockResolvedValue("Spawned");
+      await (tl as any).autoSpawnUnblockedTasks();
+
+      expect(spawnSpy).toHaveBeenCalledWith("builtin-opencode-coder", expect.any(String), "task-x");
+    });
+
+    it("uses regular coder when opencode:enabled is not set", async () => {
+      insertTask({ id: "task-y", title: "Code task", column: "backlog" });
+
+      const spawnSpy = vi.spyOn(tl as any, "spawnWorker").mockResolvedValue("Spawned");
+      await (tl as any).autoSpawnUnblockedTasks();
+
+      expect(spawnSpy).toHaveBeenCalledWith("builtin-coder", expect.any(String), "task-y");
+    });
+  });
+});

--- a/packages/server/src/agents/__tests__/worker-opencode.test.ts
+++ b/packages/server/src/agents/__tests__/worker-opencode.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrateDb, resetDb } from "../../db/index.js";
+import { AgentStatus, MessageType } from "@otterbot/shared";
+
+// --- Mocks ---
+
+// Mock auth module (getConfig)
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn(),
+  setConfig: vi.fn(),
+  deleteConfig: vi.fn(),
+}));
+
+// Mock opencode-client (dynamic import target)
+const mockExecuteTask = vi.fn();
+vi.mock("../../tools/opencode-client.js", () => ({
+  OpenCodeClient: vi.fn().mockImplementation(() => ({
+    executeTask: mockExecuteTask,
+  })),
+}));
+
+// Mock opencode-task (formatOpenCodeResult — also dynamic import target)
+vi.mock("../../tools/opencode-task.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../tools/opencode-task.js")>();
+  return {
+    ...original,
+    formatOpenCodeResult: vi.fn((result: any) =>
+      result.success
+        ? `OpenCode task completed successfully.\n\n**Summary:**\n${result.summary}`
+        : `OpenCode task failed: ${result.summary}`,
+    ),
+  };
+});
+
+// Mock tool-factory (createTools)
+vi.mock("../../tools/tool-factory.js", () => ({
+  createTools: vi.fn(() => ({})),
+}));
+
+// Mock LLM adapter to prevent real API calls
+vi.mock("../../llm/adapter.js", () => ({
+  stream: vi.fn(),
+  resolveProviderCredentials: vi.fn(() => ({ type: "anthropic" })),
+}));
+
+// Mock circuit breaker
+vi.mock("../../llm/circuit-breaker.js", () => ({
+  isProviderAvailable: vi.fn(() => true),
+  getCircuitBreaker: vi.fn(() => ({ recordSuccess: vi.fn(), recordFailure: vi.fn(), remainingCooldownMs: 0 })),
+}));
+
+// Mock settings/model-pricing
+vi.mock("../../settings/model-pricing.js", () => ({
+  calculateCost: vi.fn(() => 0),
+}));
+
+// Mock kimi-tool-parser
+vi.mock("../../llm/kimi-tool-parser.js", () => ({
+  containsKimiToolMarkup: vi.fn(() => false),
+  findToolMarkupStart: vi.fn(() => -1),
+  formatToolsForPrompt: vi.fn(() => ""),
+  parseKimiToolCalls: vi.fn(() => ({ cleanText: "", toolCalls: [] })),
+  usesTextToolCalling: vi.fn(() => false),
+}));
+
+import { Worker } from "../worker.js";
+import type { MessageBus } from "../../bus/message-bus.js";
+import type { BusMessage } from "@otterbot/shared";
+import { getConfig } from "../../auth/auth.js";
+
+const mockedGetConfig = vi.mocked(getConfig);
+
+function makeDirective(toAgentId: string, content: string): BusMessage {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2, 8)}`,
+    fromAgentId: "parent-1",
+    toAgentId,
+    type: MessageType.Directive,
+    content,
+    metadata: {},
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function createMockBus(): MessageBus {
+  return {
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    send: vi.fn(() => ({
+      id: "msg-1",
+      fromAgentId: "",
+      toAgentId: "",
+      type: MessageType.Report,
+      content: "",
+      timestamp: new Date().toISOString(),
+    })),
+    getHistory: vi.fn(() => ({ messages: [], hasMore: false })),
+    request: vi.fn(),
+    onBroadcast: vi.fn(),
+    offBroadcast: vi.fn(),
+  } as unknown as MessageBus;
+}
+
+describe("Worker — OpenCode delegation", () => {
+  let tmpDir: string;
+  let bus: MessageBus;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-worker-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+    bus = createMockBus();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function createWorker(overrides: Partial<{ registryEntryId: string; workspacePath: string | null }> = {}) {
+    return new Worker({
+      bus,
+      projectId: "proj-1",
+      parentId: "parent-1",
+      registryEntryId: overrides.registryEntryId ?? "builtin-opencode-coder",
+      model: "claude-sonnet-4-5-20250929",
+      provider: "anthropic",
+      systemPrompt: "You are a worker.",
+      workspacePath: overrides.workspacePath ?? "/workspace/project",
+      toolNames: ["file_read", "file_write", "shell_exec"],
+    });
+  }
+
+  it("calls OpenCode directly for builtin-opencode-coder with workspace", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+    mockExecuteTask.mockResolvedValue({
+      success: true,
+      sessionId: "sess-1",
+      summary: "Created feature X",
+      diff: { files: [{ path: "src/x.ts", additions: 10, deletions: 0 }] },
+    });
+
+    const worker = createWorker();
+    await worker.handleMessage(makeDirective(worker.id, "Implement feature X"));
+
+    expect(mockExecuteTask).toHaveBeenCalledOnce();
+    // Task should include workspace path context
+    const taskArg = mockExecuteTask.mock.calls[0][0] as string;
+    expect(taskArg).toContain("/workspace/project");
+    expect(taskArg).toContain("Implement feature X");
+  });
+
+  it("falls back to think() when api_url not configured", async () => {
+    mockedGetConfig.mockReturnValue(undefined);
+
+    const worker = createWorker();
+    const thinkSpy = vi.spyOn(worker as any, "think").mockResolvedValue({
+      text: "think() result",
+      thinking: undefined,
+      hadToolCalls: false,
+    });
+
+    await worker.handleMessage(makeDirective(worker.id, "Do something"));
+
+    expect(mockExecuteTask).not.toHaveBeenCalled();
+    expect(thinkSpy).toHaveBeenCalled();
+  });
+
+  it("falls back to think() for non-opencode workers", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+
+    const worker = createWorker({ registryEntryId: "builtin-coder" });
+    const thinkSpy = vi.spyOn(worker as any, "think").mockResolvedValue({
+      text: "think() result",
+      thinking: undefined,
+      hadToolCalls: false,
+    });
+
+    await worker.handleMessage(makeDirective(worker.id, "Do something"));
+
+    expect(mockExecuteTask).not.toHaveBeenCalled();
+    expect(thinkSpy).toHaveBeenCalled();
+  });
+
+  it("prepends workspace path to task context", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+    mockExecuteTask.mockResolvedValue({
+      success: true,
+      sessionId: "sess-2",
+      summary: "Done",
+      diff: null,
+    });
+
+    const worker = createWorker({ workspacePath: "/my/project" });
+    await worker.handleMessage(makeDirective(worker.id, "Build it"));
+
+    const taskArg = mockExecuteTask.mock.calls[0][0] as string;
+    expect(taskArg).toContain("IMPORTANT: All files must be created/edited inside this directory: /my/project");
+    expect(taskArg).toContain("Build it");
+  });
+
+  it("catches OpenCode client errors and reports them", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+    mockExecuteTask.mockRejectedValue(new Error("Connection refused"));
+
+    const worker = createWorker();
+    await worker.handleMessage(makeDirective(worker.id, "Do task"));
+
+    // Should have sent a report with error info
+    const sendCalls = (bus.send as ReturnType<typeof vi.fn>).mock.calls;
+    const reportCall = sendCalls.find(
+      (c: any[]) => c[0].type === MessageType.Report,
+    );
+    expect(reportCall).toBeDefined();
+    expect(reportCall![0].content).toContain("WORKER ERROR");
+    expect(reportCall![0].content).toContain("Connection refused");
+  });
+
+  it("always sends report to parent", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+    mockExecuteTask.mockResolvedValue({
+      success: true,
+      sessionId: "sess-3",
+      summary: "Done",
+      diff: null,
+    });
+
+    const worker = createWorker();
+    await worker.handleMessage(makeDirective(worker.id, "Task"));
+
+    const sendCalls = (bus.send as ReturnType<typeof vi.fn>).mock.calls;
+    const reportCall = sendCalls.find(
+      (c: any[]) => c[0].type === MessageType.Report && c[0].toAgentId === "parent-1",
+    );
+    expect(reportCall).toBeDefined();
+  });
+
+  it("sets status to Done after task", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+    mockExecuteTask.mockResolvedValue({
+      success: true,
+      sessionId: "sess-4",
+      summary: "Done",
+      diff: null,
+    });
+
+    const worker = createWorker();
+    await worker.handleMessage(makeDirective(worker.id, "Task"));
+
+    expect((worker as any).status).toBe(AgentStatus.Done);
+  });
+});

--- a/packages/server/src/tools/__tests__/format-opencode-result.test.ts
+++ b/packages/server/src/tools/__tests__/format-opencode-result.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { formatOpenCodeResult } from "../opencode-task.js";
+import type { OpenCodeTaskResult } from "../opencode-client.js";
+
+describe("formatOpenCodeResult", () => {
+  it("returns failure message for failed result", () => {
+    const result: OpenCodeTaskResult = {
+      success: false,
+      sessionId: "sess-1",
+      summary: "Could not compile project",
+      diff: null,
+    };
+    expect(formatOpenCodeResult(result)).toBe(
+      "OpenCode task failed: Could not compile project",
+    );
+  });
+
+  it("includes 'No file changes detected' when no files", () => {
+    const result: OpenCodeTaskResult = {
+      success: true,
+      sessionId: "sess-2",
+      summary: "Refactored module",
+      diff: null,
+    };
+    const output = formatOpenCodeResult(result);
+    expect(output).toContain("OpenCode task completed successfully.");
+    expect(output).toContain("Refactored module");
+    expect(output).toContain("No file changes detected.");
+  });
+
+  it("lists files with additions and deletions", () => {
+    const result: OpenCodeTaskResult = {
+      success: true,
+      sessionId: "sess-3",
+      summary: "Added feature",
+      diff: {
+        files: [
+          { path: "src/index.ts", additions: 10, deletions: 3 },
+          { path: "src/utils.ts", additions: 5, deletions: 2 },
+        ],
+      },
+    };
+    const output = formatOpenCodeResult(result);
+    expect(output).toContain("src/index.ts (+10, -3)");
+    expect(output).toContain("src/utils.ts (+5, -2)");
+    expect(output).toContain("Total: 2 file(s) changed");
+    expect(output).not.toContain("No file changes detected.");
+  });
+
+  it("shows only additions when no deletions", () => {
+    const result: OpenCodeTaskResult = {
+      success: true,
+      sessionId: "sess-4",
+      summary: "New file",
+      diff: {
+        files: [{ path: "src/new.ts", additions: 20, deletions: 0 }],
+      },
+    };
+    const output = formatOpenCodeResult(result);
+    expect(output).toContain("src/new.ts (+20)");
+    expect(output).not.toContain("-0");
+  });
+
+  it("truncates summaries longer than 2000 chars", () => {
+    const longSummary = "x".repeat(3000);
+    const result: OpenCodeTaskResult = {
+      success: true,
+      sessionId: "sess-5",
+      summary: longSummary,
+      diff: null,
+    };
+    const output = formatOpenCodeResult(result);
+    expect(output).toContain("[truncated]");
+    // The truncated summary should be at most 2000 chars of the original
+    expect(output).not.toContain("x".repeat(2001));
+  });
+
+  it("treats empty files array as no file changes", () => {
+    const result: OpenCodeTaskResult = {
+      success: true,
+      sessionId: "sess-6",
+      summary: "No-op",
+      diff: { files: [] },
+    };
+    const output = formatOpenCodeResult(result);
+    expect(output).toContain("No file changes detected.");
+  });
+});


### PR DESCRIPTION
## Summary
- Add 40 unit tests across 3 new test files covering the OpenCode pipeline logic that previously had zero test coverage
- `format-opencode-result.test.ts` (6 tests): pure function tests for result formatting
- `worker-opencode.test.ts` (7 tests): Worker OpenCode delegation, fallback to think(), error handling
- `team-lead-kanban.test.ts` (27 tests): kanban guards (task reversion, retry counting), safety net (ensureTaskMoved), failure detection, orphan cleanup, auto-spawn fallback

## Test plan
- [x] `npx pnpm test` — all 139 tests pass (99 existing + 40 new)
- [x] `npx pnpm build` — no type errors