### PR TITLE
fix(issue-103): add header link to 3D view

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -300,6 +300,19 @@ function MainApp() {
             Graph
           </button>
           <button
+            onClick={() => {
+              setCenterView("live3d");
+              setSettingsOpen(false);
+            }}
+            className={`text-xs transition-colors px-2 py-1 rounded ${
+              !settingsOpen && centerView === "live3d"
+                ? "text-primary bg-primary/10"
+                : "text-muted-foreground hover:text-foreground hover:bg-secondary"
+            }`}
+          >
+            3D View
+          </button>
+          <button
             onClick={() => setSettingsOpen(!settingsOpen)}
             className={`text-xs transition-colors px-2 py-1 rounded ${
               settingsOpen

--- a/packages/web/src/lib/get-center-tabs.test.ts
+++ b/packages/web/src/lib/get-center-tabs.test.ts
@@ -38,4 +38,12 @@ describe("centerViewLabels", () => {
       expect(typeof centerViewLabels[view]).toBe("string");
     }
   });
+
+  it("has a label for the live3d view used by the header 3D View link", () => {
+    expect(centerViewLabels["live3d"]).toBe("Live");
+  });
+
+  it("has a label for the graph view used by the header Graph link", () => {
+    expect(centerViewLabels["graph"]).toBe("Graph");
+  });
 });


### PR DESCRIPTION
## Summary
- Added a "3D View" button next to the "Graph" button in the main app header (`packages/web/src/App.tsx`)
- The button navigates to the `live3d` center view using the same `setCenterView` pattern as the existing Graph button
- Styling matches the existing header buttons with active state highlighting when selected
- Added unit tests verifying the `live3d` and `graph` view labels in `get-center-tabs.test.ts`

Closes #103

## Test plan
- [x] All 331 existing tests pass (26 test files)
- [x] New tests verify `live3d` view label is correctly defined
- [ ] Manual: Verify the "3D View" button appears next to "Graph" in the header
- [ ] Manual: Verify clicking "3D View" navigates to the live 3D view
- [ ] Manual: Verify the button highlights when the 3D view is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)