### PR TITLE
fix: await OpenCode process exit before restarting on config change

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2146,7 +2146,7 @@ async function main() {
       maxIterations?: number;
     };
   }>("/api/settings/opencode", async (req) => {
-    updateOpenCodeSettings(req.body);
+    await updateOpenCodeSettings(req.body);
     return { ok: true };
   });
 
@@ -3052,7 +3052,7 @@ Respond with ONLY a JSON object (no markdown, no explanation) with these fields:
 
   // Graceful shutdown
   const shutdown = async () => {
-    stopOpenCodeServer();
+    await stopOpenCodeServer();
     await closeBrowser();
     process.exit(0);
   };

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -964,7 +964,7 @@ export function getOpenCodeSettings(): OpenCodeSettingsResponse {
   };
 }
 
-export function updateOpenCodeSettings(data: {
+export async function updateOpenCodeSettings(data: {
   enabled?: boolean;
   apiUrl?: string;
   username?: string;
@@ -974,7 +974,7 @@ export function updateOpenCodeSettings(data: {
   model?: string;
   providerId?: string;
   interactive?: boolean;
-}): void {
+}): Promise<void> {
   const wasEnabled = getConfig("opencode:enabled") === "true";
   const oldModel = getConfig("opencode:model") ?? "";
   const oldProviderId = getConfig("opencode:provider_id") ?? "";
@@ -1040,10 +1040,10 @@ export function updateOpenCodeSettings(data: {
   if (!wasEnabled && isNowEnabled) {
     startOpenCodeServer();
   } else if (wasEnabled && !isNowEnabled) {
-    stopOpenCodeServer();
+    await stopOpenCodeServer();
   } else if (isNowEnabled && configChanged) {
     // Model, provider, or interactive mode changed — rewrite config and restart
-    stopOpenCodeServer();
+    await stopOpenCodeServer();
     startOpenCodeServer();
   }
 }


### PR DESCRIPTION
## Summary

- `stopOpenCodeServer()` now returns a `Promise<void>` that waits for the process to actually exit before resolving (with a 5s SIGKILL fallback)
- `updateOpenCodeSettings()` is now async and awaits the stop, preventing the new process from failing to bind port 4096 when the old one hasn't released it yet
- Fixes model/provider/interactive mode changes not taking effect after settings update

## Test plan

- [ ] Change OpenCode model in settings → verify new model is used on next task
- [ ] Change OpenCode provider in settings → verify new provider is used
- [ ] Toggle interactive mode → verify OpenCode restarts with correct permission config
- [ ] `npx pnpm build` — no type errors