### PR TITLE
feat: add Google Gemini LLM provider

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.1.9",
+    "@ai-sdk/google": "^3.0.30",
     "@ai-sdk/openai": "^1.1.14",
     "@ai-sdk/openai-compatible": "^0.1.8",
     "@andresaya/edge-tts": "^1.8.0",

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -258,7 +258,7 @@ export const providers = sqliteTable("providers", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   type: text("type", {
-    enum: ["anthropic", "openai", "ollama", "openai-compatible", "openrouter"],
+    enum: ["anthropic", "openai", "google", "ollama", "openai-compatible", "openrouter"],
   }).notNull(),
   apiKey: text("api_key"),
   baseUrl: text("base_url"),

--- a/packages/server/src/llm/__tests__/google-gemini-provider.test.ts
+++ b/packages/server/src/llm/__tests__/google-gemini-provider.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Unit tests for the Google Gemini LLM provider integration.
+ *
+ * These tests verify that:
+ * - resolveModel correctly creates a Google Gemini language model
+ * - Provider credentials are resolved properly
+ * - Configuration (provider type metadata, fallback models) is correct
+ * - Error handling works for unknown/misconfigured providers
+ */
+
+// ---------------------------------------------------------------------------
+// Mock the DB and auth layers so we can test resolveModel in isolation
+// ---------------------------------------------------------------------------
+
+vi.mock("../../db/index.js", () => ({
+  getDb: vi.fn(() => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          get: () => undefined,
+        }),
+      }),
+    }),
+  })),
+  schema: {
+    providers: { id: "id" },
+  },
+}));
+
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn(() => null),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the AI SDK providers to avoid real API calls
+// ---------------------------------------------------------------------------
+
+const mockGoogleModel = { modelId: "gemini-2.5-flash", provider: "google" };
+const mockCreateGoogleGenerativeAI = vi.fn(() =>
+  vi.fn((model: string) => ({ ...mockGoogleModel, modelId: model })),
+);
+
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: mockCreateGoogleGenerativeAI,
+}));
+
+// Also mock other providers that are imported at module level
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => vi.fn()),
+}));
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: vi.fn(() => vi.fn()),
+}));
+vi.mock("@ai-sdk/openai-compatible", () => ({
+  createOpenAICompatible: vi.fn(() => vi.fn()),
+}));
+vi.mock("ollama-ai-provider", () => ({
+  createOllama: vi.fn(() => vi.fn()),
+}));
+
+describe("Google Gemini provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("resolveModel", () => {
+    it("creates a Google Gemini model when provider type is 'google'", async () => {
+      const { resolveModel } = await import("../adapter.js");
+
+      const model = resolveModel({
+        provider: "google",
+        model: "gemini-2.5-flash",
+        apiKey: "test-api-key",
+      });
+
+      expect(mockCreateGoogleGenerativeAI).toHaveBeenCalledWith({
+        apiKey: "test-api-key",
+      });
+      expect(model).toMatchObject({ modelId: "gemini-2.5-flash" });
+    });
+
+    it("passes the correct model ID for different Gemini models", async () => {
+      const { resolveModel } = await import("../adapter.js");
+
+      const model = resolveModel({
+        provider: "google",
+        model: "gemini-2.5-pro",
+        apiKey: "test-key",
+      });
+
+      expect(model).toMatchObject({ modelId: "gemini-2.5-pro" });
+    });
+
+    it("uses an empty string when no API key is provided", async () => {
+      const { resolveModel } = await import("../adapter.js");
+
+      resolveModel({
+        provider: "google",
+        model: "gemini-2.0-flash",
+      });
+
+      expect(mockCreateGoogleGenerativeAI).toHaveBeenCalledWith({
+        apiKey: "",
+      });
+    });
+  });
+
+  describe("resolveProviderCredentials", () => {
+    it("falls back to legacy config when provider is not in DB", async () => {
+      const { resolveProviderCredentials } = await import("../adapter.js");
+
+      const creds = resolveProviderCredentials("google");
+      expect(creds.type).toBe("google");
+    });
+  });
+
+  describe("isThinkingModel", () => {
+    it("returns false for Google Gemini models", async () => {
+      const { isThinkingModel } = await import("../adapter.js");
+
+      expect(isThinkingModel({ provider: "google", model: "gemini-2.5-flash" })).toBe(false);
+      expect(isThinkingModel({ provider: "google", model: "gemini-2.5-pro" })).toBe(false);
+    });
+  });
+});
+
+describe("Google Gemini provider configuration", () => {
+  it("includes google in PROVIDER_TYPE_META", async () => {
+    // Import dynamically to get the mocked version
+    const { PROVIDER_TYPE_META } = await import("../../settings/settings.js");
+
+    const googleMeta = PROVIDER_TYPE_META.find((m) => m.type === "google");
+    expect(googleMeta).toBeDefined();
+    expect(googleMeta!.label).toBe("Google Gemini");
+    expect(googleMeta!.needsApiKey).toBe(true);
+    expect(googleMeta!.needsBaseUrl).toBe(false);
+  });
+
+  it("has fallback models for google provider", async () => {
+    const { fetchModelsWithCredentials } = await import("../../settings/settings.js");
+
+    // Without an API key, should return fallback models
+    const models = await fetchModelsWithCredentials("google");
+    expect(models.length).toBeGreaterThan(0);
+    expect(models).toContain("gemini-2.5-flash");
+    expect(models).toContain("gemini-2.5-pro");
+  });
+});
+
+describe("Google Gemini error handling", () => {
+  it("throws for unknown provider type", async () => {
+    const { resolveModel } = await import("../adapter.js");
+
+    expect(() =>
+      resolveModel({
+        provider: "nonexistent-provider",
+        model: "some-model",
+      }),
+    ).toThrow(/Unknown LLM provider/);
+  });
+});

--- a/packages/server/src/llm/adapter.ts
+++ b/packages/server/src/llm/adapter.ts
@@ -1,4 +1,5 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createOllama } from "ollama-ai-provider";
@@ -84,6 +85,13 @@ export function resolveModel(config: LLMConfig): LanguageModel {
         ...(baseUrl ? { baseURL: baseUrl } : {}),
       });
       return openai(config.model);
+    }
+
+    case "google": {
+      const google = createGoogleGenerativeAI({
+        apiKey: config.apiKey ?? resolved.apiKey ?? "",
+      });
+      return google(config.model);
     }
 
     case "ollama": {

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -1,4 +1,4 @@
-export type ProviderType = "anthropic" | "openai" | "ollama" | "openai-compatible" | "openrouter";
+export type ProviderType = "anthropic" | "openai" | "google" | "ollama" | "openai-compatible" | "openrouter";
 
 export interface NamedProvider {
   id: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^1.1.9
         version: 1.2.12(zod@3.25.76)
+      '@ai-sdk/google':
+        specifier: ^3.0.30
+        version: 3.0.30(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^1.1.14
         version: 1.3.24(zod@3.25.76)
@@ -278,6 +281,12 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
+  '@ai-sdk/google@3.0.30':
+    resolution: {integrity: sha512-ZzG6dU0XUSSXbxQJJTQUFpWeKkfzdpR7IykEZwaiaW5d+3u3RZ/zkRiGwAOcUpLp6k0eMd+IJF4looJv21ecxw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai-compatible@0.1.17':
     resolution: {integrity: sha512-e60+yxQ29e8RlsTWBW4kLuQJMpVJzH5+cpOeUXLXU6M9wc8BOQCyYg4jYh2ldnfvYCKXYxb2kYeLW7L9fqhhMw==}
     engines: {node: '>=18'}
@@ -305,12 +314,22 @@ packages:
     peerDependencies:
       zod: ^3.23.8
 
+  '@ai-sdk/provider-utils@4.0.15':
+    resolution: {integrity: sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@1.0.12':
     resolution: {integrity: sha512-88Uu1zJIE1UUOVJWfE2ybJXgiH8JJ97QY9fbmplErEbfa/k/1kF+tWMVAAJolF2aOGmazQGyQLhv4I9CCuVACw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@1.1.3':
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@1.2.12':
@@ -4805,6 +4824,12 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/google@3.0.30(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/openai-compatible@0.1.17(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.0.12
@@ -4833,11 +4858,22 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@4.0.15(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
   '@ai-sdk/provider@1.0.12':
     dependencies:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 


### PR DESCRIPTION
## Summary
- Adds `@ai-sdk/google` (Vercel AI SDK Google provider) as a dependency for Gemini API integration
- Introduces `"google"` as a new `ProviderType` across the shared types, DB schema, LLM adapter, and settings module
- Supports all Gemini models (2.5 Flash, 2.5 Pro, 2.0 Flash, etc.) with API-based model discovery and static fallbacks
- Includes unit tests covering model resolution, credential handling, configuration metadata, fallback models, and error cases

## Changes
- **`packages/shared/src/types/provider.ts`** — Added `"google"` to `ProviderType` union
- **`packages/server/src/db/schema.ts`** — Added `"google"` to the providers table type enum
- **`packages/server/src/llm/adapter.ts`** — Added `@ai-sdk/google` import and `"google"` case in `resolveModel()`
- **`packages/server/src/settings/settings.ts`** — Added Google Gemini provider metadata, fallback models, and model discovery via the Generative Language API
- **`packages/server/src/llm/__tests__/google-gemini-provider.test.ts`** — New test suite (7 tests)
- **`packages/server/package.json`** / **`pnpm-lock.yaml`** — Added `@ai-sdk/google` dependency

## Test plan
- [x] All 343 existing tests continue to pass
- [x] New Google Gemini provider tests pass (initialization, model resolution, credential fallback, config metadata, fallback models, error handling)
- [ ] Manual verification with a real Google API key (set up a Google provider in the UI, select a Gemini model, send a prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)