### PR TITLE
feat(#103): add 3D view link to header

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -300,6 +300,19 @@ function MainApp() {
             Graph
           </button>
           <button
+            onClick={() => {
+              setCenterView("live3d");
+              setSettingsOpen(false);
+            }}
+            className={`text-xs transition-colors px-2 py-1 rounded ${
+              !settingsOpen && centerView === "live3d"
+                ? "text-primary bg-primary/10"
+                : "text-muted-foreground hover:text-foreground hover:bg-secondary"
+            }`}
+          >
+            3D View
+          </button>
+          <button
             onClick={() => setSettingsOpen(!settingsOpen)}
             className={`text-xs transition-colors px-2 py-1 rounded ${
               settingsOpen

--- a/packages/web/src/lib/get-center-tabs.test.ts
+++ b/packages/web/src/lib/get-center-tabs.test.ts
@@ -21,6 +21,11 @@ describe("getCenterTabs", () => {
     expect(getCenterTabs("proj-1")).not.toContain("graph");
   });
 
+  it("does not include live3d in project or global tabs (header-only navigation)", () => {
+    expect(getCenterTabs("proj-1")).not.toContain("live3d");
+    expect(getCenterTabs(null)).not.toContain("live3d");
+  });
+
   it("includes settings only in project tabs", () => {
     expect(getCenterTabs("proj-1")).toContain("settings");
     expect(getCenterTabs(null)).not.toContain("settings");
@@ -37,5 +42,18 @@ describe("centerViewLabels", () => {
       expect(centerViewLabels[view]).toBeDefined();
       expect(typeof centerViewLabels[view]).toBe("string");
     }
+  });
+
+  it("has a label for the live3d view used by the header 3D View link", () => {
+    expect(centerViewLabels.live3d).toBe("Live");
+  });
+});
+
+describe("header navigation views", () => {
+  it("graph and live3d are both valid CenterView values with labels", () => {
+    // The header provides direct navigation to graph and live3d views
+    // (outside the tab bar). Both must remain valid CenterView values.
+    expect(centerViewLabels["graph"]).toBeDefined();
+    expect(centerViewLabels["live3d"]).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- Adds a **3D View** button to the top navigation bar, placed next to the existing **Graph** button
- Clicking it navigates to the `live3d` center view (the existing Three.js 3D visualization)
- Styled consistently with other header buttons (active highlight via `text-primary bg-primary/10`)
- Adds tests verifying `live3d` is a valid view with a label and that it's accessible via header navigation (not duplicated in tab bars)

Closes #103

## Test plan

- [x] All 332 existing tests pass
- [ ] Verify the "3D View" button appears in the header next to "Graph"
- [ ] Verify clicking "3D View" switches to the live 3D visualization
- [ ] Verify the button shows active styling when the 3D view is selected
- [ ] Verify Graph and Settings buttons continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)