### PR TITLE
fix: queue 3D view animations instead of running in real time

### DIFF
--- a/packages/web/src/lib/animation-queue.test.ts
+++ b/packages/web/src/lib/animation-queue.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AnimationQueue, type QueuedMovement, type StartMovementFn, type IsMovingFn } from "./animation-queue";
+import type { WaypointGraph } from "@otterbot/shared";
+
+const dummyGraph: WaypointGraph = {
+  waypoints: [
+    { id: "a", position: [0, 0, 0], tag: "center" },
+    { id: "b", position: [3, 0, 0], tag: "desk" },
+  ],
+  edges: [{ from: "a", to: "b" }],
+};
+
+function makeMovement(from = "a", to = "b"): QueuedMovement {
+  return { graph: dummyGraph, fromWaypointId: from, toWaypointId: to };
+}
+
+describe("AnimationQueue", () => {
+  let startMovement: ReturnType<typeof vi.fn<StartMovementFn>>;
+  let movingAgents: Set<string>;
+  let isMoving: IsMovingFn;
+  let queue: AnimationQueue;
+
+  beforeEach(() => {
+    startMovement = vi.fn<StartMovementFn>(() => true);
+    movingAgents = new Set();
+    isMoving = (id) => movingAgents.has(id);
+    queue = new AnimationQueue(startMovement, isMoving, 1);
+  });
+
+  it("starts movement immediately when agent is idle", () => {
+    queue.enqueue("agent1", makeMovement());
+
+    expect(startMovement).toHaveBeenCalledOnce();
+    expect(startMovement).toHaveBeenCalledWith(
+      "agent1",
+      dummyGraph,
+      "a",
+      "b",
+      undefined,
+    );
+  });
+
+  it("queues movement when agent is already moving", () => {
+    movingAgents.add("agent1");
+    queue.enqueue("agent1", makeMovement());
+
+    // First enqueue while moving: should be queued, not started
+    expect(startMovement).not.toHaveBeenCalled();
+    expect(queue.queueLength("agent1")).toBe(1);
+  });
+
+  it("starts next movement after delay when current finishes", () => {
+    // Start first movement immediately
+    queue.enqueue("agent1", makeMovement("a", "b"));
+    expect(startMovement).toHaveBeenCalledOnce();
+
+    // Agent is now moving — enqueue a second movement
+    movingAgents.add("agent1");
+    queue.enqueue("agent1", makeMovement("b", "a"));
+    expect(startMovement).toHaveBeenCalledOnce(); // still just once
+    expect(queue.queueLength("agent1")).toBe(1);
+
+    // Movement finishes
+    movingAgents.delete("agent1");
+
+    // First tick: detects movement finished, starts delay
+    queue.tick(0.016);
+    expect(queue.isWaiting("agent1")).toBe(true);
+    expect(startMovement).toHaveBeenCalledOnce(); // still waiting
+
+    // Tick through most of the delay (not quite done)
+    queue.tick(0.9);
+    expect(queue.isWaiting("agent1")).toBe(true);
+    expect(startMovement).toHaveBeenCalledOnce();
+
+    // Tick past the remaining delay
+    queue.tick(0.2);
+    expect(queue.isWaiting("agent1")).toBe(false);
+    expect(startMovement).toHaveBeenCalledTimes(2);
+    expect(startMovement).toHaveBeenLastCalledWith(
+      "agent1",
+      dummyGraph,
+      "b",
+      "a",
+      undefined,
+    );
+    expect(queue.queueLength("agent1")).toBe(0);
+  });
+
+  it("processes multiple queued movements in order", () => {
+    queue.enqueue("agent1", makeMovement("a", "b"));
+    movingAgents.add("agent1");
+
+    queue.enqueue("agent1", makeMovement("b", "a"));
+    queue.enqueue("agent1", makeMovement("a", "b"));
+    expect(queue.queueLength("agent1")).toBe(2);
+
+    // Finish first movement
+    movingAgents.delete("agent1");
+    queue.tick(0.016); // detect finished
+    queue.tick(1.0); // finish delay
+
+    expect(startMovement).toHaveBeenCalledTimes(2);
+    expect(queue.queueLength("agent1")).toBe(1);
+
+    // Start second queued movement (agent is now moving again)
+    movingAgents.add("agent1");
+    movingAgents.delete("agent1");
+    queue.tick(0.016); // detect finished
+    queue.tick(1.0); // finish delay
+
+    expect(startMovement).toHaveBeenCalledTimes(3);
+    expect(queue.queueLength("agent1")).toBe(0);
+  });
+
+  it("handles independent agents separately", () => {
+    queue.enqueue("agent1", makeMovement("a", "b"));
+    queue.enqueue("agent2", makeMovement("a", "b"));
+
+    expect(startMovement).toHaveBeenCalledTimes(2);
+    expect(startMovement).toHaveBeenCalledWith("agent1", dummyGraph, "a", "b", undefined);
+    expect(startMovement).toHaveBeenCalledWith("agent2", dummyGraph, "a", "b", undefined);
+  });
+
+  it("cancel clears the queue and stops waiting", () => {
+    queue.enqueue("agent1", makeMovement("a", "b"));
+    movingAgents.add("agent1");
+    queue.enqueue("agent1", makeMovement("b", "a"));
+
+    queue.cancel("agent1");
+
+    expect(queue.queueLength("agent1")).toBe(0);
+    expect(queue.isWaiting("agent1")).toBe(false);
+  });
+
+  it("does not start movement when from and to are the same waypoint", () => {
+    // The AnimationQueue itself doesn't check this — it's checked in triggerMovement.
+    // But we verify the queue passes through the movement as-is.
+    queue.enqueue("agent1", makeMovement("a", "a"));
+    expect(startMovement).toHaveBeenCalledWith("agent1", dummyGraph, "a", "a", undefined);
+  });
+
+  it("respects custom delay between movements", () => {
+    const customQueue = new AnimationQueue(startMovement, isMoving, 2);
+
+    customQueue.enqueue("agent1", makeMovement("a", "b"));
+    movingAgents.add("agent1");
+    customQueue.enqueue("agent1", makeMovement("b", "a"));
+
+    movingAgents.delete("agent1");
+    customQueue.tick(0.016);
+    expect(customQueue.isWaiting("agent1")).toBe(true);
+
+    // 1 second is not enough with a 2-second delay
+    customQueue.tick(1.0);
+    expect(customQueue.isWaiting("agent1")).toBe(true);
+    expect(startMovement).toHaveBeenCalledOnce();
+
+    // 2 seconds total should be enough
+    customQueue.tick(1.1);
+    expect(customQueue.isWaiting("agent1")).toBe(false);
+    expect(startMovement).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes speed through to startMovement", () => {
+    const movement: QueuedMovement = {
+      graph: dummyGraph,
+      fromWaypointId: "a",
+      toWaypointId: "b",
+      speed: 5,
+    };
+    queue.enqueue("agent1", movement);
+    expect(startMovement).toHaveBeenCalledWith("agent1", dummyGraph, "a", "b", 5);
+  });
+
+  it("does not start delay if queue is empty when movement finishes", () => {
+    queue.enqueue("agent1", makeMovement("a", "b"));
+    movingAgents.add("agent1");
+
+    // Movement finishes, nothing queued
+    movingAgents.delete("agent1");
+    queue.tick(0.016);
+
+    // No delay should be active since there's nothing to wait for
+    // (waiting is set, but it's harmless — it just won't trigger anything)
+    // Enqueue now should start immediately after delay clears
+    queue.tick(1.0);
+    queue.enqueue("agent1", makeMovement("b", "a"));
+    expect(startMovement).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web/src/lib/animation-queue.ts
+++ b/packages/web/src/lib/animation-queue.ts
@@ -1,0 +1,141 @@
+import type { WaypointGraph } from "@otterbot/shared";
+
+export interface QueuedMovement {
+  graph: WaypointGraph;
+  fromWaypointId: string;
+  toWaypointId: string;
+  speed?: number;
+}
+
+interface AgentQueueState {
+  queue: QueuedMovement[];
+  /** Seconds remaining in the delay between movements */
+  delayRemaining: number;
+  /** Whether the agent is currently waiting between movements */
+  waiting: boolean;
+}
+
+export type StartMovementFn = (
+  agentId: string,
+  graph: WaypointGraph,
+  fromWaypointId: string,
+  toWaypointId: string,
+  speed?: number,
+) => boolean;
+
+export type IsMovingFn = (agentId: string) => boolean;
+
+/**
+ * Queues animation movements per agent instead of executing them immediately.
+ *
+ * When a movement is enqueued:
+ * - If the agent has no active movement, it starts immediately.
+ * - If the agent is already moving, the new movement is added to the queue.
+ *
+ * After each movement finishes, a configurable delay (default 1s) elapses
+ * before the next queued movement begins.
+ */
+export class AnimationQueue {
+  private agents = new Map<string, AgentQueueState>();
+  private delayBetween: number;
+  private startMovement: StartMovementFn;
+  private isMoving: IsMovingFn;
+
+  constructor(
+    startMovement: StartMovementFn,
+    isMoving: IsMovingFn,
+    delayBetween: number = 1,
+  ) {
+    this.startMovement = startMovement;
+    this.isMoving = isMoving;
+    this.delayBetween = delayBetween;
+  }
+
+  /**
+   * Add a movement to an agent's queue. If the agent is idle, it starts immediately.
+   */
+  enqueue(agentId: string, movement: QueuedMovement): void {
+    let state = this.agents.get(agentId);
+    if (!state) {
+      state = { queue: [], delayRemaining: 0, waiting: false };
+      this.agents.set(agentId, state);
+    }
+
+    // If the agent is not moving and not waiting, start immediately
+    if (!this.isMoving(agentId) && !state.waiting && state.queue.length === 0) {
+      this.startMovement(
+        agentId,
+        movement.graph,
+        movement.fromWaypointId,
+        movement.toWaypointId,
+        movement.speed,
+      );
+    } else {
+      state.queue.push(movement);
+    }
+  }
+
+  /**
+   * Process the queue each frame. Call this from the render loop with the frame delta (seconds).
+   *
+   * For each agent:
+   * - If waiting (delay between movements), count down the delay.
+   * - If not moving and not waiting and queue has items, start the next movement.
+   * - If a movement just finished, begin the delay timer.
+   */
+  tick(delta: number): void {
+    for (const [agentId, state] of this.agents) {
+      const moving = this.isMoving(agentId);
+
+      if (state.waiting) {
+        state.delayRemaining -= delta;
+        if (state.delayRemaining <= 0) {
+          state.waiting = false;
+          state.delayRemaining = 0;
+          // Start next queued movement if any
+          this.processNext(agentId, state);
+        }
+        continue;
+      }
+
+      if (!moving && state.queue.length > 0) {
+        // Movement just finished — start the inter-movement delay
+        state.waiting = true;
+        state.delayRemaining = this.delayBetween;
+      }
+    }
+  }
+
+  private processNext(agentId: string, state: AgentQueueState): void {
+    if (state.queue.length === 0) return;
+    const next = state.queue.shift()!;
+    this.startMovement(
+      agentId,
+      next.graph,
+      next.fromWaypointId,
+      next.toWaypointId,
+      next.speed,
+    );
+  }
+
+  /**
+   * Cancel all queued movements for an agent.
+   */
+  cancel(agentId: string): void {
+    this.agents.delete(agentId);
+  }
+
+  /**
+   * Get the number of queued (pending) movements for an agent.
+   */
+  queueLength(agentId: string): number {
+    return this.agents.get(agentId)?.queue.length ?? 0;
+  }
+
+  /**
+   * Check whether an agent is in the delay period between movements.
+   */
+  isWaiting(agentId: string): boolean {
+    return this.agents.get(agentId)?.waiting ?? false;
+  }
+}

--- a/packages/web/src/lib/movement-triggers.ts
+++ b/packages/web/src/lib/movement-triggers.ts
@@ -114,7 +114,7 @@ function triggerMovement(
   toWaypointId: string,
 ) {
   if (fromWaypointId === toWaypointId) return;
-  useMovementStore.getState().startMovement(agentId, graph, fromWaypointId, toWaypointId);
+  useMovementStore.getState().enqueueMovement(agentId, graph, fromWaypointId, toWaypointId);
 }
 
 /**

--- a/packages/web/src/stores/movement-store.ts
+++ b/packages/web/src/stores/movement-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type { WaypointGraph } from "@otterbot/shared";
 import { findPath } from "../lib/pathfinding";
 import { PathInterpolator, type InterpolatorState } from "../lib/path-interpolator";
+import { AnimationQueue } from "../lib/animation-queue";
 
 export interface MovementEntry {
   interpolator: PathInterpolator;
@@ -11,6 +12,16 @@ export interface MovementEntry {
 interface MovementState {
   movements: Map<string, MovementEntry>;
 
+  /** Queue a movement for an agent. If already moving, the new movement waits. */
+  enqueueMovement: (
+    agentId: string,
+    graph: WaypointGraph,
+    fromWaypointId: string,
+    toWaypointId: string,
+    speed?: number,
+  ) => void;
+
+  /** Start a movement immediately (used internally by the queue). */
   startMovement: (
     agentId: string,
     graph: WaypointGraph,
@@ -24,12 +35,32 @@ interface MovementState {
   getAgentPosition: (agentId: string) => InterpolatorState | null;
 
   cancelMovement: (agentId: string) => void;
+
+  /** Exposed for testing / inspection */
+  animationQueue: AnimationQueue;
 }
 
-export const useMovementStore = create<MovementState>((set, get) => ({
-  movements: new Map(),
+function createAnimationQueue(
+  startMovement: MovementState["startMovement"],
+  getMovements: () => Map<string, MovementEntry>,
+): AnimationQueue {
+  return new AnimationQueue(
+    startMovement,
+    (agentId) => {
+      const entry = getMovements().get(agentId);
+      return entry != null && !entry.interpolator.finished;
+    },
+  );
+}
 
-  startMovement: (agentId, graph, fromWaypointId, toWaypointId, speed = 3) => {
+export const useMovementStore = create<MovementState>((set, get) => {
+  const startMovement: MovementState["startMovement"] = (
+    agentId,
+    graph,
+    fromWaypointId,
+    toWaypointId,
+    speed = 3,
+  ) => {
     const path = findPath(graph, fromWaypointId, toWaypointId);
     if (!path || path.length < 2) return false;
 
@@ -40,44 +71,70 @@ export const useMovementStore = create<MovementState>((set, get) => ({
     movements.set(agentId, { interpolator, state });
     set({ movements });
     return true;
-  },
+  };
 
-  tick: (delta) => {
-    const movements = get().movements;
-    if (movements.size === 0) return;
+  const animationQueue = createAnimationQueue(
+    startMovement,
+    () => get().movements,
+  );
 
-    const next = new Map(movements);
-    let changed = false;
+  return {
+    movements: new Map(),
+    animationQueue,
+    startMovement,
 
-    for (const [agentId, entry] of next) {
-      if (entry.interpolator.finished) {
-        next.delete(agentId);
-        changed = true;
-        continue;
+    enqueueMovement: (agentId, graph, fromWaypointId, toWaypointId, speed) => {
+      animationQueue.enqueue(agentId, {
+        graph,
+        fromWaypointId,
+        toWaypointId,
+        speed,
+      });
+    },
+
+    tick: (delta) => {
+      const movements = get().movements;
+
+      // Tick active interpolators
+      if (movements.size > 0) {
+        const next = new Map(movements);
+        let changed = false;
+
+        for (const [agentId, entry] of next) {
+          if (entry.interpolator.finished) {
+            next.delete(agentId);
+            changed = true;
+            continue;
+          }
+
+          const state = entry.interpolator.update(delta);
+          next.set(agentId, { ...entry, state });
+          changed = true;
+
+          if (entry.interpolator.finished) {
+            next.delete(agentId);
+          }
+        }
+
+        if (changed) {
+          set({ movements: next });
+        }
       }
 
-      const state = entry.interpolator.update(delta);
-      next.set(agentId, { ...entry, state });
-      changed = true;
+      // Process the animation queue (delays + next movements)
+      animationQueue.tick(delta);
+    },
 
-      if (entry.interpolator.finished) {
-        next.delete(agentId);
-      }
-    }
+    getAgentPosition: (agentId) => {
+      const entry = get().movements.get(agentId);
+      return entry?.state ?? null;
+    },
 
-    if (changed) {
-      set({ movements: next });
-    }
-  },
-
-  getAgentPosition: (agentId) => {
-    const entry = get().movements.get(agentId);
-    return entry?.state ?? null;
-  },
-
-  cancelMovement: (agentId) => {
-    const movements = new Map(get().movements);
-    movements.delete(agentId);
-    set({ movements });
-  },
-}));
+    cancelMovement: (agentId) => {
+      animationQueue.cancel(agentId);
+      const movements = new Map(get().movements);
+      movements.delete(agentId);
+      set({ movements });
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- Adds an `AnimationQueue` class that queues per-agent movements with a 1-second delay between them, preventing teleportation when multiple status changes occur in quick succession
- Updates `movement-store` to expose `enqueueMovement` and integrates the queue into the tick loop
- Updates `movement-triggers` to call `enqueueMovement` instead of `startMovement`

Closes #121

## Test plan
- [x] New unit tests for `AnimationQueue` covering: immediate start when idle, queuing when busy, delay between movements, cancel, multi-agent independence, custom delay, speed passthrough
- [x] All 364 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)