### PR TITLE
feat: add GitHub Copilot LLM provider

### DIFF
--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -258,7 +258,7 @@ export const providers = sqliteTable("providers", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   type: text("type", {
-    enum: ["anthropic", "openai", "google", "ollama", "openai-compatible", "openrouter"],
+    enum: ["anthropic", "openai", "google", "ollama", "openai-compatible", "openrouter", "github-copilot"],
   }).notNull(),
   apiKey: text("api_key"),
   baseUrl: text("base_url"),

--- a/packages/server/src/llm/adapter.test.ts
+++ b/packages/server/src/llm/adapter.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock external dependencies so we can unit-test resolveModel / isThinkingModel
+// without a real database or provider SDK.
+// ---------------------------------------------------------------------------
+
+// Mock the DB module — resolveProviderCredentials calls getDb()
+vi.mock("../db/index.js", () => ({
+  getDb: vi.fn(() => {
+    throw new Error("DB not initialized");
+  }),
+  schema: { providers: {} },
+}));
+
+// Mock the auth/config module — legacy fallback in resolveProviderCredentials
+vi.mock("../auth/auth.js", () => ({
+  getConfig: vi.fn(() => undefined),
+}));
+
+// Capture calls to provider factories so we can verify the adapter wires them correctly
+const mockAnthropicModel = { modelId: "anthropic-model" };
+const mockAnthropicFactory = vi.fn(() => mockAnthropicModel);
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => mockAnthropicFactory),
+}));
+
+const mockOpenAIModel = { modelId: "openai-model" };
+const mockOpenAIFactory = vi.fn(() => mockOpenAIModel);
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: vi.fn(() => mockOpenAIFactory),
+}));
+
+const mockGoogleModel = { modelId: "google-model" };
+const mockGoogleFactory = vi.fn(() => mockGoogleModel);
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: vi.fn(() => mockGoogleFactory),
+}));
+
+const mockOllamaModel = { modelId: "ollama-model" };
+const mockOllamaFactory = vi.fn(() => mockOllamaModel);
+vi.mock("ollama-ai-provider", () => ({
+  createOllama: vi.fn(() => mockOllamaFactory),
+}));
+
+const mockCompatibleModel = { modelId: "compatible-model" };
+const mockCompatibleFactory = vi.fn(() => mockCompatibleModel);
+vi.mock("@ai-sdk/openai-compatible", () => ({
+  createOpenAICompatible: vi.fn(() => mockCompatibleFactory),
+}));
+
+import { createOpenAI } from "@ai-sdk/openai";
+import { resolveModel, isThinkingModel, type LLMConfig } from "./adapter.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("adapter – resolveModel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates an OpenAI-based model for github-copilot provider type", () => {
+    const config: LLMConfig = {
+      provider: "github-copilot",
+      model: "gpt-4o",
+      apiKey: "ghp_test_token",
+    };
+
+    const model = resolveModel(config);
+
+    // Should have called createOpenAI with the Copilot base URL
+    expect(createOpenAI).toHaveBeenCalledWith({
+      baseURL: "https://api.githubcopilot.com",
+      apiKey: "ghp_test_token",
+    });
+
+    // The factory should have been called with the model name
+    expect(mockOpenAIFactory).toHaveBeenCalledWith("gpt-4o");
+    expect(model).toBe(mockOpenAIModel);
+  });
+
+  it("allows overriding the github-copilot baseUrl", () => {
+    const config: LLMConfig = {
+      provider: "github-copilot",
+      model: "gpt-4.1",
+      apiKey: "ghp_custom",
+      baseUrl: "https://custom-copilot-proxy.example.com",
+    };
+
+    resolveModel(config);
+
+    expect(createOpenAI).toHaveBeenCalledWith({
+      baseURL: "https://custom-copilot-proxy.example.com",
+      apiKey: "ghp_custom",
+    });
+    expect(mockOpenAIFactory).toHaveBeenCalledWith("gpt-4.1");
+  });
+
+  it("uses empty string for apiKey when none provided", () => {
+    const config: LLMConfig = {
+      provider: "github-copilot",
+      model: "o3-mini",
+    };
+
+    resolveModel(config);
+
+    expect(createOpenAI).toHaveBeenCalledWith({
+      baseURL: "https://api.githubcopilot.com",
+      apiKey: "",
+    });
+  });
+
+  it("throws for unknown provider type", () => {
+    const config: LLMConfig = {
+      provider: "nonexistent",
+      model: "some-model",
+    };
+
+    expect(() => resolveModel(config)).toThrow(/Unknown LLM provider/);
+  });
+});
+
+describe("adapter – isThinkingModel", () => {
+  it("returns false for github-copilot models", () => {
+    expect(
+      isThinkingModel({ provider: "github-copilot", model: "gpt-4o" }),
+    ).toBe(false);
+    expect(
+      isThinkingModel({ provider: "github-copilot", model: "claude-sonnet-4-5-20250929" }),
+    ).toBe(false);
+  });
+
+  it("returns true for anthropic thinking models", () => {
+    expect(
+      isThinkingModel({ provider: "anthropic", model: "claude-sonnet-4-5-20250929" }),
+    ).toBe(true);
+    expect(
+      isThinkingModel({ provider: "anthropic", model: "claude-opus-4-20250514" }),
+    ).toBe(true);
+  });
+
+  it("returns false for non-thinking anthropic models", () => {
+    expect(
+      isThinkingModel({ provider: "anthropic", model: "claude-haiku-4-20250414" }),
+    ).toBe(false);
+  });
+
+  it("returns true for openrouter anthropic thinking models", () => {
+    expect(
+      isThinkingModel({ provider: "openrouter", model: "anthropic/claude-sonnet-4-5-20250929" }),
+    ).toBe(true);
+  });
+
+  it("returns false for openrouter non-anthropic models", () => {
+    expect(
+      isThinkingModel({ provider: "openrouter", model: "openai/gpt-4o" }),
+    ).toBe(false);
+  });
+});

--- a/packages/server/src/llm/adapter.ts
+++ b/packages/server/src/llm/adapter.ts
@@ -127,6 +127,14 @@ export function resolveModel(config: LLMConfig): LanguageModel {
       return compatible(config.model);
     }
 
+    case "github-copilot": {
+      const copilot = createOpenAI({
+        baseURL: config.baseUrl ?? resolved.baseUrl ?? "https://api.githubcopilot.com",
+        apiKey: config.apiKey ?? resolved.apiKey ?? "",
+      });
+      return copilot(config.model);
+    }
+
     default:
       throw new Error(`Unknown LLM provider: ${config.provider} (type: ${resolved.type})`);
   }

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -1,4 +1,4 @@
-export type ProviderType = "anthropic" | "openai" | "google" | "ollama" | "openai-compatible" | "openrouter";
+export type ProviderType = "anthropic" | "openai" | "google" | "ollama" | "openai-compatible" | "openrouter" | "github-copilot";
 
 export interface NamedProvider {
   id: string;


### PR DESCRIPTION
## Summary
- Adds **GitHub Copilot** as a first-class LLM provider (`github-copilot`) that routes through the GitHub Copilot API (`https://api.githubcopilot.com`), which exposes an OpenAI-compatible interface
- Updates the `ProviderType` union, DB schema enum, adapter `resolveModel()` switch, provider metadata, fallback models, and model discovery
- Includes unit tests covering `resolveModel` and `isThinkingModel` for the new provider

### Files changed
- `packages/shared/src/types/provider.ts` — added `"github-copilot"` to `ProviderType` union
- `packages/server/src/llm/adapter.ts` — added `github-copilot` case using `createOpenAI` with Copilot base URL
- `packages/server/src/db/schema.ts` — added `"github-copilot"` to providers table type enum
- `packages/server/src/settings/settings.ts` — added provider metadata, fallback models, and model fetch logic
- `packages/server/src/llm/adapter.test.ts` — new test file with unit tests for the provider

## Test plan
- [x] All 449 existing tests pass
- [x] New adapter tests verify `resolveModel` creates OpenAI client with correct Copilot base URL
- [x] New tests verify `isThinkingModel` returns false for github-copilot models
- [ ] Manual: configure a GitHub Copilot provider in Settings UI, verify model discovery works
- [ ] Manual: send a test message through an agent using the Copilot provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)