### PR TITLE
feat: add clear all memories button to memory settings page

### DIFF
--- a/packages/server/src/memory/__tests__/memory-clear-all.test.ts
+++ b/packages/server/src/memory/__tests__/memory-clear-all.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// --- In-memory mock DB rows ---
+let memoryRows: Array<{ id: string; category: string; content: string; source: string; agentScope: string | null; projectId: string | null; importance: number; accessCount: number; lastAccessedAt: string | null; createdAt: string; updatedAt: string }> = [];
+let ftsRows: Array<{ id: string; content: string; category: string }> = [];
+
+const mockRun = vi.fn((sql?: any) => ({ changes: memoryRows.length }));
+const mockAll = vi.fn(() => memoryRows.map((r) => ({ id: r.id })));
+
+vi.mock("../../db/index.js", () => ({
+  getDb: vi.fn(() => ({
+    select: vi.fn((...cols: any[]) => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          get: vi.fn(() => memoryRows[0] ?? null),
+          all: vi.fn(() => memoryRows),
+        })),
+        orderBy: vi.fn(() => ({
+          all: vi.fn(() => memoryRows),
+          limit: vi.fn(() => ({
+            all: vi.fn(() => memoryRows),
+          })),
+        })),
+        all: vi.fn(() => memoryRows.map((r) => ({ id: r.id }))),
+        get: vi.fn(() => memoryRows[0] ?? null),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        run: vi.fn(() => {
+          const id = `mem_${memoryRows.length + 1}`;
+          memoryRows.push({
+            id,
+            category: "general",
+            content: "test",
+            source: "user",
+            agentScope: null,
+            projectId: null,
+            importance: 5,
+            accessCount: 0,
+            lastAccessedAt: null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          });
+          return { changes: 1 };
+        }),
+      })),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn(() => ({
+        run: vi.fn(() => {
+          const count = memoryRows.length;
+          memoryRows = [];
+          return { changes: count };
+        }),
+      })),
+      run: vi.fn(() => {
+        const count = memoryRows.length;
+        memoryRows = [];
+        return { changes: count };
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          run: vi.fn(),
+        })),
+      })),
+    })),
+    run: vi.fn(),
+    all: vi.fn(() => []),
+  })),
+  schema: {
+    memories: {
+      id: "id",
+      category: "category",
+      content: "content",
+      source: "source",
+      agentScope: "agentScope",
+      projectId: "projectId",
+      importance: "importance",
+      accessCount: "accessCount",
+      lastAccessedAt: "lastAccessedAt",
+      createdAt: "createdAt",
+      updatedAt: "updatedAt",
+    },
+  },
+}));
+
+const mockVectorRemove = vi.fn();
+vi.mock("../vector-store.js", () => ({
+  getVectorStore: vi.fn(() => ({
+    embedAndStore: vi.fn().mockResolvedValue(undefined),
+    remove: mockVectorRemove,
+    search: vi.fn().mockResolvedValue([]),
+    hybridRank: vi.fn(() => []),
+  })),
+}));
+
+// Must import after mocks
+const { MemoryService } = await import("../memory-service.js");
+
+describe("MemoryService.clearAll", () => {
+  let service: InstanceType<typeof MemoryService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    memoryRows = [];
+    ftsRows = [];
+    mockVectorRemove.mockClear();
+    service = new MemoryService();
+  });
+
+  it("returns 0 when no memories exist", () => {
+    const deleted = service.clearAll();
+    expect(deleted).toBe(0);
+  });
+
+  it("returns the number of deleted memories", () => {
+    memoryRows = [
+      { id: "m1", category: "fact", content: "The sky is blue", source: "user", agentScope: null, projectId: null, importance: 5, accessCount: 0, lastAccessedAt: null, createdAt: "2026-01-01", updatedAt: "2026-01-01" },
+      { id: "m2", category: "preference", content: "User likes dark mode", source: "user", agentScope: null, projectId: null, importance: 7, accessCount: 2, lastAccessedAt: "2026-01-02", createdAt: "2026-01-01", updatedAt: "2026-01-02" },
+      { id: "m3", category: "instruction", content: "Always use TypeScript", source: "agent", agentScope: "worker", projectId: "proj1", importance: 9, accessCount: 5, lastAccessedAt: "2026-01-03", createdAt: "2026-01-01", updatedAt: "2026-01-03" },
+    ];
+
+    const deleted = service.clearAll();
+    expect(deleted).toBe(3);
+  });
+
+  it("removes all entries from the vector store", () => {
+    memoryRows = [
+      { id: "m1", category: "fact", content: "Fact 1", source: "user", agentScope: null, projectId: null, importance: 5, accessCount: 0, lastAccessedAt: null, createdAt: "2026-01-01", updatedAt: "2026-01-01" },
+      { id: "m2", category: "fact", content: "Fact 2", source: "user", agentScope: null, projectId: null, importance: 5, accessCount: 0, lastAccessedAt: null, createdAt: "2026-01-01", updatedAt: "2026-01-01" },
+    ];
+
+    service.clearAll();
+    expect(mockVectorRemove).toHaveBeenCalledTimes(2);
+    expect(mockVectorRemove).toHaveBeenCalledWith("m1");
+    expect(mockVectorRemove).toHaveBeenCalledWith("m2");
+  });
+
+  it("clears the memories array after deletion", () => {
+    memoryRows = [
+      { id: "m1", category: "general", content: "Test", source: "user", agentScope: null, projectId: null, importance: 5, accessCount: 0, lastAccessedAt: null, createdAt: "2026-01-01", updatedAt: "2026-01-01" },
+    ];
+
+    service.clearAll();
+    expect(memoryRows).toHaveLength(0);
+  });
+});

--- a/packages/server/src/socket/handlers.ts
+++ b/packages/server/src/socket/handlers.ts
@@ -645,6 +645,15 @@ export function setupSocketHandlers(
       callback?.({ ok });
     });
 
+    socket.on("memory:clear-all", (callback) => {
+      try {
+        const deleted = memoryService.clearAll();
+        callback?.({ ok: true, deleted });
+      } catch (err) {
+        callback?.({ ok: false, deleted: 0, error: err instanceof Error ? err.message : String(err) });
+      }
+    });
+
     socket.on("memory:search", async (data, callback) => {
       const memories = await memoryService.searchWithVectors({
         query: data.query,

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -181,6 +181,9 @@ export interface ClientToServerEvents {
     data: { id: string },
     callback?: (ack: { ok: boolean; error?: string }) => void,
   ) => void;
+  "memory:clear-all": (
+    callback?: (ack: { ok: boolean; deleted: number; error?: string }) => void,
+  ) => void;
   "memory:search": (
     data: { query: string; agentScope?: string; projectId?: string; limit?: number },
     callback: (memories: Memory[]) => void,

--- a/packages/web/src/components/settings/MemoryTab.tsx
+++ b/packages/web/src/components/settings/MemoryTab.tsx
@@ -24,6 +24,7 @@ export function MemoryTab() {
   const [newCategory, setNewCategory] = useState("general");
   const [newImportance, setNewImportance] = useState(5);
   const [saving, setSaving] = useState(false);
+  const [clearing, setClearing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const socket = getSocket();
@@ -96,6 +97,20 @@ export function MemoryTab() {
     if (!confirm("Delete this memory?")) return;
     socket.emit("memory:delete", { id }, (ack) => {
       if (ack?.ok) loadMemories();
+    });
+  };
+
+  const handleClearAll = () => {
+    if (!confirm("Delete all memories? This action cannot be undone.")) return;
+    setClearing(true);
+    setError(null);
+    socket.emit("memory:clear-all", (ack) => {
+      setClearing(false);
+      if (ack?.ok) {
+        loadMemories();
+      } else {
+        setError(ack?.error ?? "Failed to clear memories");
+      }
     });
   };
 
@@ -311,9 +326,18 @@ export function MemoryTab() {
       </div>
 
       {memories.length > 0 && (
-        <p className="text-[10px] text-muted-foreground">
-          {memories.length} memor{memories.length === 1 ? "y" : "ies"}
-        </p>
+        <div className="flex items-center justify-between">
+          <p className="text-[10px] text-muted-foreground">
+            {memories.length} memor{memories.length === 1 ? "y" : "ies"}
+          </p>
+          <button
+            onClick={handleClearAll}
+            disabled={clearing}
+            className="px-3 py-1.5 text-xs text-red-400 bg-secondary border border-red-400/20 rounded hover:bg-red-500/20 transition-colors disabled:opacity-50"
+          >
+            {clearing ? "Clearing..." : "Clear All Memories"}
+          </button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds a `clearAll()` method to `MemoryService` that deletes all memories, FTS index entries, and vector store entries
- Adds `memory:clear-all` socket event with handler
- Adds a "Clear All Memories" button to the Memory settings tab with confirmation dialog, loading state, and error handling
- Includes unit tests for the new `clearAll` functionality

Closes #109

## Test plan
- [x] All 358 existing tests pass
- [x] New `memory-clear-all.test.ts` tests pass (4 tests)
- [ ] Manual: Navigate to Settings > Memory, verify "Clear All Memories" button appears when memories exist
- [ ] Manual: Click button, confirm dialog appears, memories are deleted and list refreshes
- [ ] Manual: Verify button shows "Clearing..." state during operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)