### PR TITLE
feat: scaffold Microsoft Teams chat provider

### DIFF
--- a/packages/server/src/chat/IChatProvider.ts
+++ b/packages/server/src/chat/IChatProvider.ts
@@ -1,0 +1,19 @@
+/**
+ * Common interface for messaging-platform chat providers (Discord, Teams, Slack, etc.).
+ */
+export interface IChatProvider {
+  /** Unique identifier for this provider type (e.g. "discord", "teams"). */
+  readonly id: string;
+
+  /** Human-readable display name. */
+  readonly name: string;
+
+  /** Connect to the messaging platform and begin listening for messages. */
+  start(): Promise<void>;
+
+  /** Gracefully disconnect from the messaging platform. */
+  stop(): Promise<void>;
+
+  /** Send a text message to the given channel/conversation. */
+  sendMessage(channelId: string, content: string): Promise<void>;
+}

--- a/packages/server/src/chat/registry.ts
+++ b/packages/server/src/chat/registry.ts
@@ -1,0 +1,24 @@
+import type { IChatProvider } from "./IChatProvider.js";
+import type { ChatProviderType } from "@otterbot/shared";
+import { TeamsProvider } from "./teams/TeamsProvider.js";
+
+/**
+ * Registry of available chat providers keyed by their type identifier.
+ */
+const chatProviderFactories: Record<ChatProviderType, () => IChatProvider> = {
+  teams: () => new TeamsProvider(),
+};
+
+/** Create a chat provider instance by type. */
+export function createChatProvider(type: ChatProviderType): IChatProvider {
+  const factory = chatProviderFactories[type];
+  if (!factory) {
+    throw new Error(`Unknown chat provider type: ${type}`);
+  }
+  return factory();
+}
+
+/** List all registered chat provider types. */
+export function listChatProviderTypes(): ChatProviderType[] {
+  return Object.keys(chatProviderFactories) as ChatProviderType[];
+}

--- a/packages/server/src/chat/teams/TeamsProvider.ts
+++ b/packages/server/src/chat/teams/TeamsProvider.ts
@@ -1,0 +1,23 @@
+import type { IChatProvider } from "../IChatProvider.js";
+
+/**
+ * Microsoft Teams chat provider (stub).
+ *
+ * This is a placeholder scaffold — methods are not yet implemented.
+ */
+export class TeamsProvider implements IChatProvider {
+  readonly id = "teams" as const;
+  readonly name = "Microsoft Teams";
+
+  async start(): Promise<void> {
+    throw new Error("TeamsProvider.start() is not yet implemented");
+  }
+
+  async stop(): Promise<void> {
+    throw new Error("TeamsProvider.stop() is not yet implemented");
+  }
+
+  async sendMessage(_channelId: string, _content: string): Promise<void> {
+    throw new Error("TeamsProvider.sendMessage() is not yet implemented");
+  }
+}

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -37,3 +37,6 @@ export interface AgentModelOverride {
   provider: string;
   model: string;
 }
+
+/** Supported messaging-platform chat provider types. */
+export type ChatProviderType = "teams";


### PR DESCRIPTION
## Summary
- Add `IChatProvider` interface defining the common contract for messaging-platform adapters (`start`, `stop`, `sendMessage`)
- Scaffold `TeamsProvider` stub in `packages/server/src/chat/teams/` implementing `IChatProvider` with placeholder methods
- Add `ChatProviderType` union type (`"teams"`) to `packages/shared/src/types/provider.ts`
- Add chat provider registry with factory function in `packages/server/src/chat/registry.ts`

## Test plan
- [ ] Verify build passes (`pnpm build`)
- [ ] Verify type-check passes for shared and server packages
- [ ] No functional testing needed — this is a stub scaffold only

🤖 Generated with [Claude Code](https://claude.com/claude-code)