### PR TITLE
fix: correct SSE event property mappings for CodeView and permissions

### DIFF
--- a/packages/server/src/tools/opencode-client.ts
+++ b/packages/server/src/tools/opencode-client.ts
@@ -372,17 +372,21 @@ export class OpenCodeClient {
             console.log(`[OpenCode Client] Permission event properties:`, JSON.stringify(props));
             const permissionId = (props.id ?? props.permissionID) as string | undefined;
             if (permissionId) {
-              console.log(`[OpenCode Client] Permission requested: ${props.title ?? props.type} (${permissionId})`);
+              // permission.asked shape: { id, sessionID, permission: "toolname", patterns: [...], metadata, tool: { messageID, callID } }
+              const permissionType = (props.permission as string) ?? (props.type as string) ?? "unknown";
+              const permissionTitle = permissionType; // No separate title field — use the permission/tool name
+              const permissionPatterns = (props.patterns ?? props.pattern) as string | string[] | undefined;
+              console.log(`[OpenCode Client] Permission requested: ${permissionTitle} (${permissionId})`);
               this.permissionPending = true;
               try {
                 let response: "once" | "always" | "reject" = "once";
                 if (this.onPermissionRequest) {
                   response = await this.onPermissionRequest(sessionId, {
                     id: permissionId,
-                    type: (props.type as string) ?? "unknown",
-                    title: (props.title as string) ?? "",
-                    pattern: props.pattern as string | string[] | undefined,
-                    metadata: props.metadata as Record<string, unknown> ?? {},
+                    type: permissionType,
+                    title: permissionTitle,
+                    pattern: permissionPatterns,
+                    metadata: (props.metadata as Record<string, unknown>) ?? {},
                   });
                 }
                 console.log(`[OpenCode Client] Responding to permission ${permissionId}: ${response}`);


### PR DESCRIPTION
## Summary

- **Delta events**: Fixed property mapping for `message.part.delta` — uses `partID`/`messageID`/`field`/`delta` (not nested `part.id`/`part.type`)
- **Permission events**: Fixed `permission.asked` property mapping — tool name is in `permission` field (not `type`), patterns in `patterns` (not `pattern`), no `title` field exists
- **Streaming output**: CodeView now handles `message.part.delta` events for real-time text streaming
- **Permission display**: Permission prompt now shows the actual tool name (e.g. "todowrite") instead of "unknown"

## Test plan

- [ ] Start OpenCode task → streaming text appears in CodeView in real time
- [ ] Enable interactive mode → permission prompt shows correct tool name
- [ ] Approve/deny from CodeView or chat → works correctly
- [ ] `npx pnpm build` — no type errors