### PR TITLE
feat: add live coding view with OpenCode SSE event replay

### DIFF
--- a/packages/server/src/agents/__tests__/worker-opencode-events.test.ts
+++ b/packages/server/src/agents/__tests__/worker-opencode-events.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrateDb, resetDb } from "../../db/index.js";
+import { MessageType } from "@otterbot/shared";
+
+// --- Mocks ---
+
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn(),
+  setConfig: vi.fn(),
+  deleteConfig: vi.fn(),
+}));
+
+// Capture the onEvent callback when OpenCodeClient is constructed
+let capturedOnEvent: ((event: { type: string; properties: Record<string, unknown> }) => void) | undefined;
+
+const mockExecuteTask = vi.fn();
+vi.mock("../../tools/opencode-client.js", () => ({
+  OpenCodeClient: vi.fn().mockImplementation((config: any) => {
+    capturedOnEvent = config.onEvent;
+    return { executeTask: mockExecuteTask };
+  }),
+}));
+
+vi.mock("../../tools/opencode-task.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../tools/opencode-task.js")>();
+  return {
+    ...original,
+    formatOpenCodeResult: vi.fn((result: any) =>
+      result.success ? `Done: ${result.summary}` : `Failed: ${result.summary}`,
+    ),
+  };
+});
+
+vi.mock("../../tools/tool-factory.js", () => ({
+  createTools: vi.fn(() => ({})),
+}));
+
+vi.mock("../../llm/adapter.js", () => ({
+  stream: vi.fn(),
+  resolveProviderCredentials: vi.fn(() => ({ type: "anthropic" })),
+}));
+
+vi.mock("../../llm/circuit-breaker.js", () => ({
+  isProviderAvailable: vi.fn(() => true),
+  getCircuitBreaker: vi.fn(() => ({ recordSuccess: vi.fn(), recordFailure: vi.fn(), remainingCooldownMs: 0 })),
+}));
+
+vi.mock("../../settings/model-pricing.js", () => ({
+  calculateCost: vi.fn(() => 0),
+}));
+
+vi.mock("../../llm/kimi-tool-parser.js", () => ({
+  containsKimiToolMarkup: vi.fn(() => false),
+  findToolMarkupStart: vi.fn(() => -1),
+  formatToolsForPrompt: vi.fn(() => ""),
+  parseKimiToolCalls: vi.fn(() => ({ cleanText: "", toolCalls: [] })),
+  usesTextToolCalling: vi.fn(() => false),
+}));
+
+import { Worker } from "../worker.js";
+import type { MessageBus } from "../../bus/message-bus.js";
+import type { BusMessage } from "@otterbot/shared";
+import { getConfig } from "../../auth/auth.js";
+
+const mockedGetConfig = vi.mocked(getConfig);
+
+function makeDirective(toAgentId: string, content: string): BusMessage {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2, 8)}`,
+    fromAgentId: "parent-1",
+    toAgentId,
+    type: MessageType.Directive,
+    content,
+    metadata: {},
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function createMockBus(): MessageBus {
+  return {
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    send: vi.fn(() => ({
+      id: "msg-1",
+      fromAgentId: "",
+      toAgentId: "",
+      type: MessageType.Report,
+      content: "",
+      timestamp: new Date().toISOString(),
+    })),
+    getHistory: vi.fn(() => ({ messages: [], hasMore: false })),
+    request: vi.fn(),
+    onBroadcast: vi.fn(),
+    offBroadcast: vi.fn(),
+  } as unknown as MessageBus;
+}
+
+describe("Worker — onOpenCodeEvent callback", () => {
+  let tmpDir: string;
+  let bus: MessageBus;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-worker-event-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+    bus = createMockBus();
+    vi.clearAllMocks();
+    capturedOnEvent = undefined;
+  });
+
+  afterEach(() => {
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function createWorker(onOpenCodeEvent?: any) {
+    return new Worker({
+      bus,
+      projectId: "proj-1",
+      parentId: "parent-1",
+      registryEntryId: "builtin-opencode-coder",
+      model: "claude-sonnet-4-5-20250929",
+      provider: "anthropic",
+      systemPrompt: "You are a worker.",
+      workspacePath: "/workspace/project",
+      toolNames: [],
+      onOpenCodeEvent,
+    });
+  }
+
+  it("emits __session-start before executeTask", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+
+    const events: Array<{ agentId: string; sessionId: string; event: any }> = [];
+    const onOpenCodeEvent = vi.fn((agentId: string, sessionId: string, event: any) => {
+      events.push({ agentId, sessionId, event });
+    });
+
+    mockExecuteTask.mockResolvedValue({
+      success: true,
+      sessionId: "sess-1",
+      summary: "Done",
+      diff: null,
+    });
+
+    const worker = createWorker(onOpenCodeEvent);
+    await worker.handleMessage(makeDirective(worker.id, "Build it"));
+
+    // First event should be __session-start
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    expect(events[0].event.type).toBe("__session-start");
+    expect(events[0].event.properties.task).toBe("Build it");
+    expect(events[0].event.properties.projectId).toBe("proj-1");
+    expect(events[0].agentId).toBe(worker.id);
+  });
+
+  it("emits __session-end after executeTask completes successfully", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+
+    const events: Array<{ agentId: string; sessionId: string; event: any }> = [];
+    const onOpenCodeEvent = vi.fn((agentId: string, sessionId: string, event: any) => {
+      events.push({ agentId, sessionId, event });
+    });
+
+    mockExecuteTask.mockResolvedValue({
+      success: true,
+      sessionId: "sess-1",
+      summary: "Done",
+      diff: { files: [{ path: "src/x.ts", additions: 5, deletions: 0 }] },
+    });
+
+    const worker = createWorker(onOpenCodeEvent);
+    await worker.handleMessage(makeDirective(worker.id, "Build it"));
+
+    // Last event should be __session-end
+    const lastEvent = events[events.length - 1];
+    expect(lastEvent.event.type).toBe("__session-end");
+    expect(lastEvent.sessionId).toBe("sess-1");
+    expect(lastEvent.event.properties.status).toBe("completed");
+    expect(lastEvent.event.properties.diff).toEqual([
+      { path: "src/x.ts", additions: 5, deletions: 0 },
+    ]);
+  });
+
+  it("emits __session-end with error status on failure", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+
+    const events: Array<{ agentId: string; sessionId: string; event: any }> = [];
+    const onOpenCodeEvent = vi.fn((agentId: string, sessionId: string, event: any) => {
+      events.push({ agentId, sessionId, event });
+    });
+
+    mockExecuteTask.mockResolvedValue({
+      success: false,
+      sessionId: "sess-2",
+      summary: "Build failed",
+      diff: null,
+      error: "compilation_error",
+    });
+
+    const worker = createWorker(onOpenCodeEvent);
+    await worker.handleMessage(makeDirective(worker.id, "Build it"));
+
+    const lastEvent = events[events.length - 1];
+    expect(lastEvent.event.type).toBe("__session-end");
+    expect(lastEvent.event.properties.status).toBe("error");
+  });
+
+  it("passes onEvent callback to OpenCodeClient constructor", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+
+    const onOpenCodeEvent = vi.fn();
+
+    mockExecuteTask.mockResolvedValue({
+      success: true,
+      sessionId: "sess-1",
+      summary: "Done",
+      diff: null,
+    });
+
+    const worker = createWorker(onOpenCodeEvent);
+    await worker.handleMessage(makeDirective(worker.id, "Build it"));
+
+    // The captured onEvent should be a function
+    expect(capturedOnEvent).toBeInstanceOf(Function);
+  });
+
+  it("forwards SSE events through the callback chain", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+
+    const events: Array<{ agentId: string; sessionId: string; event: any }> = [];
+    const onOpenCodeEvent = vi.fn((agentId: string, sessionId: string, event: any) => {
+      events.push({ agentId, sessionId, event });
+    });
+
+    // Simulate executeTask calling the onEvent callback during execution
+    mockExecuteTask.mockImplementation(async () => {
+      // Simulate SSE events being fired during task execution
+      if (capturedOnEvent) {
+        capturedOnEvent({
+          type: "message.part.updated",
+          properties: { sessionID: "sess-1", delta: "Hello", partID: "p1", messageID: "m1", type: "text" },
+        });
+        capturedOnEvent({
+          type: "session.status",
+          properties: { sessionID: "sess-1", status: "active" },
+        });
+      }
+      return {
+        success: true,
+        sessionId: "sess-1",
+        summary: "Done",
+        diff: null,
+      };
+    });
+
+    const worker = createWorker(onOpenCodeEvent);
+    await worker.handleMessage(makeDirective(worker.id, "Build it"));
+
+    // Should have: __session-start, 2 SSE events forwarded, __session-end
+    expect(events.length).toBe(4);
+
+    // SSE events (in the middle)
+    expect(events[1].event.type).toBe("message.part.updated");
+    expect(events[2].event.type).toBe("session.status");
+  });
+
+  it("does not emit events when onOpenCodeEvent is not provided", async () => {
+    mockedGetConfig.mockImplementation((key: string) => {
+      if (key === "opencode:api_url") return "http://localhost:3333";
+      return undefined;
+    });
+
+    mockExecuteTask.mockResolvedValue({
+      success: true,
+      sessionId: "sess-1",
+      summary: "Done",
+      diff: null,
+    });
+
+    // Create worker without onOpenCodeEvent
+    const worker = createWorker(undefined);
+    // Should complete without errors
+    await expect(
+      worker.handleMessage(makeDirective(worker.id, "Build it")),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/server/src/agents/coo.ts
+++ b/packages/server/src/agents/coo.ts
@@ -63,6 +63,7 @@ export interface COODependencies {
   onAgentThinking?: (agentId: string, token: string, messageId: string) => void;
   onAgentThinkingEnd?: (agentId: string, messageId: string) => void;
   onAgentToolCall?: (agentId: string, toolName: string, args: Record<string, unknown>) => void;
+  onOpenCodeEvent?: (agentId: string, sessionId: string, event: { type: string; properties: Record<string, unknown> }) => void;
   onAgentDestroyed?: (agentId: string) => void;
 }
 
@@ -82,6 +83,7 @@ export class COO extends BaseAgent {
   private _onAgentThinking?: (agentId: string, token: string, messageId: string) => void;
   private _onAgentThinkingEnd?: (agentId: string, messageId: string) => void;
   private _onAgentToolCall?: (agentId: string, toolName: string, args: Record<string, unknown>) => void;
+  private _onOpenCodeEvent?: (agentId: string, sessionId: string, event: { type: string; properties: Record<string, unknown> }) => void;
   private onAgentDestroyed?: (agentId: string) => void;
   private allowedToolNames: Set<string>;
   private contextManager!: ConversationContextManager;
@@ -181,6 +183,7 @@ The user can see everything on the desktop in real-time.`;
     this._onAgentThinking = deps.onAgentThinking;
     this._onAgentThinkingEnd = deps.onAgentThinkingEnd;
     this._onAgentToolCall = deps.onAgentToolCall;
+    this._onOpenCodeEvent = deps.onOpenCodeEvent;
     this.onAgentDestroyed = deps.onAgentDestroyed;
     this.contextManager = new ConversationContextManager(systemPrompt);
   }
@@ -707,6 +710,7 @@ The user can see everything on the desktop in real-time.`;
       onAgentThinking: this._onAgentThinking,
       onAgentThinkingEnd: this._onAgentThinkingEnd,
       onAgentToolCall: this._onAgentToolCall,
+      onOpenCodeEvent: this._onOpenCodeEvent,
     });
 
     this.teamLeads.set(projectId, teamLead);
@@ -1220,6 +1224,7 @@ The user can see everything on the desktop in real-time.`;
       onAgentThinking: this._onAgentThinking,
       onAgentThinkingEnd: this._onAgentThinkingEnd,
       onAgentToolCall: this._onAgentToolCall,
+      onOpenCodeEvent: this._onOpenCodeEvent,
     });
 
     this.teamLeads.set(project.id, teamLead);

--- a/packages/server/src/agents/team-lead.ts
+++ b/packages/server/src/agents/team-lead.ts
@@ -163,6 +163,7 @@ export interface TeamLeadDependencies {
   onAgentThinking?: (agentId: string, token: string, messageId: string) => void;
   onAgentThinkingEnd?: (agentId: string, messageId: string) => void;
   onAgentToolCall?: (agentId: string, toolName: string, args: Record<string, unknown>) => void;
+  onOpenCodeEvent?: (agentId: string, sessionId: string, event: { type: string; properties: Record<string, unknown> }) => void;
 }
 
 const MAX_CONTINUATION_CYCLES = 5;
@@ -179,6 +180,7 @@ export class TeamLead extends BaseAgent {
   private allowedToolNames: Set<string>;
   private onAgentSpawned?: (agent: BaseAgent) => void;
   private onKanbanChange?: (event: "created" | "updated" | "deleted", task: KanbanTask) => void;
+  private _onOpenCodeEvent?: (agentId: string, sessionId: string, event: { type: string; properties: Record<string, unknown> }) => void;
 
   constructor(deps: TeamLeadDependencies) {
     const registry = new Registry();
@@ -216,6 +218,7 @@ export class TeamLead extends BaseAgent {
     this.workspace = deps.workspace;
     this.onAgentSpawned = deps.onAgentSpawned;
     this.onKanbanChange = deps.onKanbanChange;
+    this._onOpenCodeEvent = deps.onOpenCodeEvent;
 
     // Restore persisted flags from previous runs
     this.verificationRequested = this.loadFlag("verification");
@@ -1138,6 +1141,7 @@ export class TeamLead extends BaseAgent {
         onAgentThinking: this.onAgentThinking,
         onAgentThinkingEnd: this.onAgentThinkingEnd,
         onAgentToolCall: this.onAgentToolCall,
+        onOpenCodeEvent: this._onOpenCodeEvent,
       });
 
       this.workers.set(worker.id, worker);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -51,6 +51,7 @@ import {
   emitAgentThinkingEnd,
   emitAgentToolCall,
   emitAgentDestroyed,
+  emitOpenCodeEvent,
 } from "./socket/handlers.js";
 import {
   isSetupComplete,
@@ -416,6 +417,9 @@ async function main() {
         },
         onAgentToolCall: (agentId, toolName, args) => {
           emitAgentToolCall(io, agentId, toolName, args);
+        },
+        onOpenCodeEvent: (agentId, sessionId, event) => {
+          emitOpenCodeEvent(io, agentId, sessionId, event);
         },
         onAgentDestroyed: (agentId) => {
           emitAgentDestroyed(io, agentId);

--- a/packages/server/src/socket/__tests__/emit-opencode-event.test.ts
+++ b/packages/server/src/socket/__tests__/emit-opencode-event.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { emitOpenCodeEvent } from "../handlers.js";
+
+function createMockIo() {
+  return {
+    emit: vi.fn(),
+  } as any;
+}
+
+describe("emitOpenCodeEvent", () => {
+  let io: ReturnType<typeof createMockIo>;
+
+  beforeEach(() => {
+    io = createMockIo();
+  });
+
+  describe("__session-start internal marker", () => {
+    it("emits opencode:session-start with session data", () => {
+      emitOpenCodeEvent(io, "agent-1", "", {
+        type: "__session-start",
+        properties: { task: "Build feature X", projectId: "proj-1" },
+      });
+
+      expect(io.emit).toHaveBeenCalledTimes(1);
+      expect(io.emit).toHaveBeenCalledWith("opencode:session-start", {
+        id: "",
+        agentId: "agent-1",
+        projectId: "proj-1",
+        task: "Build feature X",
+        status: "active",
+        startedAt: expect.any(String),
+      });
+    });
+
+    it("handles null projectId", () => {
+      emitOpenCodeEvent(io, "agent-1", "", {
+        type: "__session-start",
+        properties: { task: "Do stuff", projectId: "" },
+      });
+
+      const emitted = io.emit.mock.calls[0][1];
+      expect(emitted.projectId).toBeNull();
+    });
+  });
+
+  describe("__session-end internal marker", () => {
+    it("emits opencode:session-end with status and diff", () => {
+      const diff = [{ path: "src/x.ts", additions: 10, deletions: 2 }];
+      emitOpenCodeEvent(io, "agent-1", "sess-1", {
+        type: "__session-end",
+        properties: { status: "completed", diff, error: undefined },
+      });
+
+      expect(io.emit).toHaveBeenCalledTimes(1);
+      expect(io.emit).toHaveBeenCalledWith("opencode:session-end", {
+        agentId: "agent-1",
+        sessionId: "sess-1",
+        status: "completed",
+        diff: [{ path: "src/x.ts", additions: 10, deletions: 2 }],
+      });
+    });
+
+    it("handles null diff", () => {
+      emitOpenCodeEvent(io, "agent-1", "sess-1", {
+        type: "__session-end",
+        properties: { status: "error", diff: null },
+      });
+
+      const emitted = io.emit.mock.calls[0][1];
+      expect(emitted.diff).toBeNull();
+    });
+  });
+
+  describe("message.part.updated events", () => {
+    it("emits opencode:event and opencode:part-delta for text deltas", () => {
+      emitOpenCodeEvent(io, "agent-1", "sess-1", {
+        type: "message.part.updated",
+        properties: {
+          partID: "part-1",
+          messageID: "msg-1",
+          type: "text",
+          delta: "Hello world",
+        },
+      });
+
+      // Should emit both the raw event and the parsed part-delta
+      expect(io.emit).toHaveBeenCalledWith("opencode:event", {
+        agentId: "agent-1",
+        sessionId: "sess-1",
+        type: "message.part.updated",
+        properties: expect.any(Object),
+      });
+
+      expect(io.emit).toHaveBeenCalledWith("opencode:part-delta", {
+        agentId: "agent-1",
+        sessionId: "sess-1",
+        messageId: "msg-1",
+        partId: "part-1",
+        type: "text",
+        delta: "Hello world",
+        toolName: undefined,
+        toolState: undefined,
+      });
+    });
+
+    it("includes toolName and toolState for tool-invocation parts", () => {
+      emitOpenCodeEvent(io, "agent-1", "sess-1", {
+        type: "message.part.updated",
+        properties: {
+          partID: "part-2",
+          messageID: "msg-1",
+          type: "tool-invocation",
+          delta: '{"file": "src/x.ts"}',
+          toolName: "file_write",
+          state: "call",
+        },
+      });
+
+      expect(io.emit).toHaveBeenCalledWith("opencode:part-delta", {
+        agentId: "agent-1",
+        sessionId: "sess-1",
+        messageId: "msg-1",
+        partId: "part-2",
+        type: "tool-invocation",
+        delta: '{"file": "src/x.ts"}',
+        toolName: "file_write",
+        toolState: "call",
+      });
+    });
+
+    it("does not emit part-delta when delta is missing", () => {
+      emitOpenCodeEvent(io, "agent-1", "sess-1", {
+        type: "message.part.updated",
+        properties: {
+          partID: "part-3",
+          messageID: "msg-1",
+          type: "text",
+          // no delta field
+        },
+      });
+
+      // Should still emit the raw event
+      expect(io.emit).toHaveBeenCalledWith("opencode:event", expect.any(Object));
+      // Should NOT emit part-delta
+      const partDeltaCalls = io.emit.mock.calls.filter(
+        (c: any[]) => c[0] === "opencode:part-delta",
+      );
+      expect(partDeltaCalls).toHaveLength(0);
+    });
+  });
+
+  describe("message.updated events", () => {
+    it("emits opencode:event and opencode:message with parsed parts", () => {
+      emitOpenCodeEvent(io, "agent-1", "sess-1", {
+        type: "message.updated",
+        properties: {
+          messageID: "msg-1",
+          role: "assistant",
+          parts: [
+            { id: "p1", type: "text", content: "Hello" },
+            { id: "p2", type: "tool-invocation", toolName: "shell", state: "result", toolResult: "ok" },
+          ],
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      });
+
+      expect(io.emit).toHaveBeenCalledWith("opencode:message", {
+        agentId: "agent-1",
+        sessionId: "sess-1",
+        message: {
+          id: "msg-1",
+          sessionId: "sess-1",
+          role: "assistant",
+          parts: [
+            {
+              id: "p1",
+              messageId: "msg-1",
+              type: "text",
+              content: "Hello",
+              toolName: undefined,
+              toolArgs: undefined,
+              toolState: undefined,
+              toolResult: undefined,
+            },
+            {
+              id: "p2",
+              messageId: "msg-1",
+              type: "tool-invocation",
+              content: "",
+              toolName: "shell",
+              toolArgs: undefined,
+              toolState: "result",
+              toolResult: "ok",
+            },
+          ],
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      });
+    });
+
+    it("does not emit opencode:message when role is missing", () => {
+      emitOpenCodeEvent(io, "agent-1", "sess-1", {
+        type: "message.updated",
+        properties: {
+          messageID: "msg-1",
+          // no role
+          parts: [],
+        },
+      });
+
+      const messageCalls = io.emit.mock.calls.filter(
+        (c: any[]) => c[0] === "opencode:message",
+      );
+      expect(messageCalls).toHaveLength(0);
+    });
+  });
+
+  describe("generic events", () => {
+    it("emits opencode:event for session.status", () => {
+      emitOpenCodeEvent(io, "agent-1", "sess-1", {
+        type: "session.status",
+        properties: { sessionID: "sess-1", status: "active" },
+      });
+
+      expect(io.emit).toHaveBeenCalledWith("opencode:event", {
+        agentId: "agent-1",
+        sessionId: "sess-1",
+        type: "session.status",
+        properties: { sessionID: "sess-1", status: "active" },
+      });
+    });
+
+    it("emits opencode:event for session.diff", () => {
+      emitOpenCodeEvent(io, "agent-1", "sess-1", {
+        type: "session.diff",
+        properties: { files: [] },
+      });
+
+      expect(io.emit).toHaveBeenCalledWith("opencode:event", {
+        agentId: "agent-1",
+        sessionId: "sess-1",
+        type: "session.diff",
+        properties: { files: [] },
+      });
+    });
+  });
+});

--- a/packages/server/src/tools/__tests__/opencode-client-events.test.ts
+++ b/packages/server/src/tools/__tests__/opencode-client-events.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock undici Agent to prevent actual network connections
+vi.mock("undici", () => ({
+  Agent: vi.fn().mockImplementation(() => ({})),
+}));
+
+// Mock the SDK client
+const mockSubscribe = vi.fn();
+const mockCreate = vi.fn();
+const mockPrompt = vi.fn();
+const mockDiff = vi.fn();
+const mockAbort = vi.fn();
+
+vi.mock("@opencode-ai/sdk/client", () => ({
+  createOpencodeClient: vi.fn(() => ({
+    event: { subscribe: mockSubscribe },
+    session: {
+      create: mockCreate,
+      prompt: mockPrompt,
+      diff: mockDiff,
+      abort: mockAbort,
+      list: vi.fn(() => ({ error: null, data: [] })),
+      messages: vi.fn(() => ({ error: null, data: [] })),
+    },
+  })),
+}));
+
+import { OpenCodeClient } from "../opencode-client.js";
+
+describe("OpenCodeClient — onEvent callback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores the onEvent callback from config", () => {
+    const onEvent = vi.fn();
+    const client = new OpenCodeClient({
+      apiUrl: "http://localhost:3333",
+      onEvent,
+    });
+    // Access private field to verify it's stored
+    expect((client as any).onEvent).toBe(onEvent);
+  });
+
+  it("forwards SSE events through the onEvent callback during monitorViaSse", async () => {
+    const onEvent = vi.fn();
+
+    // Create an async iterable that yields a few events then ends
+    const events = [
+      { type: "message.part.updated", properties: { sessionID: "sess-1", delta: "Hello", partID: "p1", messageID: "m1", type: "text" } },
+      { type: "session.status", properties: { sessionID: "sess-1", status: "active" } },
+    ];
+
+    let eventIdx = 0;
+    mockSubscribe.mockResolvedValue({
+      stream: {
+        [Symbol.asyncIterator]() {
+          return {
+            next: async () => {
+              if (eventIdx < events.length) {
+                return { value: events[eventIdx++], done: false };
+              }
+              return { value: undefined, done: true };
+            },
+          };
+        },
+      },
+    });
+
+    const client = new OpenCodeClient({
+      apiUrl: "http://localhost:3333",
+      onEvent,
+    });
+
+    const controller = new AbortController();
+    // Call monitorViaSse directly via the private method
+    const result = await (client as any).monitorViaSse(
+      "sess-1",
+      controller,
+      Date.now(),
+      Date.now(),
+    );
+
+    // Should have forwarded both events
+    expect(onEvent).toHaveBeenCalledTimes(2);
+    expect(onEvent).toHaveBeenCalledWith({
+      type: "message.part.updated",
+      properties: expect.objectContaining({ delta: "Hello" }),
+    });
+    expect(onEvent).toHaveBeenCalledWith({
+      type: "session.status",
+      properties: expect.objectContaining({ status: "active" }),
+    });
+  });
+
+  it("does not throw when onEvent is not provided", async () => {
+    const events = [
+      { type: "session.status", properties: { sessionID: "sess-1" } },
+    ];
+    let eventIdx = 0;
+    mockSubscribe.mockResolvedValue({
+      stream: {
+        [Symbol.asyncIterator]() {
+          return {
+            next: async () => {
+              if (eventIdx < events.length) {
+                return { value: events[eventIdx++], done: false };
+              }
+              return { value: undefined, done: true };
+            },
+          };
+        },
+      },
+    });
+
+    const client = new OpenCodeClient({ apiUrl: "http://localhost:3333" });
+    const controller = new AbortController();
+
+    // Should complete without throwing
+    await expect(
+      (client as any).monitorViaSse("sess-1", controller, Date.now(), Date.now()),
+    ).resolves.toBeDefined();
+  });
+
+  it("does not forward events for other sessions", async () => {
+    const onEvent = vi.fn();
+    const events = [
+      { type: "message.updated", properties: { sessionID: "other-session", role: "assistant" } },
+    ];
+    let eventIdx = 0;
+    mockSubscribe.mockResolvedValue({
+      stream: {
+        [Symbol.asyncIterator]() {
+          return {
+            next: async () => {
+              if (eventIdx < events.length) {
+                return { value: events[eventIdx++], done: false };
+              }
+              return { value: undefined, done: true };
+            },
+          };
+        },
+      },
+    });
+
+    const client = new OpenCodeClient({ apiUrl: "http://localhost:3333", onEvent });
+    const controller = new AbortController();
+
+    await (client as any).monitorViaSse("sess-1", controller, Date.now(), Date.now());
+
+    // Should NOT forward event for a different session
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it("catches errors in onEvent callback without breaking the loop", async () => {
+    const onEvent = vi.fn().mockImplementation(() => {
+      throw new Error("callback error");
+    });
+
+    const events = [
+      { type: "session.status", properties: { sessionID: "sess-1" } },
+      { type: "message.updated", properties: { sessionID: "sess-1", role: "assistant", messageID: "m1" } },
+    ];
+    let eventIdx = 0;
+    mockSubscribe.mockResolvedValue({
+      stream: {
+        [Symbol.asyncIterator]() {
+          return {
+            next: async () => {
+              if (eventIdx < events.length) {
+                return { value: events[eventIdx++], done: false };
+              }
+              return { value: undefined, done: true };
+            },
+          };
+        },
+      },
+    });
+
+    const client = new OpenCodeClient({ apiUrl: "http://localhost:3333", onEvent });
+    const controller = new AbortController();
+
+    // Should complete successfully despite callback throwing
+    const result = await (client as any).monitorViaSse("sess-1", controller, Date.now(), Date.now());
+    expect(result).toBe("idle");
+
+    // Both events should have been attempted
+    expect(onEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,3 +13,4 @@ export * from "./types/gmail.js";
 export * from "./types/calendar.js";
 export * from "./types/skill.js";
 export * from "./types/custom-tool.js";
+export * from "./types/opencode.js";

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -3,6 +3,7 @@ import type { BusMessage, Conversation } from "./message.js";
 import type { RegistryEntry, Project } from "./registry.js";
 import type { KanbanTask } from "./kanban.js";
 import type { SceneZone } from "./environment.js";
+import type { OpenCodeSession, OpenCodeMessage, OpenCodeFileDiff } from "./opencode.js";
 
 /** Events emitted from server to client */
 export interface ServerToClientEvents {
@@ -32,6 +33,11 @@ export interface ServerToClientEvents {
   "admin-assistant:stream": (data: { token: string; messageId: string }) => void;
   "admin-assistant:thinking": (data: { token: string; messageId: string }) => void;
   "admin-assistant:thinking-end": (data: { messageId: string }) => void;
+  "opencode:session-start": (data: OpenCodeSession) => void;
+  "opencode:session-end": (data: { agentId: string; sessionId: string; status: string; diff: OpenCodeFileDiff[] | null }) => void;
+  "opencode:event": (data: { agentId: string; sessionId: string; type: string; properties: Record<string, unknown> }) => void;
+  "opencode:message": (data: { agentId: string; sessionId: string; message: OpenCodeMessage }) => void;
+  "opencode:part-delta": (data: { agentId: string; sessionId: string; messageId: string; partId: string; type: string; delta: string; toolName?: string; toolState?: string }) => void;
 }
 
 /** Events emitted from client to server */

--- a/packages/shared/src/types/opencode.ts
+++ b/packages/shared/src/types/opencode.ts
@@ -1,0 +1,36 @@
+/** Types for the OpenCode live coding view */
+
+export interface OpenCodeSession {
+  id: string;
+  agentId: string;
+  projectId: string | null;
+  task: string;
+  status: "active" | "idle" | "completed" | "error";
+  startedAt: string;
+  completedAt?: string;
+}
+
+export interface OpenCodePart {
+  id: string;
+  messageId: string;
+  type: "text" | "reasoning" | "tool-invocation" | "step-start" | "file" | "source-url";
+  content: string;
+  toolName?: string;
+  toolArgs?: Record<string, unknown>;
+  toolState?: "call" | "partial-call" | "result";
+  toolResult?: string;
+}
+
+export interface OpenCodeMessage {
+  id: string;
+  sessionId: string;
+  role: "user" | "assistant";
+  parts: OpenCodePart[];
+  createdAt: string;
+}
+
+export interface OpenCodeFileDiff {
+  path: string;
+  additions: number;
+  deletions: number;
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -22,6 +22,7 @@ import { UsageDashboard } from "./components/usage/UsageDashboard";
 import { TodoView } from "./components/todos/TodoView";
 import { InboxView } from "./components/inbox/InboxView";
 import { CalendarView } from "./components/calendar/CalendarView";
+import { CodeView } from "./components/code/CodeView";
 import { useDesktopStore } from "./stores/desktop-store";
 import { initMovementTriggers } from "./lib/movement-triggers";
 import { Group, Panel, Separator, useDefaultLayout, usePanelRef } from "react-resizable-panels";
@@ -85,7 +86,7 @@ interface UserProfile {
   cooName?: string;
 }
 
-type CenterView = "graph" | "live3d" | "charter" | "kanban" | "desktop" | "files" | "usage" | "todos" | "inbox" | "calendar";
+type CenterView = "graph" | "live3d" | "charter" | "kanban" | "desktop" | "files" | "usage" | "todos" | "inbox" | "calendar" | "code";
 
 function MainApp() {
   const socket = useSocket();
@@ -350,6 +351,8 @@ function ResizableLayout({
         return <CalendarView />;
       case "desktop":
         return <DesktopView />;
+      case "code":
+        return <CodeView />;
       case "live3d":
         return (
           <LiveView userProfile={userProfile} onToggleView={() => setCenterView("graph")} />
@@ -398,6 +401,7 @@ function ResizableLayout({
                   "todos" as CenterView,
                   "inbox" as CenterView,
                   "calendar" as CenterView,
+                  "code" as CenterView,
                   "usage" as CenterView,
                   "desktop" as CenterView,
                 ] as CenterView[]
@@ -411,6 +415,7 @@ function ResizableLayout({
                   todos: "Todos",
                   inbox: "Inbox",
                   calendar: "Calendar",
+                  code: "Code",
                   usage: "Usage",
                   desktop: "Desktop",
                 };

--- a/packages/web/src/components/code/CodeView.tsx
+++ b/packages/web/src/components/code/CodeView.tsx
@@ -1,0 +1,324 @@
+import { useEffect, useRef, useState } from "react";
+import { useOpenCodeStore } from "../../stores/opencode-store";
+import type { OpenCodeSession, OpenCodeFileDiff } from "@otterbot/shared";
+
+function StatusDot({ status }: { status: OpenCodeSession["status"] }) {
+  const colors: Record<string, string> = {
+    active: "bg-green-400 animate-pulse",
+    idle: "bg-yellow-400",
+    completed: "bg-emerald-500",
+    error: "bg-red-500",
+  };
+  return <span className={`inline-block w-2 h-2 rounded-full ${colors[status] ?? "bg-gray-400"}`} />;
+}
+
+function SessionSidebar({
+  sessions,
+  selectedAgentId,
+  onSelect,
+}: {
+  sessions: Map<string, OpenCodeSession>;
+  selectedAgentId: string | null;
+  onSelect: (agentId: string) => void;
+}) {
+  const entries = Array.from(sessions.values()).sort(
+    (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+  );
+
+  if (entries.length === 0) {
+    return (
+      <div className="p-3 text-xs text-muted-foreground">
+        No active OpenCode sessions. Start a coding task to see live output here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5 p-1">
+      {entries.map((session) => (
+        <button
+          key={session.agentId}
+          onClick={() => onSelect(session.agentId)}
+          className={`flex items-center gap-2 px-2 py-1.5 rounded text-left text-xs transition-colors ${
+            selectedAgentId === session.agentId
+              ? "bg-primary/20 text-primary"
+              : "text-muted-foreground hover:text-foreground hover:bg-secondary"
+          }`}
+        >
+          <StatusDot status={session.status} />
+          <div className="min-w-0 flex-1">
+            <div className="truncate font-mono">{session.agentId.slice(0, 8)}</div>
+            <div className="truncate opacity-70">{session.task.slice(0, 50)}</div>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function PartContent({
+  type,
+  content,
+  toolName,
+  toolState,
+}: {
+  type: string;
+  content: string;
+  toolName?: string;
+  toolState?: string;
+}) {
+  if (type === "reasoning") {
+    return (
+      <details className="group">
+        <summary className="cursor-pointer text-xs text-violet-400 opacity-70 hover:opacity-100 py-0.5">
+          Thinking...
+        </summary>
+        <div className="pl-3 border-l border-violet-500/20 text-violet-300/60 text-xs whitespace-pre-wrap">
+          {content}
+        </div>
+      </details>
+    );
+  }
+
+  if (type === "tool-invocation") {
+    return (
+      <div className="my-1 rounded border border-blue-500/20 bg-blue-500/5 text-xs">
+        <div className="flex items-center gap-1.5 px-2 py-1 border-b border-blue-500/10">
+          <span className="text-blue-400 font-medium">{toolName || "tool"}</span>
+          {toolState && (
+            <span className={`text-[10px] px-1 rounded ${
+              toolState === "result"
+                ? "bg-emerald-500/20 text-emerald-400"
+                : "bg-yellow-500/20 text-yellow-400"
+            }`}>
+              {toolState}
+            </span>
+          )}
+        </div>
+        <pre className="px-2 py-1 whitespace-pre-wrap break-all text-foreground/80 max-h-[200px] overflow-y-auto">
+          {content}
+        </pre>
+      </div>
+    );
+  }
+
+  if (type === "step-start") {
+    return (
+      <div className="flex items-center gap-2 py-1 text-xs text-muted-foreground">
+        <div className="flex-1 border-t border-border" />
+        <span>Step</span>
+        <div className="flex-1 border-t border-border" />
+      </div>
+    );
+  }
+
+  // text or other
+  return (
+    <div className="whitespace-pre-wrap text-xs text-foreground/90">{content}</div>
+  );
+}
+
+function DiffSummary({ diffs }: { diffs: OpenCodeFileDiff[] }) {
+  if (diffs.length === 0) return null;
+  return (
+    <div className="border-t border-border mt-2 pt-2">
+      <div className="text-xs font-medium text-muted-foreground mb-1">Files Changed</div>
+      <div className="flex flex-col gap-0.5">
+        {diffs.map((d) => (
+          <div key={d.path} className="flex items-center gap-2 text-xs font-mono">
+            <span className="truncate flex-1 text-foreground/80">{d.path}</span>
+            {d.additions > 0 && <span className="text-green-400">+{d.additions}</span>}
+            {d.deletions > 0 && <span className="text-red-400">-{d.deletions}</span>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SessionContent({ agentId }: { agentId: string }) {
+  const session = useOpenCodeStore((s) => s.sessions.get(agentId));
+  const sessionId = session?.id || "";
+  const sessionMessages = useOpenCodeStore((s) => s.messages.get(sessionId) ?? []);
+  const partBuffers = useOpenCodeStore((s) => s.partBuffers);
+  const sessionDiffs = useOpenCodeStore((s) => s.diffs.get(sessionId) ?? []);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  // Auto-scroll on new content
+  useEffect(() => {
+    if (autoScroll && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [sessionMessages, partBuffers, autoScroll]);
+
+  const handleScroll = () => {
+    if (!scrollRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+    setAutoScroll(scrollHeight - scrollTop - clientHeight < 50);
+  };
+
+  if (!session) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-xs text-muted-foreground">
+        Select a session to view
+      </div>
+    );
+  }
+
+  // Collect streaming parts from buffers for this session
+  const streamingParts: Array<{
+    key: string;
+    messageId: string;
+    partId: string;
+    type: string;
+    content: string;
+    toolName?: string;
+    toolState?: string;
+  }> = [];
+
+  for (const [key, buf] of partBuffers) {
+    if (key.startsWith(`${sessionId}:`)) {
+      const parts = key.split(":");
+      streamingParts.push({
+        key,
+        messageId: parts[1],
+        partId: parts[2],
+        type: buf.type,
+        content: buf.content,
+        toolName: buf.toolName,
+        toolState: buf.toolState,
+      });
+    }
+  }
+
+  // Group streaming parts by messageId
+  const streamingByMessage = new Map<string, typeof streamingParts>();
+  for (const part of streamingParts) {
+    const existing = streamingByMessage.get(part.messageId) ?? [];
+    existing.push(part);
+    streamingByMessage.set(part.messageId, existing);
+  }
+
+  // Track which messageIds are in full messages to avoid duplication
+  const fullMessageIds = new Set(sessionMessages.map((m) => m.id));
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      {/* Session header */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-card/50">
+        <StatusDot status={session.status} />
+        <span className="text-xs font-mono text-foreground/80">{session.agentId.slice(0, 12)}</span>
+        <span className="text-xs text-muted-foreground truncate flex-1">{session.task.slice(0, 100)}</span>
+      </div>
+
+      {/* Message area */}
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto p-3 space-y-3 font-mono bg-[#0d1117]"
+      >
+        {/* User message (the task) */}
+        <div className="rounded border border-border/50 bg-card/30 p-2">
+          <div className="text-[10px] text-muted-foreground mb-1">Task</div>
+          <div className="text-xs text-foreground whitespace-pre-wrap">{session.task}</div>
+        </div>
+
+        {/* Full messages from server */}
+        {sessionMessages
+          .filter((m) => m.role === "assistant")
+          .map((msg) => (
+            <div key={msg.id} className="space-y-1">
+              {msg.parts.map((part, i) => (
+                <PartContent
+                  key={part.id || i}
+                  type={part.type}
+                  content={part.content}
+                  toolName={part.toolName}
+                  toolState={part.toolState}
+                />
+              ))}
+            </div>
+          ))}
+
+        {/* Streaming parts not yet in full messages */}
+        {Array.from(streamingByMessage.entries())
+          .filter(([msgId]) => !fullMessageIds.has(msgId))
+          .map(([msgId, parts]) => (
+            <div key={msgId} className="space-y-1">
+              {parts.map((part) => (
+                <PartContent
+                  key={part.key}
+                  type={part.type}
+                  content={part.content}
+                  toolName={part.toolName}
+                  toolState={part.toolState}
+                />
+              ))}
+            </div>
+          ))}
+
+        {/* Active indicator */}
+        {session.status === "active" && (
+          <div className="flex items-center gap-2 text-xs text-green-400/70">
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
+            Working...
+          </div>
+        )}
+
+        {/* Diff summary */}
+        {sessionDiffs.length > 0 && <DiffSummary diffs={sessionDiffs} />}
+
+        {/* Completion status */}
+        {session.status === "completed" && (
+          <div className="text-xs text-emerald-400 border-t border-border pt-2 mt-2">
+            Session completed
+          </div>
+        )}
+        {session.status === "error" && (
+          <div className="text-xs text-red-400 border-t border-border pt-2 mt-2">
+            Session ended with error
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function CodeView() {
+  const sessions = useOpenCodeStore((s) => s.sessions);
+  const selectedAgentId = useOpenCodeStore((s) => s.selectedAgentId);
+  const selectAgent = useOpenCodeStore((s) => s.selectAgent);
+
+  return (
+    <div className="h-full flex bg-[#0d1117] text-foreground">
+      {/* Left sidebar — session list */}
+      <div className="w-48 shrink-0 border-r border-border overflow-y-auto bg-card/30">
+        <div className="px-2 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider border-b border-border">
+          Sessions
+        </div>
+        <SessionSidebar
+          sessions={sessions}
+          selectedAgentId={selectedAgentId}
+          onSelect={selectAgent}
+        />
+      </div>
+
+      {/* Main content */}
+      {selectedAgentId ? (
+        <SessionContent agentId={selectedAgentId} />
+      ) : (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center text-muted-foreground text-xs">
+            <div className="text-lg mb-2 opacity-30">{"</>"}</div>
+            <div>Live coding view</div>
+            <div className="mt-1 opacity-70">
+              OpenCode sessions will appear here when workers execute coding tasks
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/stores/__tests__/opencode-store.test.ts
+++ b/packages/web/src/stores/__tests__/opencode-store.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useOpenCodeStore } from "../opencode-store";
+import type { OpenCodeSession, OpenCodeMessage } from "@otterbot/shared";
+
+function makeSession(overrides: Partial<OpenCodeSession> = {}): OpenCodeSession {
+  return {
+    id: "sess-1",
+    agentId: "agent-1",
+    projectId: "proj-1",
+    task: "Build feature X",
+    status: "active",
+    startedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<OpenCodeMessage> = {}): OpenCodeMessage {
+  return {
+    id: "msg-1",
+    sessionId: "sess-1",
+    role: "assistant",
+    parts: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("opencode-store", () => {
+  beforeEach(() => {
+    // Reset store state between tests
+    useOpenCodeStore.setState({
+      sessions: new Map(),
+      messages: new Map(),
+      partBuffers: new Map(),
+      diffs: new Map(),
+      selectedAgentId: null,
+    });
+  });
+
+  describe("selectAgent", () => {
+    it("sets the selected agent ID", () => {
+      useOpenCodeStore.getState().selectAgent("agent-1");
+      expect(useOpenCodeStore.getState().selectedAgentId).toBe("agent-1");
+    });
+
+    it("can clear selection with null", () => {
+      useOpenCodeStore.getState().selectAgent("agent-1");
+      useOpenCodeStore.getState().selectAgent(null);
+      expect(useOpenCodeStore.getState().selectedAgentId).toBeNull();
+    });
+  });
+
+  describe("startSession", () => {
+    it("adds a session keyed by agentId", () => {
+      const session = makeSession();
+      useOpenCodeStore.getState().startSession(session);
+      expect(useOpenCodeStore.getState().sessions.get("agent-1")).toEqual(session);
+    });
+
+    it("auto-selects the first session", () => {
+      useOpenCodeStore.getState().startSession(makeSession());
+      expect(useOpenCodeStore.getState().selectedAgentId).toBe("agent-1");
+    });
+
+    it("does not override existing selection", () => {
+      useOpenCodeStore.getState().selectAgent("agent-0");
+      useOpenCodeStore.getState().startSession(makeSession());
+      expect(useOpenCodeStore.getState().selectedAgentId).toBe("agent-0");
+    });
+
+    it("handles multiple sessions", () => {
+      useOpenCodeStore.getState().startSession(makeSession({ agentId: "agent-1" }));
+      useOpenCodeStore.getState().startSession(makeSession({ agentId: "agent-2", id: "sess-2" }));
+      expect(useOpenCodeStore.getState().sessions.size).toBe(2);
+    });
+  });
+
+  describe("endSession", () => {
+    it("updates session status and completedAt", () => {
+      useOpenCodeStore.getState().startSession(makeSession());
+      useOpenCodeStore.getState().endSession("agent-1", "sess-1", "completed", null);
+
+      const session = useOpenCodeStore.getState().sessions.get("agent-1")!;
+      expect(session.status).toBe("completed");
+      expect(session.completedAt).toBeDefined();
+    });
+
+    it("updates session ID if provided", () => {
+      useOpenCodeStore.getState().startSession(makeSession({ id: "" }));
+      useOpenCodeStore.getState().endSession("agent-1", "sess-real", "completed", null);
+
+      const session = useOpenCodeStore.getState().sessions.get("agent-1")!;
+      expect(session.id).toBe("sess-real");
+    });
+
+    it("stores diffs when provided", () => {
+      useOpenCodeStore.getState().startSession(makeSession());
+      const diffs = [{ path: "src/x.ts", additions: 10, deletions: 2 }];
+      useOpenCodeStore.getState().endSession("agent-1", "sess-1", "completed", diffs);
+
+      expect(useOpenCodeStore.getState().diffs.get("sess-1")).toEqual(diffs);
+    });
+
+    it("does not crash for unknown agent", () => {
+      useOpenCodeStore.getState().endSession("unknown", "sess-x", "completed", null);
+      expect(useOpenCodeStore.getState().sessions.size).toBe(0);
+    });
+  });
+
+  describe("addMessage", () => {
+    it("adds a message to the session", () => {
+      const msg = makeMessage();
+      useOpenCodeStore.getState().addMessage("agent-1", "sess-1", msg);
+
+      expect(useOpenCodeStore.getState().messages.get("sess-1")).toEqual([msg]);
+    });
+
+    it("appends subsequent messages", () => {
+      useOpenCodeStore.getState().addMessage("agent-1", "sess-1", makeMessage({ id: "msg-1" }));
+      useOpenCodeStore.getState().addMessage("agent-1", "sess-1", makeMessage({ id: "msg-2" }));
+
+      expect(useOpenCodeStore.getState().messages.get("sess-1")!.length).toBe(2);
+    });
+
+    it("replaces a message with the same ID", () => {
+      useOpenCodeStore.getState().addMessage("agent-1", "sess-1", makeMessage({
+        id: "msg-1",
+        parts: [{ id: "p1", messageId: "msg-1", type: "text", content: "v1" }],
+      }));
+      useOpenCodeStore.getState().addMessage("agent-1", "sess-1", makeMessage({
+        id: "msg-1",
+        parts: [{ id: "p1", messageId: "msg-1", type: "text", content: "v2" }],
+      }));
+
+      const msgs = useOpenCodeStore.getState().messages.get("sess-1")!;
+      expect(msgs.length).toBe(1);
+      expect(msgs[0].parts[0].content).toBe("v2");
+    });
+  });
+
+  describe("appendPartDelta", () => {
+    it("accumulates delta text for a part", () => {
+      const store = useOpenCodeStore.getState();
+      store.appendPartDelta("agent-1", "sess-1", "msg-1", "part-1", "text", "Hello ");
+      store.appendPartDelta("agent-1", "sess-1", "msg-1", "part-1", "text", "world");
+
+      const key = "sess-1:msg-1:part-1";
+      const buf = useOpenCodeStore.getState().partBuffers.get(key)!;
+      expect(buf.content).toBe("Hello world");
+      expect(buf.type).toBe("text");
+    });
+
+    it("stores toolName and toolState", () => {
+      useOpenCodeStore.getState().appendPartDelta(
+        "agent-1", "sess-1", "msg-1", "part-2", "tool-invocation",
+        '{"file": "x"}', "file_write", "call",
+      );
+
+      const buf = useOpenCodeStore.getState().partBuffers.get("sess-1:msg-1:part-2")!;
+      expect(buf.toolName).toBe("file_write");
+      expect(buf.toolState).toBe("call");
+    });
+
+    it("preserves toolName across deltas when not re-specified", () => {
+      const store = useOpenCodeStore.getState();
+      store.appendPartDelta("agent-1", "sess-1", "msg-1", "p1", "tool-invocation", "first", "shell");
+      store.appendPartDelta("agent-1", "sess-1", "msg-1", "p1", "tool-invocation", "second");
+
+      const buf = useOpenCodeStore.getState().partBuffers.get("sess-1:msg-1:p1")!;
+      expect(buf.content).toBe("firstsecond");
+      expect(buf.toolName).toBe("shell");
+    });
+
+    it("tracks separate buffers per part", () => {
+      const store = useOpenCodeStore.getState();
+      store.appendPartDelta("agent-1", "sess-1", "msg-1", "p1", "text", "AAA");
+      store.appendPartDelta("agent-1", "sess-1", "msg-1", "p2", "reasoning", "BBB");
+
+      expect(useOpenCodeStore.getState().partBuffers.size).toBe(2);
+      expect(useOpenCodeStore.getState().partBuffers.get("sess-1:msg-1:p1")!.content).toBe("AAA");
+      expect(useOpenCodeStore.getState().partBuffers.get("sess-1:msg-1:p2")!.content).toBe("BBB");
+    });
+  });
+
+  describe("clearSession", () => {
+    it("removes session, messages, diffs, and part buffers", () => {
+      const store = useOpenCodeStore.getState();
+
+      // Set up a session with data
+      store.startSession(makeSession());
+      store.addMessage("agent-1", "sess-1", makeMessage());
+      store.appendPartDelta("agent-1", "sess-1", "msg-1", "p1", "text", "data");
+      store.endSession("agent-1", "sess-1", "completed", [
+        { path: "x.ts", additions: 1, deletions: 0 },
+      ]);
+
+      // Verify data exists
+      expect(useOpenCodeStore.getState().sessions.size).toBe(1);
+      expect(useOpenCodeStore.getState().messages.size).toBe(1);
+      expect(useOpenCodeStore.getState().partBuffers.size).toBe(1);
+      expect(useOpenCodeStore.getState().diffs.size).toBe(1);
+
+      // Clear
+      useOpenCodeStore.getState().clearSession("agent-1");
+
+      expect(useOpenCodeStore.getState().sessions.size).toBe(0);
+      expect(useOpenCodeStore.getState().messages.size).toBe(0);
+      expect(useOpenCodeStore.getState().partBuffers.size).toBe(0);
+      expect(useOpenCodeStore.getState().diffs.size).toBe(0);
+    });
+
+    it("clears selection if the cleared agent was selected", () => {
+      useOpenCodeStore.getState().startSession(makeSession());
+      expect(useOpenCodeStore.getState().selectedAgentId).toBe("agent-1");
+
+      useOpenCodeStore.getState().clearSession("agent-1");
+      expect(useOpenCodeStore.getState().selectedAgentId).toBeNull();
+    });
+
+    it("does not affect other sessions", () => {
+      useOpenCodeStore.getState().startSession(makeSession({ agentId: "agent-1", id: "sess-1" }));
+      useOpenCodeStore.getState().startSession(makeSession({ agentId: "agent-2", id: "sess-2" }));
+
+      useOpenCodeStore.getState().clearSession("agent-1");
+      expect(useOpenCodeStore.getState().sessions.size).toBe(1);
+      expect(useOpenCodeStore.getState().sessions.has("agent-2")).toBe(true);
+    });
+
+    it("does not crash for unknown agent", () => {
+      useOpenCodeStore.getState().clearSession("unknown");
+      expect(useOpenCodeStore.getState().sessions.size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a "Code" tab that replays OpenCode worker activity in real-time, showing the full conversation between OpenCode and the LLM including streaming text, thinking, tool calls, and file diffs
- Wires OpenCode SSE events through the full agent callback chain (Worker → TeamLead → COO → Socket.IO) to forward live events to the frontend
- Creates a terminal-themed CodeView component with session sidebar, auto-scrolling message replay, and file diff summary

## Changes

**Shared types** (`packages/shared`):
- New `types/opencode.ts` — `OpenCodeSession`, `OpenCodePart`, `OpenCodeMessage`, `OpenCodeFileDiff`
- New `ServerToClientEvents` — `opencode:session-start`, `session-end`, `event`, `message`, `part-delta`

**Server** (`packages/server`):
- `OpenCodeClient` — added `onEvent` callback to forward SSE events from `monitorViaSse()`
- `Worker` — added `onOpenCodeEvent` dep, emits `__session-start`/`__session-end` markers, forwards SSE events
- `TeamLead` / `COO` / `index.ts` — wired `onOpenCodeEvent` through the callback chain (same pattern as `onAgentToolCall`)
- `handlers.ts` — `emitOpenCodeEvent()` parses raw SSE events into structured Socket.IO emissions

**Frontend** (`packages/web`):
- New `opencode-store.ts` — Zustand store for sessions, messages, streaming part buffers, diffs
- `use-socket.ts` — added listeners for all 4 opencode events
- New `CodeView.tsx` — session sidebar + streaming message replay with reasoning, tool calls, step markers
- `App.tsx` — added `"code"` to `CenterView` and "Code" tab in the tab bar

## Test plan

- [x] `npx pnpm build` — all 3 packages compile cleanly
- [x] `npx pnpm test` — 182 tests pass (43 new)
- [ ] Manual: start app, trigger OpenCode coding task, verify Code tab shows live streaming
- [ ] Manual: verify session sidebar, status transitions, file diff summary on completion