### PR TITLE
Add support for 'generic working' animation in 3D view

### DIFF
--- a/packages/server/src/models3d/model-packs.ts
+++ b/packages/server/src/models3d/model-packs.ts
@@ -46,11 +46,13 @@ export function discoverModelPacks(assetsRoot: string): ModelPack[] {
     // Look for animation GLBs
     let idleAnim: string | null = null;
     let actionAnim: string | null = null;
+    let workingAnim: string | null = null;
     if (animDir) {
       const animFiles = readdirSync(animDir).filter((f) => f.endsWith(".glb"));
       for (const f of animFiles) {
         if (f.includes("General")) idleAnim = f;
         if (f.includes("Movement")) actionAnim = f;
+        if (f.includes("Working")) workingAnim = f;
       }
     }
 
@@ -83,6 +85,10 @@ export function discoverModelPacks(assetsRoot: string): ModelPack[] {
           actionAnim && animPrefix
             ? `${animPrefix}/${actionAnim}`
             : `${prefix}/characters/${characterFile}`,
+        working:
+          workingAnim && animPrefix
+            ? `${animPrefix}/${workingAnim}`
+            : undefined,
       },
     });
   }

--- a/packages/shared/src/types/model-pack.ts
+++ b/packages/shared/src/types/model-pack.ts
@@ -6,6 +6,7 @@ export interface ModelPack {
   animations: {
     idle: string;
     action: string;
+    working?: string;
   };
 }
 


### PR DESCRIPTION
This change enables the "generic working" animation for workers when they are actively doing something (status "acting"). It updates the shared types, server-side discovery logic, and frontend rendering component to support a new "working" animation category. It also improves the fallback behavior for the "acting" state to use idle animations instead of walking if no specific working animation is available.

---
*PR created automatically by Jules for task [9202087153347421072](https://jules.google.com/task/9202087153347421072) started by @TOoSmOotH*