### PR TITLE
feat: OpenCode live coding view with interactive permissions

### DIFF
--- a/packages/server/src/agents/coo.ts
+++ b/packages/server/src/agents/coo.ts
@@ -65,6 +65,7 @@ export interface COODependencies {
   onAgentToolCall?: (agentId: string, toolName: string, args: Record<string, unknown>) => void;
   onOpenCodeEvent?: (agentId: string, sessionId: string, event: { type: string; properties: Record<string, unknown> }) => void;
   onOpenCodeAwaitingInput?: (agentId: string, sessionId: string, prompt: string) => Promise<string | null>;
+  onOpenCodePermissionRequest?: (agentId: string, sessionId: string, permission: { id: string; type: string; title: string; pattern?: string | string[]; metadata: Record<string, unknown> }) => Promise<"once" | "always" | "reject">;
   onAgentDestroyed?: (agentId: string) => void;
 }
 
@@ -86,6 +87,7 @@ export class COO extends BaseAgent {
   private _onAgentToolCall?: (agentId: string, toolName: string, args: Record<string, unknown>) => void;
   private _onOpenCodeEvent?: (agentId: string, sessionId: string, event: { type: string; properties: Record<string, unknown> }) => void;
   private _onOpenCodeAwaitingInput?: (agentId: string, sessionId: string, prompt: string) => Promise<string | null>;
+  private _onOpenCodePermissionRequest?: (agentId: string, sessionId: string, permission: { id: string; type: string; title: string; pattern?: string | string[]; metadata: Record<string, unknown> }) => Promise<"once" | "always" | "reject">;
   private onAgentDestroyed?: (agentId: string) => void;
   private allowedToolNames: Set<string>;
   private contextManager!: ConversationContextManager;
@@ -187,6 +189,7 @@ The user can see everything on the desktop in real-time.`;
     this._onAgentToolCall = deps.onAgentToolCall;
     this._onOpenCodeEvent = deps.onOpenCodeEvent;
     this._onOpenCodeAwaitingInput = deps.onOpenCodeAwaitingInput;
+    this._onOpenCodePermissionRequest = deps.onOpenCodePermissionRequest;
     this.onAgentDestroyed = deps.onAgentDestroyed;
     this.contextManager = new ConversationContextManager(systemPrompt);
   }
@@ -715,6 +718,7 @@ The user can see everything on the desktop in real-time.`;
       onAgentToolCall: this._onAgentToolCall,
       onOpenCodeEvent: this._onOpenCodeEvent,
       onOpenCodeAwaitingInput: this._onOpenCodeAwaitingInput,
+      onOpenCodePermissionRequest: this._onOpenCodePermissionRequest,
     });
 
     this.teamLeads.set(projectId, teamLead);
@@ -1230,6 +1234,7 @@ The user can see everything on the desktop in real-time.`;
       onAgentToolCall: this._onAgentToolCall,
       onOpenCodeEvent: this._onOpenCodeEvent,
       onOpenCodeAwaitingInput: this._onOpenCodeAwaitingInput,
+      onOpenCodePermissionRequest: this._onOpenCodePermissionRequest,
     });
 
     this.teamLeads.set(project.id, teamLead);

--- a/packages/server/src/agents/team-lead.ts
+++ b/packages/server/src/agents/team-lead.ts
@@ -165,6 +165,7 @@ export interface TeamLeadDependencies {
   onAgentToolCall?: (agentId: string, toolName: string, args: Record<string, unknown>) => void;
   onOpenCodeEvent?: (agentId: string, sessionId: string, event: { type: string; properties: Record<string, unknown> }) => void;
   onOpenCodeAwaitingInput?: (agentId: string, sessionId: string, prompt: string) => Promise<string | null>;
+  onOpenCodePermissionRequest?: (agentId: string, sessionId: string, permission: { id: string; type: string; title: string; pattern?: string | string[]; metadata: Record<string, unknown> }) => Promise<"once" | "always" | "reject">;
 }
 
 const MAX_CONTINUATION_CYCLES = 5;
@@ -183,6 +184,7 @@ export class TeamLead extends BaseAgent {
   private onKanbanChange?: (event: "created" | "updated" | "deleted", task: KanbanTask) => void;
   private _onOpenCodeEvent?: (agentId: string, sessionId: string, event: { type: string; properties: Record<string, unknown> }) => void;
   private _onOpenCodeAwaitingInput?: (agentId: string, sessionId: string, prompt: string) => Promise<string | null>;
+  private _onOpenCodePermissionRequest?: (agentId: string, sessionId: string, permission: { id: string; type: string; title: string; pattern?: string | string[]; metadata: Record<string, unknown> }) => Promise<"once" | "always" | "reject">;
 
   constructor(deps: TeamLeadDependencies) {
     const registry = new Registry();
@@ -222,6 +224,7 @@ export class TeamLead extends BaseAgent {
     this.onKanbanChange = deps.onKanbanChange;
     this._onOpenCodeEvent = deps.onOpenCodeEvent;
     this._onOpenCodeAwaitingInput = deps.onOpenCodeAwaitingInput;
+    this._onOpenCodePermissionRequest = deps.onOpenCodePermissionRequest;
 
     // Restore persisted flags from previous runs
     this.verificationRequested = this.loadFlag("verification");
@@ -1146,6 +1149,7 @@ export class TeamLead extends BaseAgent {
         onAgentToolCall: this.onAgentToolCall,
         onOpenCodeEvent: this._onOpenCodeEvent,
         onOpenCodeAwaitingInput: this._onOpenCodeAwaitingInput,
+        onOpenCodePermissionRequest: this._onOpenCodePermissionRequest,
       });
 
       this.workers.set(worker.id, worker);

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -342,7 +342,7 @@ export const opencodeSessions = sqliteTable("opencode_sessions", {
   projectId: text("project_id"),
   task: text("task").notNull().default(""),
   status: text("status", {
-    enum: ["active", "idle", "completed", "error", "awaiting-input"],
+    enum: ["active", "idle", "completed", "error", "awaiting-input", "awaiting-permission"],
   })
     .notNull()
     .default("active"),

--- a/packages/server/src/opencode/opencode-manager.ts
+++ b/packages/server/src/opencode/opencode-manager.ts
@@ -40,6 +40,7 @@ export interface OpenCodeConfigOptions {
   model: string;
   apiKey?: string;
   baseUrl?: string;
+  interactive?: boolean;
 }
 
 export function writeOpenCodeConfig(opts: OpenCodeConfigOptions): void {
@@ -82,8 +83,8 @@ export function writeOpenCodeConfig(opts: OpenCodeConfigOptions): void {
       [openCodeProvider]: providerEntry,
     },
     model: `${openCodeProvider}/${opts.model}`,
-    // Auto-approve all permission prompts — OpenCode runs autonomously as a tool
-    permission: "allow",
+    // When interactive mode is on, require permission for tool use; otherwise auto-approve
+    permission: opts.interactive ? "ask" : "allow",
     server: {
       port: 4096,
       hostname: "127.0.0.1",
@@ -184,11 +185,13 @@ function ensureConfigAndCredentials(): boolean {
   const { apiKey, providerType, baseUrl } = resolveProviderInfo();
   const effectiveProviderType = getConfig("opencode:provider_type") ?? providerType ?? "anthropic";
 
+  const interactive = getConfig("opencode:interactive") === "true";
   writeOpenCodeConfig({
     providerType: effectiveProviderType,
     model,
     apiKey,
     baseUrl,
+    interactive,
   });
 
   return true;

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -978,6 +978,7 @@ export function updateOpenCodeSettings(data: {
   const wasEnabled = getConfig("opencode:enabled") === "true";
   const oldModel = getConfig("opencode:model") ?? "";
   const oldProviderId = getConfig("opencode:provider_id") ?? "";
+  const oldInteractive = getConfig("opencode:interactive") === "true";
 
   if (data.enabled !== undefined) {
     setConfig("opencode:enabled", data.enabled ? "true" : "false");
@@ -1031,15 +1032,17 @@ export function updateOpenCodeSettings(data: {
   const isNowEnabled = getConfig("opencode:enabled") === "true";
   const newModel = getConfig("opencode:model") ?? "";
   const newProviderId = getConfig("opencode:provider_id") ?? "";
-  const modelOrProviderChanged = newModel !== oldModel || newProviderId !== oldProviderId;
+  const newInteractive = getConfig("opencode:interactive") === "true";
+  const configChanged =
+    newModel !== oldModel || newProviderId !== oldProviderId || newInteractive !== oldInteractive;
 
   // Manage OpenCode process lifecycle
   if (!wasEnabled && isNowEnabled) {
     startOpenCodeServer();
   } else if (wasEnabled && !isNowEnabled) {
     stopOpenCodeServer();
-  } else if (isNowEnabled && modelOrProviderChanged) {
-    // Model or provider changed — rewrite config and restart
+  } else if (isNowEnabled && configChanged) {
+    // Model, provider, or interactive mode changed — rewrite config and restart
     stopOpenCodeServer();
     startOpenCodeServer();
   }

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -3,7 +3,7 @@ import type { BusMessage, Conversation } from "./message.js";
 import type { RegistryEntry, Project } from "./registry.js";
 import type { KanbanTask } from "./kanban.js";
 import type { SceneZone } from "./environment.js";
-import type { OpenCodeSession, OpenCodeMessage, OpenCodeFileDiff } from "./opencode.js";
+import type { OpenCodeSession, OpenCodeMessage, OpenCodeFileDiff, OpenCodePermission } from "./opencode.js";
 
 /** Events emitted from server to client */
 export interface ServerToClientEvents {
@@ -39,6 +39,7 @@ export interface ServerToClientEvents {
   "opencode:message": (data: { agentId: string; sessionId: string; message: OpenCodeMessage }) => void;
   "opencode:part-delta": (data: { agentId: string; sessionId: string; messageId: string; partId: string; type: string; delta: string; toolName?: string; toolState?: string }) => void;
   "opencode:awaiting-input": (data: { agentId: string; sessionId: string; prompt: string }) => void;
+  "opencode:permission-request": (data: { agentId: string; sessionId: string; permission: OpenCodePermission }) => void;
 }
 
 /** Events emitted from client to server */
@@ -94,6 +95,10 @@ export interface ClientToServerEvents {
   ) => void;
   "opencode:respond": (
     data: { agentId: string; sessionId: string; content: string },
+    callback?: (ack: { ok: boolean; error?: string }) => void,
+  ) => void;
+  "opencode:permission-respond": (
+    data: { agentId: string; sessionId: string; permissionId: string; response: "once" | "always" | "reject" },
     callback?: (ack: { ok: boolean; error?: string }) => void,
   ) => void;
 }

--- a/packages/shared/src/types/opencode.ts
+++ b/packages/shared/src/types/opencode.ts
@@ -5,7 +5,7 @@ export interface OpenCodeSession {
   agentId: string;
   projectId: string | null;
   task: string;
-  status: "active" | "idle" | "completed" | "error" | "awaiting-input";
+  status: "active" | "idle" | "completed" | "error" | "awaiting-input" | "awaiting-permission";
   startedAt: string;
   completedAt?: string;
 }
@@ -33,4 +33,12 @@ export interface OpenCodeFileDiff {
   path: string;
   additions: number;
   deletions: number;
+}
+
+export interface OpenCodePermission {
+  id: string;
+  type: string;       // "edit" | "bash" | "webfetch" etc.
+  title: string;
+  pattern?: string | string[];
+  metadata: Record<string, unknown>;
 }

--- a/packages/web/src/hooks/use-socket.ts
+++ b/packages/web/src/hooks/use-socket.ts
@@ -36,6 +36,8 @@ export function useSocket() {
   const appendOpenCodePartDelta = useOpenCodeStore((s) => s.appendPartDelta);
   const setAwaitingInput = useOpenCodeStore((s) => s.setAwaitingInput);
   const clearAwaitingInput = useOpenCodeStore((s) => s.clearAwaitingInput);
+  const setPendingPermission = useOpenCodeStore((s) => s.setPendingPermission);
+  const clearPendingPermission = useOpenCodeStore((s) => s.clearPendingPermission);
 
   useEffect(() => {
     if (initialized.current) return;
@@ -154,6 +156,7 @@ export function useSocket() {
     socket.on("opencode:session-end", (data) => {
       endOpenCodeSession(data.agentId, data.sessionId, data.status, data.diff);
       clearAwaitingInput(data.agentId);
+      clearPendingPermission(data.agentId);
     });
 
     socket.on("opencode:message", (data) => {
@@ -175,6 +178,10 @@ export function useSocket() {
 
     socket.on("opencode:awaiting-input", (data) => {
       setAwaitingInput(data.agentId, { sessionId: data.sessionId, prompt: data.prompt });
+    });
+
+    socket.on("opencode:permission-request", (data) => {
+      setPendingPermission(data.agentId, { sessionId: data.sessionId, permission: data.permission });
     });
 
     return () => {
@@ -205,6 +212,7 @@ export function useSocket() {
       socket.off("opencode:message");
       socket.off("opencode:part-delta");
       socket.off("opencode:awaiting-input");
+      socket.off("opencode:permission-request");
     };
   }, []);
 


### PR DESCRIPTION
## Summary

- **Live coding view**: Real-time CodeView component showing OpenCode SSE events (tool calls, file edits, thinking, bash output) with syntax-highlighted diffs and streaming activity
- **Session history**: Persist OpenCode sessions, messages, and diffs to the database for replay and review
- **Token usage tracking**: Capture and persist OpenCode token usage to the `token_usage` table
- **Interactive permission handling**: When interactive mode is enabled, OpenCode prompts for user permission before making changes — approvable from both the CodeView UI and chat
- **Settings improvements**: Interactive mode toggle in settings, OpenCode server restarts on config changes (model, provider, interactive mode)
- **Bug fixes**: Resolved infinite re-render loop in CodeView, fixed SSE event parsing to match SDK format, fixed idle event detection

## Test plan

- [ ] Enable OpenCode with interactive mode off → tasks run autonomously with no permission prompts
- [ ] Enable interactive mode → OpenCode prompts for permission on edits/bash commands
- [ ] Approve/deny permissions from CodeView UI buttons (Allow Once, Always Allow, Deny)
- [ ] Approve/deny permissions from chat using keywords (allow, deny, always)
- [ ] Toggle interactive mode in settings → OpenCode server restarts automatically
- [ ] Verify live coding view shows real-time SSE events during OpenCode tasks
- [ ] Verify session history persists and can be reviewed after completion
- [ ] Run `npx pnpm test` — all tests pass
- [ ] Run `npx pnpm build` — no type errors