### PR TITLE
fix: OpenCode live view, permissions, and config restart

### DIFF
--- a/packages/server/src/tools/opencode-client.ts
+++ b/packages/server/src/tools/opencode-client.ts
@@ -328,6 +328,11 @@ export class OpenCodeClient {
           lastActivityTime = Date.now();
           console.log(`[OpenCode Client] SSE activity: ${eventType ?? "unknown"}`);
 
+          // Debug: log structure of delta and permission events
+          if (eventType === "message.part.delta") {
+            console.log(`[OpenCode Client] part.delta properties:`, JSON.stringify(props).slice(0, 500));
+          }
+
           // Forward event to listener
           if (eventType) {
             try {


### PR DESCRIPTION
## Summary

- **Live CodeView output**: Handle `message.part.delta` SSE events for real-time streaming output in CodeView (previously only `message.part.updated` was handled, missing the actual delta chunks)
- **Permission event fix**: Correct SSE event name from `permission.updated` to `permission.asked` and fix session matching for permission events that don't include `sessionID` in properties
- **Config restart fix**: `stopOpenCodeServer()` now awaits process exit (with 5s SIGKILL fallback) before starting a new one, fixing model/provider changes not taking effect
- **Interactive permissions**: Full permission handling flow for interactive mode — approve/deny from CodeView UI and chat

## Test plan

- [ ] Start OpenCode task → verify live output appears in CodeView (text, tool calls, reasoning)
- [ ] Enable interactive mode → permission prompt appears in CodeView and chat
- [ ] Approve/deny permissions → OpenCode continues/stops appropriately
- [ ] Change model in settings → verify new model takes effect after automatic restart
- [ ] `npx pnpm build` — no type errors