### PR TITLE
feat: live coding view with OpenCode SSE event replay

### DIFF
--- a/packages/server/src/tools/__tests__/opencode-client-events.test.ts
+++ b/packages/server/src/tools/__tests__/opencode-client-events.test.ts
@@ -48,7 +48,7 @@ describe("OpenCodeClient — onEvent callback", () => {
 
     // Create an async iterable that yields a few events then ends
     const events = [
-      { type: "message.part.updated", properties: { sessionID: "sess-1", delta: "Hello", partID: "p1", messageID: "m1", type: "text" } },
+      { type: "message.part.updated", properties: { sessionID: "sess-1", part: { id: "p1", sessionID: "sess-1", messageID: "m1", type: "text", text: "Hello" }, delta: "Hello" } },
       { type: "session.status", properties: { sessionID: "sess-1", status: "active" } },
     ];
 
@@ -86,7 +86,7 @@ describe("OpenCodeClient — onEvent callback", () => {
     expect(onEvent).toHaveBeenCalledTimes(2);
     expect(onEvent).toHaveBeenCalledWith({
       type: "message.part.updated",
-      properties: expect.objectContaining({ delta: "Hello" }),
+      properties: expect.objectContaining({ delta: "Hello", part: expect.any(Object) }),
     });
     expect(onEvent).toHaveBeenCalledWith({
       type: "session.status",

--- a/packages/web/src/components/code/CodeView.tsx
+++ b/packages/web/src/components/code/CodeView.tsx
@@ -58,15 +58,23 @@ function SessionSidebar({
 
 function PartContent({
   type,
-  content,
+  content: rawContent,
   toolName,
-  toolState,
+  toolState: rawToolState,
 }: {
   type: string;
   content: string;
   toolName?: string;
   toolState?: string;
 }) {
+  // Safety: ensure content is always a string (SSE data may contain objects)
+  const content = typeof rawContent === "string"
+    ? rawContent
+    : (rawContent != null ? JSON.stringify(rawContent) : "");
+  const toolState = typeof rawToolState === "string"
+    ? rawToolState
+    : (rawToolState != null ? JSON.stringify(rawToolState) : undefined);
+
   if (type === "reasoning") {
     return (
       <details className="group">
@@ -234,9 +242,9 @@ function SessionContent({ agentId }: { agentId: string }) {
                 <PartContent
                   key={part.id || i}
                   type={part.type}
-                  content={part.content}
+                  content={String(part.content ?? "")}
                   toolName={part.toolName}
-                  toolState={part.toolState}
+                  toolState={typeof part.toolState === "string" ? part.toolState : undefined}
                 />
               ))}
             </div>

--- a/packages/web/src/stores/__tests__/opencode-store.test.ts
+++ b/packages/web/src/stores/__tests__/opencode-store.test.ts
@@ -122,6 +122,14 @@ describe("opencode-store", () => {
       expect(useOpenCodeStore.getState().messages.get("sess-1")!.length).toBe(2);
     });
 
+    it("updates session ID if it was empty", () => {
+      useOpenCodeStore.getState().startSession(makeSession({ id: "" }));
+      useOpenCodeStore.getState().addMessage("agent-1", "sess-real", makeMessage({ id: "msg-1" }));
+
+      const session = useOpenCodeStore.getState().sessions.get("agent-1")!;
+      expect(session.id).toBe("sess-real");
+    });
+
     it("replaces a message with the same ID", () => {
       useOpenCodeStore.getState().addMessage("agent-1", "sess-1", makeMessage({
         id: "msg-1",
@@ -139,6 +147,14 @@ describe("opencode-store", () => {
   });
 
   describe("appendPartDelta", () => {
+    it("updates session ID if it was empty", () => {
+      useOpenCodeStore.getState().startSession(makeSession({ id: "" }));
+      useOpenCodeStore.getState().appendPartDelta("agent-1", "sess-real", "msg-1", "p1", "text", "hi");
+
+      const session = useOpenCodeStore.getState().sessions.get("agent-1")!;
+      expect(session.id).toBe("sess-real");
+    });
+
     it("accumulates delta text for a part", () => {
       const store = useOpenCodeStore.getState();
       store.appendPartDelta("agent-1", "sess-1", "msg-1", "part-1", "text", "Hello ");


### PR DESCRIPTION
## Summary

- Adds a "Code" tab that replays OpenCode SSE events in real-time, showing the full LLM conversation (text, reasoning, tool calls, file diffs)
- Forwards OpenCode SSE events through the callback chain (Worker → TeamLead → COO → Socket.IO) to the frontend
- Parses SDK event format correctly (`properties.part` for parts, `properties.info` for messages) with safety coercion for non-string values
- Includes Zustand store with session ID auto-update, streaming part buffers, and session lifecycle management
- 49 new unit tests covering event parsing, store logic, client event forwarding, and worker integration

## Changes

- **Shared**: New OpenCode types (`OpenCodeSession`, `OpenCodeMessage`, `OpenCodePart`, `OpenCodeFileDiff`), 5 new `ServerToClientEvents`
- **Server**: `onEvent` callback in `OpenCodeClient`, `onOpenCodeEvent` wired through Worker → TeamLead → COO → index.ts, `emitOpenCodeEvent` handler parsing SDK events
- **Web**: `opencode-store.ts` (Zustand), socket listeners in `use-socket.ts`, `CodeView.tsx` component, "Code" tab in `App.tsx`

## Test plan

- [x] All 188 tests pass (`npx pnpm test`)
- [ ] Start app with `npx pnpm dev`, trigger an OpenCode coding task
- [ ] Verify session appears in Code tab sidebar with status dot
- [ ] Verify messages stream in real-time (text, tool calls, thinking)
- [ ] Verify file diff summary appears on session completion
- [ ] Verify status transitions (active → completed/error)