### PR TITLE
feat: auto-comment on GitHub issues when accepted by the bot

### DIFF
--- a/packages/server/src/github/__tests__/issue-monitor.test.ts
+++ b/packages/server/src/github/__tests__/issue-monitor.test.ts
@@ -15,8 +15,17 @@ vi.mock("../../auth/auth.js", () => ({
 
 // Mock github-service
 const mockFetchAssignedIssues = vi.fn().mockResolvedValue([]);
+const mockCreateIssueComment = vi.fn().mockResolvedValue({
+  id: 1,
+  user: { login: "otterbot" },
+  body: "",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  html_url: "https://github.com/owner/repo/issues/1#issuecomment-1",
+});
 vi.mock("../github-service.js", () => ({
   fetchAssignedIssues: (...args: any[]) => mockFetchAssignedIssues(...args),
+  createIssueComment: (...args: any[]) => mockCreateIssueComment(...args),
   cloneRepo: vi.fn(),
   getRepoDefaultBranch: vi.fn().mockResolvedValue("main"),
 }));
@@ -60,6 +69,14 @@ describe("GitHubIssueMonitor", () => {
     resetDb();
     configStore.clear();
     mockFetchAssignedIssues.mockReset().mockResolvedValue([]);
+    mockCreateIssueComment.mockReset().mockResolvedValue({
+      id: 1,
+      user: { login: "otterbot" },
+      body: "",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      html_url: "https://github.com/owner/repo/issues/1#issuecomment-1",
+    });
     process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
     process.env.OTTERBOT_DB_KEY = "test-key";
     await migrateDb();
@@ -372,6 +389,162 @@ describe("GitHubIssueMonitor", () => {
           toAgentId: "tl-1",
           content: expect.stringContaining("#99"),
         }),
+      );
+    });
+
+    it("posts an acknowledgement comment on a new issue", async () => {
+      const db = getDb();
+
+      db.insert(schema.projects)
+        .values({
+          id: "proj-comment",
+          name: "Comment Project",
+          description: "test",
+          status: "active",
+          githubRepo: "owner/repo",
+          githubBranch: "main",
+          githubIssueMonitor: true,
+          rules: [],
+          createdAt: new Date().toISOString(),
+        })
+        .run();
+
+      monitor.watchProject("proj-comment", "owner/repo", "testuser");
+      configStore.set("github:token", "ghp_test");
+
+      mockFetchAssignedIssues.mockResolvedValue([
+        {
+          number: 112,
+          title: "Auto-respond to issues",
+          body: "Bot should comment when accepting an issue",
+          labels: [],
+          assignees: [{ login: "testuser" }],
+          state: "open",
+          html_url: "https://github.com/owner/repo/issues/112",
+          created_at: "2026-02-01T00:00:00Z",
+          updated_at: "2026-02-01T00:00:00Z",
+        },
+      ]);
+
+      await (monitor as any).poll();
+
+      expect(mockCreateIssueComment).toHaveBeenCalledTimes(1);
+      expect(mockCreateIssueComment).toHaveBeenCalledWith(
+        "owner/repo",
+        "ghp_test",
+        112,
+        expect.stringContaining("being looked at"),
+      );
+    });
+
+    it("does not comment on already-tracked issues", async () => {
+      const db = getDb();
+
+      db.insert(schema.projects)
+        .values({
+          id: "proj-nocomment",
+          name: "No Comment Project",
+          description: "test",
+          status: "active",
+          githubRepo: "owner/repo",
+          githubBranch: "main",
+          githubIssueMonitor: true,
+          rules: [],
+          createdAt: new Date().toISOString(),
+        })
+        .run();
+
+      // Pre-existing task — issue already tracked
+      db.insert(schema.kanbanTasks)
+        .values({
+          id: "existing-task-2",
+          projectId: "proj-nocomment",
+          title: "#50: Already tracked",
+          description: "",
+          column: "backlog",
+          position: 0,
+          labels: ["github-issue-50"],
+          blockedBy: [],
+          retryCount: 0,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })
+        .run();
+
+      monitor.watchProject("proj-nocomment", "owner/repo", "testuser");
+      configStore.set("github:token", "ghp_test");
+
+      mockFetchAssignedIssues.mockResolvedValue([
+        {
+          number: 50,
+          title: "Already tracked",
+          body: "",
+          labels: [],
+          assignees: [{ login: "testuser" }],
+          state: "open",
+          html_url: "https://github.com/owner/repo/issues/50",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-02T00:00:00Z",
+        },
+      ]);
+
+      await (monitor as any).poll();
+
+      expect(mockCreateIssueComment).not.toHaveBeenCalled();
+    });
+
+    it("still creates the kanban task when commenting fails", async () => {
+      const db = getDb();
+
+      db.insert(schema.projects)
+        .values({
+          id: "proj-fail-comment",
+          name: "Fail Comment Project",
+          description: "test",
+          status: "active",
+          githubRepo: "owner/repo",
+          githubBranch: "main",
+          githubIssueMonitor: true,
+          rules: [],
+          createdAt: new Date().toISOString(),
+        })
+        .run();
+
+      monitor.watchProject("proj-fail-comment", "owner/repo", "testuser");
+      configStore.set("github:token", "ghp_test");
+
+      mockCreateIssueComment.mockRejectedValue(new Error("API rate limited"));
+
+      mockFetchAssignedIssues.mockResolvedValue([
+        {
+          number: 77,
+          title: "Issue with failing comment",
+          body: "Test resilience",
+          labels: [],
+          assignees: [{ login: "testuser" }],
+          state: "open",
+          html_url: "https://github.com/owner/repo/issues/77",
+          created_at: "2026-02-01T00:00:00Z",
+          updated_at: "2026-02-01T00:00:00Z",
+        },
+      ]);
+
+      await (monitor as any).poll();
+
+      // Kanban task should still be created despite comment failure
+      const tasks = db
+        .select()
+        .from(schema.kanbanTasks)
+        .where(eq(schema.kanbanTasks.projectId, "proj-fail-comment"))
+        .all();
+
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].title).toBe("#77: Issue with failing comment");
+
+      // UI event should still be emitted
+      expect(mockIo.emit).toHaveBeenCalledWith(
+        "kanban:task-created",
+        expect.objectContaining({ title: "#77: Issue with failing comment" }),
       );
     });
 


### PR DESCRIPTION
## Summary
- When the issue monitor picks up a newly assigned GitHub issue, Otterbot now automatically posts a comment on the issue indicating it is being looked at.
- The comment is posted after creating the kanban task; failures to comment are logged but do not block the workflow.
- Three new unit tests cover: successful commenting, skipping already-tracked issues, and resilience when the comment API fails.

Closes #112

## Test plan
- [x] Existing tests pass (335/335)
- [x] New test: posts acknowledgement comment on new issues
- [x] New test: does not comment on already-tracked issues
- [x] New test: kanban task still created when commenting fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)