### PR TITLE
fix: display project name on 3D zone label instead of 'Project Office'

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -486,7 +486,7 @@ async function main() {
         onProjectCreated: (project) => {
           emitProjectCreated(io, project);
           // Auto-create a zone for the new project
-          const zone = worldLayout.addZone(project.id);
+          const zone = worldLayout.addZone(project.id, undefined, project.name);
           if (zone) {
             io.emit("world:zone-added", { zone });
           }
@@ -686,7 +686,7 @@ async function main() {
         for (const project of activeProjects) {
           const existing = worldLayout.loadZoneConfig(project.id);
           if (!existing) {
-            const zone = worldLayout.addZone(project.id);
+            const zone = worldLayout.addZone(project.id, undefined, project.name);
             if (zone) {
               io.emit("world:zone-added", { zone });
               console.log(`[world] Recreated office zone for project "${project.name}" (${project.id})`);

--- a/packages/server/src/models3d/__tests__/extract-project-label.test.ts
+++ b/packages/server/src/models3d/__tests__/extract-project-label.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { extractProjectLabel } from "../world-layout.js";
+
+describe("extractProjectLabel", () => {
+  it("strips the 6-char nanoid suffix from a project ID", () => {
+    expect(extractProjectLabel("awesome-a7kh9d")).toBe("awesome");
+  });
+
+  it("handles multi-segment slugs", () => {
+    expect(extractProjectLabel("my-cool-project-a7kh9d")).toBe("my-cool-project");
+  });
+
+  it("returns the full ID when there is no 6-char suffix", () => {
+    expect(extractProjectLabel("standalone")).toBe("standalone");
+  });
+
+  it("returns the full ID when the suffix is not exactly 6 chars", () => {
+    expect(extractProjectLabel("project-abc")).toBe("project-abc");
+    expect(extractProjectLabel("project-abcdefgh")).toBe("project-abcdefgh");
+  });
+
+  it("handles an ID that is only a nanoid (no slug prefix)", () => {
+    // nanoid(6) alone has no hyphen, so it should be returned as-is
+    expect(extractProjectLabel("a7kh9d")).toBe("a7kh9d");
+  });
+});


### PR DESCRIPTION
## Summary

- The glowing perimeter label in the 3D Live View was hardcoded to **"Project Office"** for every project zone, regardless of the actual project name
- Now extracts the human-readable prefix from the project ID (e.g. `awesome` from `awesome-a7kh9d`) and displays it as the zone label
- When the full project name is available from callers (project creation and startup recovery), it is passed through directly for maximum accuracy
- Added `extractProjectLabel()` utility with unit tests

Closes #111

## Test plan

- [x] All 337 existing tests pass
- [x] New `extractProjectLabel` unit tests cover: single-segment slugs, multi-segment slugs, no-suffix IDs, wrong-length suffixes, bare nanoid inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)