### PR TITLE
fix: ensure PRs include "Closes #<issue>" to auto-close GitHub issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- Describe your changes briefly -->
+
+## Related Issue
+
+<!-- Link to the GitHub issue this PR addresses. Use "Closes #<number>" to auto-close the issue on merge. -->
+
+Closes #
+
+## Test Plan
+
+<!-- How was this tested? -->

--- a/packages/server/src/agents/coo.ts
+++ b/packages/server/src/agents/coo.ts
@@ -1473,7 +1473,8 @@ The user can see everything on the desktop in real-time.`;
       `Target branch: ${branch}\n` +
       `Repository is already cloned to your workspace.\n\n` +
       `**PR Workflow:** Workers must create feature branches from \`${branch}\`, commit their changes, push, and open a pull request targeting \`${branch}\`.\n` +
-      `Use conventional commits and reference issue numbers where applicable.${rulesBlock}\n\n` +
+      `Use conventional commits and reference issue numbers where applicable.\n` +
+      `**Important:** When a PR addresses a GitHub issue, the body MUST include \`Closes #<issue_number>\` so the issue is automatically closed on merge.${rulesBlock}\n\n` +
       `Await issue-triggered tasks or COO directives.`;
 
     this.sendMessage(teamLead.id, MessageType.Directive, directive, {

--- a/packages/server/src/agents/team-lead.ts
+++ b/packages/server/src/agents/team-lead.ts
@@ -225,6 +225,7 @@ export class TeamLead extends BaseAgent {
         `Target branch: ${ghBranch ?? "main"}`,
         `**PR Workflow:** Workers must create feature branches from \`${ghBranch ?? "main"}\`, commit, push, and open a PR targeting \`${ghBranch ?? "main"}\`.`,
         `Use conventional commits and reference issue numbers.`,
+        `**Important:** When the work addresses a GitHub issue, the PR body MUST include \`Closes #<issue_number>\` so that merging the PR automatically closes the issue.`,
       ];
       if (ghRulesRaw) {
         try {
@@ -1333,6 +1334,7 @@ export class TeamLead extends BaseAgent {
             `Create a feature branch from \`${wGhBranch ?? "main"}\`.`,
             `After completing your work, push your branch and create a pull request targeting \`${wGhBranch ?? "main"}\`.`,
             `Use conventional commits and reference issue numbers where applicable.`,
+            `**Important:** When your work addresses a GitHub issue, include \`Closes #<issue_number>\` in the PR body so the issue is automatically closed on merge.`,
           ];
           if (wGhRulesRaw) {
             try {

--- a/packages/server/src/github/issue-monitor.ts
+++ b/packages/server/src/github/issue-monitor.ts
@@ -163,7 +163,8 @@ export class GitHubIssueMonitor {
               `New GitHub issue #${issue.number} assigned: "${issue.title}"\n\n` +
               `${issue.body ?? "(no description)"}\n\n` +
               `Task created on kanban board (${taskId}). ` +
-              `Spawn a worker to create a feature branch, implement the fix, and open a PR.`,
+              `Spawn a worker to create a feature branch, implement the fix, and open a PR.\n` +
+              `**Important:** The PR body MUST include \`Closes #${issue.number}\` so the issue is automatically closed on merge.`,
             projectId,
           });
         }

--- a/packages/server/src/tools/github.ts
+++ b/packages/server/src/tools/github.ts
@@ -241,7 +241,7 @@ export function createGitHubCommentTool(ctx: ToolContext) {
 export function createGitHubCreatePRTool(ctx: ToolContext) {
   return tool({
     description:
-      "Create a new GitHub pull request. Returns the PR URL and number.",
+      "Create a new GitHub pull request. Returns the PR URL and number. When the PR addresses a GitHub issue, include 'Closes #<number>' in the body to auto-close the issue on merge.",
     parameters: z.object({
       title: z.string().describe("PR title"),
       head: z.string().describe("The branch containing your changes"),
@@ -252,7 +252,7 @@ export function createGitHubCreatePRTool(ctx: ToolContext) {
       body: z
         .string()
         .optional()
-        .describe("PR description (Markdown supported)"),
+        .describe("PR description (Markdown supported). Include 'Closes #<issue_number>' when addressing a GitHub issue."),
     }),
     execute: async ({ title, head, base, body }) => {
       try {


### PR DESCRIPTION
## Summary

- Updated agent prompts (TeamLead system prompt, worker GitHub context, COO directive) to instruct workers to include `Closes #<issue_number>` in PR bodies
- Updated the `github_create_pr` tool description and `body` parameter hint to remind callers about the `Closes #` convention
- Updated the issue monitor directive to explicitly include the issue number in the closing instruction (e.g., `Closes #42`)
- Added a `.github/PULL_REQUEST_TEMPLATE.md` with a "Related Issue" section prompting `Closes #`

## Related Issue

Closes #155

## Test Plan

- [x] All 440 existing tests pass (`npx pnpm test`)
- [x] Type-check passes (pre-existing errors only, none from changed files)
- [ ] Verify that when the issue monitor dispatches a new GitHub issue, the directive includes the `Closes #N` instruction
- [ ] Verify that workers spawned for issue-linked tasks include `Closes #N` in PR bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)