### PR TITLE
Detachable 3D Live View

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -23,6 +23,7 @@ import { TodoView } from "./components/todos/TodoView";
 import { InboxView } from "./components/inbox/InboxView";
 import { CalendarView } from "./components/calendar/CalendarView";
 import { CodeView } from "./components/code/CodeView";
+import { DetachedLiveView } from "./components/live-view/DetachedLiveView";
 import { useDesktopStore } from "./stores/desktop-store";
 import { useOpenCodeStore } from "./stores/opencode-store";
 import { initMovementTriggers } from "./lib/movement-triggers";
@@ -45,6 +46,12 @@ export default function App() {
         <DesktopView />
       </div>
     );
+  }
+
+  // Detached 3D view mode
+  const isDetached3D = new URLSearchParams(window.location.search).has("detached-3d");
+  if (isDetached3D && screen === "app") {
+    return <DetachedLiveView />;
   }
 
   if (screen === "loading") {

--- a/packages/web/src/components/live-view/DetachedLiveView.tsx
+++ b/packages/web/src/components/live-view/DetachedLiveView.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { LiveView } from "./LiveView";
+import { useSocket } from "../../hooks/use-socket";
+import { useAgentStore } from "../../stores/agent-store";
+
+interface UserProfile {
+  name: string | null;
+  avatar: string | null;
+  modelPackId?: string | null;
+  cooName?: string;
+}
+
+export function DetachedLiveView() {
+  const [userProfile, setUserProfile] = useState<UserProfile | undefined>();
+  const loadAgents = useAgentStore((s) => s.loadAgents);
+
+  // Initialize socket listeners
+  useSocket();
+
+  useEffect(() => {
+    // Load profile
+    fetch("/api/profile")
+      .then((r) => r.json())
+      .then(setUserProfile)
+      .catch(console.error);
+
+    // Load agents
+    fetch("/api/agents")
+      .then((r) => r.json())
+      .then(loadAgents)
+      .catch(console.error);
+  }, [loadAgents]);
+
+  if (!userProfile) {
+    return (
+      <div className="h-screen w-screen bg-black text-white flex items-center justify-center">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <div className="w-6 h-6 rounded-md bg-primary/20 flex items-center justify-center animate-pulse">
+            <span className="text-primary text-xs font-bold">S</span>
+          </div>
+          <span className="text-sm">Loading 3D View...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen w-screen overflow-hidden bg-black">
+      <LiveView userProfile={userProfile} />
+    </div>
+  );
+}

--- a/packages/web/src/components/live-view/LiveView.tsx
+++ b/packages/web/src/components/live-view/LiveView.tsx
@@ -173,17 +173,30 @@ export function LiveView({ userProfile, onToggleView }: LiveViewProps) {
           )}
 
           {onToggleView && (
-            <button
-              onClick={onToggleView}
-              title="Switch to Agent Graph"
-              className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded hover:bg-secondary"
-            >
-              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="10" />
-                <line x1="2" y1="12" x2="22" y2="12" />
-                <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-              </svg>
-            </button>
+            <>
+              <button
+                onClick={() => window.open(window.location.origin + "?detached-3d=true", "Detached3D", "width=1200,height=800")}
+                title="Pop out 3D View"
+                className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded hover:bg-secondary"
+              >
+                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                  <polyline points="15 3 21 3 21 9" />
+                  <line x1="10" y1="14" x2="21" y2="3" />
+                </svg>
+              </button>
+              <button
+                onClick={onToggleView}
+                title="Switch to Agent Graph"
+                className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded hover:bg-secondary"
+              >
+                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="10" />
+                  <line x1="2" y1="12" x2="22" y2="12" />
+                  <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+                </svg>
+              </button>
+            </>
           )}
         </div>
       </div>

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -13,11 +13,18 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      "/api": "http://localhost:62626",
-      "/assets/3d": "http://localhost:62626",
+      "/api": {
+        target: "https://localhost:62626",
+        secure: false,
+      },
+      "/assets/3d": {
+        target: "https://localhost:62626",
+        secure: false,
+      },
       "/socket.io": {
-        target: "http://localhost:62626",
+        target: "https://localhost:62626",
         ws: true,
+        secure: false,
       },
       "/novnc": {
         target: "https://localhost:62626",


### PR DESCRIPTION
Implemented a detachable 3D view feature. A new "Pop out" button in the Live View header opens the 3D scene in a separate, full-screen window. This allows users to keep the agent activity visible on a secondary monitor while working in other parts of the application. The implementation uses a query parameter (`detached-3d=true`) to render a simplified view component (`DetachedLiveView`) that initializes necessary stores and socket connections independently. Also updated Vite proxy configuration to correctly target the HTTPS backend server.

---
*PR created automatically by Jules for task [1933679285994052246](https://jules.google.com/task/1933679285994052246) started by @TOoSmOotH*