### PR TITLE
fix(project): restore office area after restart (fix #39)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
-    include: ["packages/*/src/**/*.test.ts"],
+    include: ["packages/**/src/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
When the application restarts, active projects were not getting their office area zones restored.

Changes:
- Move WorldLayoutManager initialization earlier in startup
- Make startCoo() async to properly await recoverActiveProjects()
- After recovering active projects, check which ones don't have zones and create them
- Emit 'world:zone-added' events for restored zones