### PR TITLE
feat: list all agent types under Settings → Models

### DIFF
--- a/packages/server/src/agents/team-lead.ts
+++ b/packages/server/src/agents/team-lead.ts
@@ -31,6 +31,7 @@ import type { WorkspaceManager } from "../workspace/workspace.js";
 import { eq } from "drizzle-orm";
 import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
 import { execSync } from "node:child_process";
+import { getAgentModelOverride } from "../settings/settings.js";
 import { getConfiguredSearchProvider } from "../tools/search/providers.js";
 import { isDesktopEnabled } from "../desktop/desktop.js";
 import { TEAM_LEAD_PROMPT } from "./prompts/team-lead.js";
@@ -1363,10 +1364,12 @@ export class TeamLead extends BaseAgent {
         modelPackId: (entry as any).modelPackId ?? getRandomModelPackId(),
         gearConfig: (entry as any).gearConfig ? JSON.parse((entry as any).gearConfig) : null,
         model:
+          getAgentModelOverride(entry.id)?.model ??
           getConfig("worker_model") ??
           getConfig("coo_model") ??
           entry.defaultModel,
         provider:
+          getAgentModelOverride(entry.id)?.provider ??
           getConfig("worker_provider") ??
           getConfig("coo_provider") ??
           entry.defaultProvider,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -143,6 +143,9 @@ import {
   deleteCustomModel,
   applyGitSSHConfig,
   getClaudeCodeOAuthUsage,
+  getAgentModelOverrides,
+  setAgentModelOverride,
+  clearAgentModelOverride,
   type TierDefaults,
 } from "./settings/settings.js";
 import type { ProviderType } from "@otterbot/shared";
@@ -2279,6 +2282,26 @@ async function main() {
     Body: Partial<TierDefaults>;
   }>("/api/settings/defaults", async (req) => {
     updateTierDefaults(req.body);
+    return { ok: true };
+  });
+
+  // Per-agent model overrides
+  app.get("/api/settings/agent-model-overrides", async () => {
+    return { overrides: getAgentModelOverrides() };
+  });
+
+  app.put<{
+    Params: { registryEntryId: string };
+    Body: { provider: string; model: string };
+  }>("/api/settings/agent-model-overrides/:registryEntryId", async (req) => {
+    setAgentModelOverride(req.params.registryEntryId, req.body.provider, req.body.model);
+    return { ok: true };
+  });
+
+  app.delete<{
+    Params: { registryEntryId: string };
+  }>("/api/settings/agent-model-overrides/:registryEntryId", async (req) => {
+    clearAgentModelOverride(req.params.registryEntryId);
     return { ok: true };
   });
 

--- a/packages/server/src/settings/__tests__/agent-model-overrides.test.ts
+++ b/packages/server/src/settings/__tests__/agent-model-overrides.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// --- Mocks ---
+
+const configStore = new Map<string, string>();
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn((key: string) => configStore.get(key)),
+  setConfig: vi.fn((key: string, value: string) => configStore.set(key, value)),
+  deleteConfig: vi.fn((key: string) => configStore.delete(key)),
+}));
+
+vi.mock("../../opencode/opencode-manager.js", () => ({
+  ensureOpenCodeConfig: vi.fn(),
+  writeOpenCodeConfig: vi.fn(),
+}));
+
+vi.mock("../../tools/opencode-client.js", () => ({
+  OpenCodeClient: vi.fn().mockImplementation(() => ({
+    healthCheck: vi.fn().mockResolvedValue({ ok: true }),
+  })),
+}));
+
+vi.mock("../../coding-agents/claude-code-manager.js", () => ({
+  isClaudeCodeInstalled: vi.fn(() => false),
+  isClaudeCodeReady: vi.fn(() => false),
+}));
+
+vi.mock("../../coding-agents/codex-manager.js", () => ({
+  isCodexInstalled: vi.fn(() => false),
+  isCodexReady: vi.fn(() => false),
+}));
+
+// Mock DB — getAgentModelOverrides reads from the config table via raw select
+const mockConfigRows: Array<{ key: string; value: string }> = [];
+vi.mock("../../db/index.js", () => ({
+  getDb: vi.fn(() => ({
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        all: vi.fn(() => mockConfigRows),
+        where: vi.fn(() => ({
+          get: vi.fn(() => null),
+        })),
+      })),
+    })),
+  })),
+  schema: {
+    providers: {},
+    config: {},
+  },
+}));
+
+vi.mock("../../llm/adapter.js", () => ({
+  resolveModel: vi.fn(),
+}));
+
+vi.mock("../../tools/search/providers.js", () => ({
+  getConfiguredSearchProvider: vi.fn(() => null),
+}));
+
+vi.mock("../../tts/tts.js", () => ({
+  getConfiguredTTSProvider: vi.fn(() => null),
+}));
+
+vi.mock("../../stt/stt.js", () => ({
+  getConfiguredSTTProvider: vi.fn(() => null),
+}));
+
+import {
+  getAgentModelOverrides,
+  getAgentModelOverride,
+  setAgentModelOverride,
+  clearAgentModelOverride,
+} from "../settings.js";
+
+describe("Agent model overrides", () => {
+  beforeEach(() => {
+    configStore.clear();
+    mockConfigRows.length = 0;
+  });
+
+  describe("setAgentModelOverride", () => {
+    it("stores provider and model in config", () => {
+      setAgentModelOverride("builtin-web-search", "anthropic-1", "claude-opus-4-20250514");
+
+      expect(configStore.get("agent_override:builtin-web-search:provider")).toBe("anthropic-1");
+      expect(configStore.get("agent_override:builtin-web-search:model")).toBe("claude-opus-4-20250514");
+    });
+
+    it("overwrites existing override", () => {
+      setAgentModelOverride("builtin-coder", "openai-1", "gpt-4o");
+      setAgentModelOverride("builtin-coder", "anthropic-1", "claude-sonnet-4-5-20250929");
+
+      expect(configStore.get("agent_override:builtin-coder:provider")).toBe("anthropic-1");
+      expect(configStore.get("agent_override:builtin-coder:model")).toBe("claude-sonnet-4-5-20250929");
+    });
+  });
+
+  describe("getAgentModelOverride", () => {
+    it("returns null when no override is set", () => {
+      const result = getAgentModelOverride("builtin-web-search");
+      expect(result).toBeNull();
+    });
+
+    it("returns null when only provider is set (incomplete override)", () => {
+      configStore.set("agent_override:builtin-web-search:provider", "anthropic-1");
+      const result = getAgentModelOverride("builtin-web-search");
+      expect(result).toBeNull();
+    });
+
+    it("returns override when both provider and model are set", () => {
+      configStore.set("agent_override:builtin-web-search:provider", "anthropic-1");
+      configStore.set("agent_override:builtin-web-search:model", "claude-opus-4-20250514");
+
+      const result = getAgentModelOverride("builtin-web-search");
+      expect(result).toEqual({
+        registryEntryId: "builtin-web-search",
+        provider: "anthropic-1",
+        model: "claude-opus-4-20250514",
+      });
+    });
+  });
+
+  describe("clearAgentModelOverride", () => {
+    it("removes both provider and model from config", () => {
+      configStore.set("agent_override:builtin-coder:provider", "openai-1");
+      configStore.set("agent_override:builtin-coder:model", "gpt-4o");
+
+      clearAgentModelOverride("builtin-coder");
+
+      expect(configStore.has("agent_override:builtin-coder:provider")).toBe(false);
+      expect(configStore.has("agent_override:builtin-coder:model")).toBe(false);
+    });
+
+    it("does not error when clearing non-existent override", () => {
+      expect(() => clearAgentModelOverride("non-existent")).not.toThrow();
+    });
+  });
+
+  describe("getAgentModelOverrides", () => {
+    it("returns empty array when no overrides exist", () => {
+      const result = getAgentModelOverrides();
+      expect(result).toEqual([]);
+    });
+
+    it("returns all complete overrides from config rows", () => {
+      mockConfigRows.push(
+        { key: "agent_override:builtin-web-search:provider", value: "anthropic-1" },
+        { key: "agent_override:builtin-web-search:model", value: "claude-opus-4-20250514" },
+        { key: "agent_override:builtin-coder:provider", value: "openai-1" },
+        { key: "agent_override:builtin-coder:model", value: "gpt-4o" },
+      );
+
+      const result = getAgentModelOverrides();
+      expect(result).toHaveLength(2);
+      expect(result).toContainEqual({
+        registryEntryId: "builtin-web-search",
+        provider: "anthropic-1",
+        model: "claude-opus-4-20250514",
+      });
+      expect(result).toContainEqual({
+        registryEntryId: "builtin-coder",
+        provider: "openai-1",
+        model: "gpt-4o",
+      });
+    });
+
+    it("skips incomplete overrides (missing model)", () => {
+      mockConfigRows.push(
+        { key: "agent_override:builtin-web-search:provider", value: "anthropic-1" },
+        // No model for builtin-web-search
+        { key: "agent_override:builtin-coder:provider", value: "openai-1" },
+        { key: "agent_override:builtin-coder:model", value: "gpt-4o" },
+      );
+
+      const result = getAgentModelOverrides();
+      expect(result).toHaveLength(1);
+      expect(result[0].registryEntryId).toBe("builtin-coder");
+    });
+
+    it("ignores non-override config keys", () => {
+      mockConfigRows.push(
+        { key: "coo_provider", value: "anthropic-1" },
+        { key: "coo_model", value: "claude-sonnet-4-5-20250929" },
+        { key: "agent_override:builtin-coder:provider", value: "openai-1" },
+        { key: "agent_override:builtin-coder:model", value: "gpt-4o" },
+      );
+
+      const result = getAgentModelOverrides();
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("round-trip", () => {
+    it("set then get returns the override", () => {
+      setAgentModelOverride("builtin-web-search", "anthropic-1", "claude-opus-4-20250514");
+
+      const result = getAgentModelOverride("builtin-web-search");
+      expect(result).toEqual({
+        registryEntryId: "builtin-web-search",
+        provider: "anthropic-1",
+        model: "claude-opus-4-20250514",
+      });
+    });
+
+    it("set then clear then get returns null", () => {
+      setAgentModelOverride("builtin-web-search", "anthropic-1", "claude-opus-4-20250514");
+      clearAgentModelOverride("builtin-web-search");
+
+      const result = getAgentModelOverride("builtin-web-search");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -30,3 +30,10 @@ export interface ModelOption {
   label?: string;
   source: "discovered" | "custom";
 }
+
+/** Per-agent-type model/provider override (stored in config table) */
+export interface AgentModelOverride {
+  registryEntryId: string;
+  provider: string;
+  model: string;
+}

--- a/packages/web/src/components/settings/ModelsTab.tsx
+++ b/packages/web/src/components/settings/ModelsTab.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useSettingsStore } from "../../stores/settings-store";
 import { ModelCombobox } from "./ModelCombobox";
 import { ModelPricingPrompt } from "./ModelPricingPrompt";
+import type { RegistryEntry } from "@otterbot/shared";
 
 const TIER_LABELS: Record<string, { label: string; hint: string; tip?: string }> = {
   coo: {
@@ -20,6 +21,12 @@ const TIER_LABELS: Record<string, { label: string; hint: string; tip?: string }>
   },
 };
 
+const ROLE_LABELS: Record<string, string> = {
+  coo: "COO",
+  team_lead: "Team Lead",
+  worker: "Worker",
+};
+
 export function ModelsTab() {
   const defaults = useSettingsStore((s) => s.defaults);
   const providers = useSettingsStore((s) => s.providers);
@@ -30,6 +37,10 @@ export function ModelsTab() {
   const loadCustomModels = useSettingsStore((s) => s.loadCustomModels);
   const createCustomModel = useSettingsStore((s) => s.createCustomModel);
   const deleteCustomModel = useSettingsStore((s) => s.deleteCustomModel);
+  const agentModelOverrides = useSettingsStore((s) => s.agentModelOverrides);
+  const loadAgentModelOverrides = useSettingsStore((s) => s.loadAgentModelOverrides);
+  const setAgentModelOverride = useSettingsStore((s) => s.setAgentModelOverride);
+  const clearAgentModelOverride = useSettingsStore((s) => s.clearAgentModelOverride);
 
   const [form, setForm] = useState({
     coo: { ...defaults.coo },
@@ -43,6 +54,9 @@ export function ModelsTab() {
   const [cmProviderId, setCmProviderId] = useState("");
   const [cmModelId, setCmModelId] = useState("");
   const [cmLabel, setCmLabel] = useState("");
+
+  // Agent registry entries
+  const [registryEntries, setRegistryEntries] = useState<RegistryEntry[]>([]);
 
   // Sync form when settings reload
   useEffect(() => {
@@ -66,6 +80,15 @@ export function ModelsTab() {
       setCmProviderId(providers[0].id);
     }
   }, [providers]);
+
+  // Load registry entries and agent overrides
+  useEffect(() => {
+    loadAgentModelOverrides();
+    fetch("/api/registry")
+      .then((res) => res.json())
+      .then((data) => setRegistryEntries(data))
+      .catch(() => {});
+  }, []);
 
   const handleProviderChange = (
     tier: "coo" | "teamLead" | "worker",
@@ -189,6 +212,18 @@ export function ModelsTab() {
         )}
       </div>
 
+      {/* Agent Model Assignments */}
+      <AgentModelAssignments
+        entries={registryEntries}
+        providers={providers}
+        models={models}
+        overrides={agentModelOverrides}
+        defaults={defaults}
+        fetchModels={fetchModels}
+        onSetOverride={setAgentModelOverride}
+        onClearOverride={clearAgentModelOverride}
+      />
+
       {/* Custom Models section */}
       <div className="border-t border-border pt-6 space-y-4">
         <div>
@@ -290,6 +325,238 @@ export function ModelsTab() {
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Agent Model Assignments sub-component
+// ---------------------------------------------------------------------------
+
+interface AgentModelAssignmentsProps {
+  entries: RegistryEntry[];
+  providers: { id: string; name: string; type: string; apiKeySet: boolean }[];
+  models: Record<string, { modelId: string; label?: string; source: string }[]>;
+  overrides: { registryEntryId: string; provider: string; model: string }[];
+  defaults: {
+    coo: { provider: string; model: string };
+    teamLead: { provider: string; model: string };
+    worker: { provider: string; model: string };
+  };
+  fetchModels: (providerId: string) => Promise<void>;
+  onSetOverride: (registryEntryId: string, provider: string, model: string) => Promise<void>;
+  onClearOverride: (registryEntryId: string) => Promise<void>;
+}
+
+function AgentModelAssignments({
+  entries,
+  providers,
+  models,
+  overrides,
+  defaults,
+  fetchModels,
+  onSetOverride,
+  onClearOverride,
+}: AgentModelAssignmentsProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editProvider, setEditProvider] = useState("");
+  const [editModel, setEditModel] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const grouped = useMemo(() => {
+    const core = entries.filter(
+      (e) => e.builtIn && (e.role === "coo" || e.role === "team_lead"),
+    );
+    const workers = entries.filter((e) => e.builtIn && e.role === "worker");
+    const custom = entries.filter((e) => !e.builtIn);
+    return { core, workers, custom };
+  }, [entries]);
+
+  const overrideMap = useMemo(() => {
+    const map = new Map<string, { provider: string; model: string }>();
+    for (const o of overrides) {
+      map.set(o.registryEntryId, { provider: o.provider, model: o.model });
+    }
+    return map;
+  }, [overrides]);
+
+  const getEffective = (entry: RegistryEntry) => {
+    const override = overrideMap.get(entry.id);
+    if (override) return { ...override, source: "override" as const };
+    const tierKey = entry.role === "coo" ? "coo" : entry.role === "team_lead" ? "teamLead" : "worker";
+    const tier = defaults[tierKey as keyof typeof defaults];
+    if (tier.provider && tier.model) return { ...tier, source: "tier" as const };
+    return { provider: defaults.coo.provider, model: defaults.coo.model, source: "coo" as const };
+  };
+
+  const startEdit = (entry: RegistryEntry) => {
+    const override = overrideMap.get(entry.id);
+    const effective = getEffective(entry);
+    setEditProvider(override?.provider ?? effective.provider);
+    setEditModel(override?.model ?? effective.model);
+    setEditingId(entry.id);
+    // Ensure models are fetched for the provider
+    const pid = override?.provider ?? effective.provider;
+    if (pid && !models[pid]) {
+      fetchModels(pid);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!editingId || !editProvider || !editModel) return;
+    setSaving(true);
+    await onSetOverride(editingId, editProvider, editModel);
+    setSaving(false);
+    setEditingId(null);
+  };
+
+  const handleClear = async (registryEntryId: string) => {
+    await onClearOverride(registryEntryId);
+    if (editingId === registryEntryId) {
+      setEditingId(null);
+    }
+  };
+
+  if (entries.length === 0) return null;
+
+  const renderGroup = (label: string, items: RegistryEntry[]) => {
+    if (items.length === 0) return null;
+    return (
+      <div key={label} className="space-y-2">
+        <h4 className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
+          {label}
+        </h4>
+        {items.map((entry) => {
+          const effective = getEffective(entry);
+          const hasOverride = overrideMap.has(entry.id);
+          const isEditing = editingId === entry.id;
+          const providerName =
+            providers.find((p) => p.id === effective.provider)?.name ?? effective.provider;
+
+          return (
+            <div
+              key={entry.id}
+              className="border border-border rounded-lg p-3 space-y-2"
+              data-testid={`agent-entry-${entry.id}`}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">{entry.name}</span>
+                  <span className="text-[9px] uppercase tracking-wider text-muted-foreground bg-secondary px-1.5 py-0.5 rounded">
+                    {ROLE_LABELS[entry.role] ?? entry.role}
+                  </span>
+                  {hasOverride && (
+                    <span className="text-[9px] uppercase tracking-wider text-primary bg-primary/10 px-1.5 py-0.5 rounded">
+                      Custom
+                    </span>
+                  )}
+                </div>
+                <div className="flex gap-1">
+                  {!isEditing && (
+                    <button
+                      onClick={() => startEdit(entry)}
+                      className="text-xs text-muted-foreground hover:text-foreground px-2 py-0.5 rounded hover:bg-secondary"
+                    >
+                      Edit
+                    </button>
+                  )}
+                  {hasOverride && !isEditing && (
+                    <button
+                      onClick={() => handleClear(entry.id)}
+                      className="text-xs text-destructive hover:bg-destructive/10 px-2 py-0.5 rounded"
+                    >
+                      Reset
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {!isEditing ? (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span className="bg-secondary px-1.5 py-0.5 rounded font-mono">
+                    {providerName}
+                  </span>
+                  <span className="bg-secondary px-1.5 py-0.5 rounded font-mono">
+                    {effective.model}
+                  </span>
+                  {!hasOverride && (
+                    <span className="text-[10px] italic">
+                      (using {effective.source === "tier" ? "tier" : "COO"} default)
+                    </span>
+                  )}
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+                        Provider
+                      </label>
+                      <select
+                        value={editProvider}
+                        onChange={(e) => {
+                          setEditProvider(e.target.value);
+                          if (!models[e.target.value]) {
+                            fetchModels(e.target.value);
+                          }
+                        }}
+                        className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary"
+                      >
+                        {providers.map((p) => (
+                          <option key={p.id} value={p.id}>
+                            {p.name} ({p.type})
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+                        Model
+                      </label>
+                      <ModelCombobox
+                        value={editModel}
+                        options={models[editProvider] ?? []}
+                        onChange={setEditModel}
+                        placeholder="Select or type a model..."
+                      />
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={handleSave}
+                      disabled={saving}
+                      className="text-xs bg-primary text-primary-foreground px-3 py-1 rounded-md hover:bg-primary/90 disabled:opacity-50"
+                    >
+                      {saving ? "Saving..." : "Save"}
+                    </button>
+                    <button
+                      onClick={() => setEditingId(null)}
+                      className="text-xs text-muted-foreground px-3 py-1 rounded-md hover:bg-secondary"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <div className="border-t border-border pt-6 space-y-4">
+      <div>
+        <h3 className="text-sm font-medium">Agent Model Assignments</h3>
+        <p className="text-[10px] text-muted-foreground">
+          Override the model for specific agent types. Agents without a custom override
+          use their tier default (which falls back to the COO default).
+        </p>
+      </div>
+      {renderGroup("Core", grouped.core)}
+      {renderGroup("Workers", grouped.workers)}
+      {renderGroup("Custom", grouped.custom)}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds per-agent model/provider override system so users can assign specific models to individual agent types (e.g. web search agent, coder) from Settings → Models
- Displays all registry entries (core, workers, custom) grouped in the Models tab with current model/provider and edit/reset controls
- Stores overrides in the config table (`agent_override:{id}:provider` / `agent_override:{id}:model`) and applies them at worker spawn time before tier defaults

Closes #95

## Changes
- **`packages/shared/src/types/provider.ts`** — Added `AgentModelOverride` interface
- **`packages/server/src/settings/settings.ts`** — Added `get/set/clearAgentModelOverride` and `getAgentModelOverrides` functions
- **`packages/server/src/index.ts`** — Added `GET/PUT/DELETE /api/settings/agent-model-overrides` endpoints
- **`packages/server/src/agents/team-lead.ts`** — Worker spawn now checks per-agent overrides before tier defaults
- **`packages/web/src/stores/settings-store.ts`** — Added override state and actions to the Zustand store
- **`packages/web/src/components/settings/ModelsTab.tsx`** — Added "Agent Model Assignments" section listing all agent types with edit/reset controls

## Test plan
- [x] 13 new unit tests covering `get/set/clear` round-trips, incomplete overrides, and bulk listing
- [x] All 345 existing tests continue to pass
- [ ] Manual: Navigate to Settings → Models, verify all agent types are listed
- [ ] Manual: Set a custom model for an agent type, verify it persists and shows "Custom" badge
- [ ] Manual: Reset an override, verify it falls back to tier default

🤖 Generated with [Claude Code](https://claude.com/claude-code)