### PR TITLE
fix: post acknowledgement comment on GitHub issues when accepted

### DIFF
--- a/packages/server/src/github/__tests__/issue-monitor.test.ts
+++ b/packages/server/src/github/__tests__/issue-monitor.test.ts
@@ -15,8 +15,17 @@ vi.mock("../../auth/auth.js", () => ({
 
 // Mock github-service
 const mockFetchAssignedIssues = vi.fn().mockResolvedValue([]);
+const mockCreateIssueComment = vi.fn().mockResolvedValue({
+  id: 1,
+  user: { login: "otterbot" },
+  body: "",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  html_url: "",
+});
 vi.mock("../github-service.js", () => ({
   fetchAssignedIssues: (...args: any[]) => mockFetchAssignedIssues(...args),
+  createIssueComment: (...args: any[]) => mockCreateIssueComment(...args),
   cloneRepo: vi.fn(),
   getRepoDefaultBranch: vi.fn().mockResolvedValue("main"),
 }));
@@ -60,6 +69,14 @@ describe("GitHubIssueMonitor", () => {
     resetDb();
     configStore.clear();
     mockFetchAssignedIssues.mockReset().mockResolvedValue([]);
+    mockCreateIssueComment.mockReset().mockResolvedValue({
+      id: 1,
+      user: { login: "otterbot" },
+      body: "",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      html_url: "",
+    });
     process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
     process.env.OTTERBOT_DB_KEY = "test-key";
     await migrateDb();
@@ -373,6 +390,154 @@ describe("GitHubIssueMonitor", () => {
           content: expect.stringContaining("#99"),
         }),
       );
+    });
+
+    it("posts an acknowledgement comment on the GitHub issue", async () => {
+      const db = getDb();
+
+      db.insert(schema.projects)
+        .values({
+          id: "proj-comment",
+          name: "Comment Project",
+          description: "test",
+          status: "active",
+          githubRepo: "owner/repo",
+          githubBranch: "main",
+          githubIssueMonitor: true,
+          rules: [],
+          createdAt: new Date().toISOString(),
+        })
+        .run();
+
+      monitor.watchProject("proj-comment", "owner/repo", "testuser");
+      configStore.set("github:token", "ghp_test");
+
+      mockFetchAssignedIssues.mockResolvedValue([
+        {
+          number: 112,
+          title: "Comment on accepted issues",
+          body: "Bot should comment when it accepts an issue",
+          labels: [],
+          assignees: [{ login: "testuser" }],
+          state: "open",
+          html_url: "https://github.com/owner/repo/issues/112",
+          created_at: "2026-02-01T00:00:00Z",
+          updated_at: "2026-02-01T00:00:00Z",
+        },
+      ]);
+
+      await (monitor as any).poll();
+
+      expect(mockCreateIssueComment).toHaveBeenCalledWith(
+        "owner/repo",
+        "ghp_test",
+        112,
+        expect.stringContaining("looking into this issue"),
+      );
+    });
+
+    it("does not post a comment for already-tracked issues", async () => {
+      const db = getDb();
+
+      db.insert(schema.projects)
+        .values({
+          id: "proj-nocomment",
+          name: "No Comment Project",
+          description: "test",
+          status: "active",
+          githubRepo: "owner/repo",
+          githubBranch: "main",
+          githubIssueMonitor: true,
+          rules: [],
+          createdAt: new Date().toISOString(),
+        })
+        .run();
+
+      // Pre-existing task
+      db.insert(schema.kanbanTasks)
+        .values({
+          id: "existing-task-nc",
+          projectId: "proj-nocomment",
+          title: "#50: Already tracked",
+          description: "",
+          column: "backlog",
+          position: 0,
+          labels: ["github-issue-50"],
+          blockedBy: [],
+          retryCount: 0,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })
+        .run();
+
+      monitor.watchProject("proj-nocomment", "owner/repo", "testuser");
+      configStore.set("github:token", "ghp_test");
+
+      mockFetchAssignedIssues.mockResolvedValue([
+        {
+          number: 50,
+          title: "Already tracked",
+          body: "This is already in the backlog",
+          labels: [],
+          assignees: [{ login: "testuser" }],
+          state: "open",
+          html_url: "https://github.com/owner/repo/issues/50",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-02T00:00:00Z",
+        },
+      ]);
+
+      await (monitor as any).poll();
+
+      expect(mockCreateIssueComment).not.toHaveBeenCalled();
+    });
+
+    it("continues processing when comment posting fails", async () => {
+      const db = getDb();
+
+      db.insert(schema.projects)
+        .values({
+          id: "proj-commenterr",
+          name: "Comment Error Project",
+          description: "test",
+          status: "active",
+          githubRepo: "owner/repo",
+          githubBranch: "main",
+          githubIssueMonitor: true,
+          rules: [],
+          createdAt: new Date().toISOString(),
+        })
+        .run();
+
+      monitor.watchProject("proj-commenterr", "owner/repo", "testuser");
+      configStore.set("github:token", "ghp_test");
+
+      mockCreateIssueComment.mockRejectedValue(new Error("GitHub API error 403"));
+
+      mockFetchAssignedIssues.mockResolvedValue([
+        {
+          number: 77,
+          title: "Comment will fail",
+          body: "Test graceful error handling",
+          labels: [],
+          assignees: [{ login: "testuser" }],
+          state: "open",
+          html_url: "https://github.com/owner/repo/issues/77",
+          created_at: "2026-02-01T00:00:00Z",
+          updated_at: "2026-02-01T00:00:00Z",
+        },
+      ]);
+
+      await (monitor as any).poll();
+
+      // Task should still be created despite comment failure
+      const tasks = db
+        .select()
+        .from(schema.kanbanTasks)
+        .where(eq(schema.kanbanTasks.projectId, "proj-commenterr"))
+        .all();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].title).toBe("#77: Comment will fail");
     });
 
     it("skips polling when github:token is not set", async () => {

--- a/packages/server/src/github/issue-monitor.ts
+++ b/packages/server/src/github/issue-monitor.ts
@@ -5,7 +5,7 @@ import type { ServerToClientEvents, ClientToServerEvents, KanbanTask } from "@ot
 import { MessageType } from "@otterbot/shared";
 import { getDb, schema } from "../db/index.js";
 import { getConfig, setConfig } from "../auth/auth.js";
-import { fetchAssignedIssues } from "./github-service.js";
+import { fetchAssignedIssues, createIssueComment } from "./github-service.js";
 import type { COO } from "../agents/coo.js";
 
 type TypedServer = Server<ClientToServerEvents, ServerToClientEvents>;
@@ -167,6 +167,21 @@ export class GitHubIssueMonitor {
             projectId,
           });
         }
+      }
+
+      // Post acknowledgement comment on the GitHub issue
+      try {
+        await createIssueComment(
+          watched.repo,
+          token,
+          issue.number,
+          `👀 I'm looking into this issue and will begin working on a fix shortly.`,
+        );
+      } catch (commentErr) {
+        console.error(
+          `[IssueMonitor] Failed to comment on issue #${issue.number}:`,
+          commentErr,
+        );
       }
 
       console.log(`[IssueMonitor] Created task for issue #${issue.number} in project ${projectId}`);


### PR DESCRIPTION
## Summary

- When the issue monitor detects a new assigned GitHub issue, it now posts an acknowledgement comment on that issue (e.g. "I'm looking into this issue and will begin working on a fix shortly")
- Comment failures are gracefully caught and logged without disrupting task creation or directive sending
- Adds 3 new unit tests covering the comment posting, skip-on-duplicate, and error resilience behaviors

Closes #112

## Test plan

- [x] New test: acknowledgement comment is posted when a new issue is accepted
- [x] New test: no comment is posted for already-tracked issues (deduplication)
- [x] New test: comment API failure does not prevent kanban task creation
- [x] All 335 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)