### PR TITLE
feat: add Slack as chat provider

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,6 +24,7 @@
     "@huggingface/transformers": "^3.4.1",
     "@opencode-ai/sdk": "^1.2.6",
     "@otterbot/shared": "workspace:*",
+    "@slack/bolt": "^4.6.0",
     "ai": "^4.1.61",
     "better-sqlite3-multiple-ciphers": "^11.8.1",
     "discord.js": "^14.16.0",

--- a/packages/server/src/slack/__tests__/slack-bridge.test.ts
+++ b/packages/server/src/slack/__tests__/slack-bridge.test.ts
@@ -1,0 +1,795 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventEmitter } from "events";
+import { migrateDb, resetDb } from "../../db/index.js";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage } from "@otterbot/shared";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Mock @slack/bolt
+// ---------------------------------------------------------------------------
+
+class MockSlackApp extends EventEmitter {
+  client = {
+    conversations: {
+      list: vi.fn().mockResolvedValue({
+        channels: [
+          { id: "C001", name: "general" },
+          { id: "C002", name: "random" },
+        ],
+      }),
+    },
+    chat: {
+      postMessage: vi.fn().mockResolvedValue({ ok: true }),
+    },
+  };
+  private handlers: Record<string, Function[]> = {};
+  token: string = "";
+  signingSecret: string = "";
+  appToken: string = "";
+  socketMode: boolean = false;
+  started = false;
+
+  constructor(opts: Record<string, unknown>) {
+    super();
+    this.token = opts.token as string;
+    this.signingSecret = opts.signingSecret as string;
+    this.appToken = opts.appToken as string;
+    this.socketMode = opts.socketMode as boolean;
+  }
+
+  message(handler: Function) {
+    if (!this.handlers.message) this.handlers.message = [];
+    this.handlers.message.push(handler);
+  }
+
+  event(name: string, handler: Function) {
+    if (!this.handlers[`event:${name}`]) this.handlers[`event:${name}`] = [];
+    this.handlers[`event:${name}`].push(handler);
+  }
+
+  command(name: string, handler: Function) {
+    if (!this.handlers[`command:${name}`]) this.handlers[`command:${name}`] = [];
+    this.handlers[`command:${name}`].push(handler);
+  }
+
+  async start() {
+    this.started = true;
+  }
+
+  async stop() {
+    this.started = false;
+  }
+
+  // Test helpers to trigger handlers
+  async _triggerMessage(message: Record<string, unknown>, say: Function) {
+    for (const handler of this.handlers.message ?? []) {
+      await handler({ message, say });
+    }
+  }
+
+  async _triggerEvent(eventName: string, event: Record<string, unknown>, say?: Function) {
+    for (const handler of this.handlers[`event:${eventName}`] ?? []) {
+      await handler({ event, say });
+    }
+  }
+
+  async _triggerCommand(commandName: string, command: Record<string, unknown>, ack: Function, say: Function) {
+    for (const handler of this.handlers[`command:${commandName}`] ?? []) {
+      await handler({ command, ack, say });
+    }
+  }
+}
+
+let mockAppInstance: MockSlackApp | null = null;
+
+vi.mock("@slack/bolt", () => ({
+  App: class extends MockSlackApp {
+    constructor(opts: Record<string, unknown>) {
+      super(opts);
+      mockAppInstance = this;
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+// Import after mocking
+const { SlackBridge } = await import("../slack-bridge.js");
+
+interface SendParams {
+  fromAgentId: string | null;
+  toAgentId: string | null;
+  type: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  conversationId?: string;
+}
+
+function createMockBus() {
+  const broadcastHandlers: ((message: BusMessage) => void)[] = [];
+  const sent: SendParams[] = [];
+
+  const bus = {
+    send: vi.fn((params: SendParams) => {
+      sent.push(params);
+      const message: BusMessage = {
+        id: "test-msg-id",
+        fromAgentId: params.fromAgentId,
+        toAgentId: params.toAgentId,
+        type: params.type as BusMessage["type"],
+        content: params.content,
+        metadata: params.metadata ?? {},
+        conversationId: params.conversationId,
+        timestamp: new Date().toISOString(),
+      };
+      return message;
+    }),
+    onBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      broadcastHandlers.push(handler);
+    }),
+    offBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      const idx = broadcastHandlers.indexOf(handler);
+      if (idx >= 0) broadcastHandlers.splice(idx, 1);
+    }),
+    _broadcastHandlers: broadcastHandlers,
+    _sent: sent,
+  };
+
+  return bus;
+}
+
+function createMockCoo() {
+  return {
+    startNewConversation: vi.fn(),
+  };
+}
+
+function createMockIo() {
+  return {
+    emit: vi.fn(),
+  };
+}
+
+const testConfig = {
+  botToken: "xoxb-test-token",
+  signingSecret: "test-signing-secret",
+  appToken: "xapp-test-app-token",
+};
+
+describe("SlackBridge", () => {
+  let tmpDir: string;
+  let bus: ReturnType<typeof createMockBus>;
+  let coo: ReturnType<typeof createMockCoo>;
+  let io: ReturnType<typeof createMockIo>;
+  let bridge: InstanceType<typeof SlackBridge>;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-slack-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+
+    bus = createMockBus();
+    coo = createMockCoo();
+    io = createMockIo();
+    mockAppInstance = null;
+
+    bridge = new SlackBridge({
+      bus: bus as any,
+      coo: coo as any,
+      io: io as any,
+    });
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // Connection & Lifecycle
+  // -------------------------------------------------------------------------
+
+  describe("connection initialization", () => {
+    it("starts the Slack app with socket mode", async () => {
+      await bridge.start(testConfig);
+
+      expect(mockAppInstance).not.toBeNull();
+      expect(mockAppInstance!.started).toBe(true);
+      expect(mockAppInstance!.socketMode).toBe(true);
+    });
+
+    it("emits connected status on start", async () => {
+      await bridge.start(testConfig);
+
+      expect(io.emit).toHaveBeenCalledWith("slack:status", {
+        status: "connected",
+      });
+    });
+
+    it("subscribes to bus broadcasts", async () => {
+      await bridge.start(testConfig);
+      expect(bus.onBroadcast).toHaveBeenCalledOnce();
+    });
+
+    it("passes the correct tokens to the Slack App", async () => {
+      await bridge.start(testConfig);
+
+      expect(mockAppInstance!.token).toBe("xoxb-test-token");
+      expect(mockAppInstance!.signingSecret).toBe("test-signing-secret");
+      expect(mockAppInstance!.appToken).toBe("xapp-test-app-token");
+    });
+  });
+
+  describe("cleanup on stop", () => {
+    it("stops the Slack app", async () => {
+      await bridge.start(testConfig);
+      const app = mockAppInstance!;
+      await bridge.stop();
+
+      expect(app.started).toBe(false);
+    });
+
+    it("unsubscribes from bus broadcasts", async () => {
+      await bridge.start(testConfig);
+      await bridge.stop();
+      expect(bus.offBroadcast).toHaveBeenCalledOnce();
+    });
+
+    it("emits disconnected status", async () => {
+      await bridge.start(testConfig);
+      await bridge.stop();
+
+      expect(io.emit).toHaveBeenCalledWith("slack:status", {
+        status: "disconnected",
+      });
+    });
+
+    it("can restart after stop", async () => {
+      await bridge.start(testConfig);
+      await bridge.stop();
+      await bridge.start(testConfig);
+
+      expect(mockAppInstance!.started).toBe(true);
+      expect(io.emit).toHaveBeenCalledWith("slack:status", {
+        status: "connected",
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Inbound Messages (Slack → COO)
+  // -------------------------------------------------------------------------
+
+  describe("message handling", () => {
+    it("routes DM messages to COO", async () => {
+      await bridge.start(testConfig);
+
+      // First pair the user
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:paired:U123", JSON.stringify({
+        slackUserId: "U123",
+        slackUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+      // Disable require_mention for DMs test
+      setConfig("slack:require_mention", "false");
+
+      const say = vi.fn();
+      await mockAppInstance!._triggerMessage(
+        {
+          user: "U123",
+          channel: "D456",
+          channel_type: "im",
+          text: "hello there",
+          ts: "1234567890.123456",
+        },
+        say,
+      );
+
+      expect(bus.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromAgentId: null,
+          toAgentId: "coo",
+          type: MessageType.Chat,
+          content: "hello there",
+          metadata: expect.objectContaining({
+            source: "slack",
+            slackUserId: "U123",
+            slackChannelId: "D456",
+          }),
+        }),
+      );
+    });
+
+    it("ignores bot messages", async () => {
+      await bridge.start(testConfig);
+
+      const say = vi.fn();
+      await mockAppInstance!._triggerMessage(
+        {
+          bot_id: "B123",
+          user: "U123",
+          channel: "D456",
+          channel_type: "im",
+          text: "bot message",
+          ts: "1234567890.123456",
+        },
+        say,
+      );
+
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("ignores message subtypes (edits, deletes)", async () => {
+      await bridge.start(testConfig);
+
+      const say = vi.fn();
+      await mockAppInstance!._triggerMessage(
+        {
+          subtype: "message_changed",
+          user: "U123",
+          channel: "D456",
+          channel_type: "im",
+          text: "edited message",
+          ts: "1234567890.123456",
+        },
+        say,
+      );
+
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("generates pairing code for unpaired users", async () => {
+      await bridge.start(testConfig);
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:require_mention", "false");
+
+      const say = vi.fn();
+      await mockAppInstance!._triggerMessage(
+        {
+          user: "U999",
+          channel: "D456",
+          channel_type: "im",
+          text: "hello",
+          ts: "1234567890.123456",
+        },
+        say,
+      );
+
+      expect(say).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining("approve this code"),
+        }),
+      );
+      expect(io.emit).toHaveBeenCalledWith(
+        "slack:pairing-request",
+        expect.objectContaining({
+          slackUserId: "U999",
+        }),
+      );
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("creates a conversation for new messages", async () => {
+      await bridge.start(testConfig);
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:paired:U123", JSON.stringify({
+        slackUserId: "U123",
+        slackUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+      setConfig("slack:require_mention", "false");
+
+      const say = vi.fn();
+      await mockAppInstance!._triggerMessage(
+        {
+          user: "U123",
+          channel: "D456",
+          channel_type: "im",
+          text: "hello",
+          ts: "1234567890.123456",
+        },
+        say,
+      );
+
+      expect(coo.startNewConversation).toHaveBeenCalledOnce();
+      expect(io.emit).toHaveBeenCalledWith(
+        "conversation:created",
+        expect.objectContaining({
+          title: expect.stringContaining("Slack:"),
+        }),
+      );
+    });
+
+    it("reuses conversation for same user+channel", async () => {
+      await bridge.start(testConfig);
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:paired:U123", JSON.stringify({
+        slackUserId: "U123",
+        slackUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+      setConfig("slack:require_mention", "false");
+
+      const say = vi.fn();
+
+      await mockAppInstance!._triggerMessage(
+        { user: "U123", channel: "D456", channel_type: "im", text: "first", ts: "1" },
+        say,
+      );
+      await mockAppInstance!._triggerMessage(
+        { user: "U123", channel: "D456", channel_type: "im", text: "second", ts: "2" },
+        say,
+      );
+
+      expect(coo.startNewConversation).toHaveBeenCalledOnce();
+      expect(bus.send).toHaveBeenCalledTimes(2);
+    });
+
+    it("ignores channel messages when requireMention is true (default)", async () => {
+      await bridge.start(testConfig);
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:paired:U123", JSON.stringify({
+        slackUserId: "U123",
+        slackUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      const say = vi.fn();
+      await mockAppInstance!._triggerMessage(
+        {
+          user: "U123",
+          channel: "C001",
+          channel_type: "channel",
+          text: "hello in channel",
+          ts: "1234567890.123456",
+        },
+        say,
+      );
+
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("respects allowed channels whitelist", async () => {
+      await bridge.start(testConfig);
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:paired:U123", JSON.stringify({
+        slackUserId: "U123",
+        slackUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+      setConfig("slack:require_mention", "false");
+      setConfig("slack:allowed_channels", JSON.stringify(["C001"]));
+
+      const say = vi.fn();
+
+      // Not in allowed channels
+      await mockAppInstance!._triggerMessage(
+        { user: "U123", channel: "C999", channel_type: "channel", text: "hello", ts: "1" },
+        say,
+      );
+      expect(bus.send).not.toHaveBeenCalled();
+
+      // In allowed channels
+      await mockAppInstance!._triggerMessage(
+        { user: "U123", channel: "C001", channel_type: "channel", text: "hello", ts: "2" },
+        say,
+      );
+      expect(bus.send).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // App Mention Events
+  // -------------------------------------------------------------------------
+
+  describe("app_mention handling", () => {
+    it("routes app_mention events to COO", async () => {
+      await bridge.start(testConfig);
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:paired:U123", JSON.stringify({
+        slackUserId: "U123",
+        slackUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      const say = vi.fn();
+      await mockAppInstance!._triggerEvent("app_mention", {
+        user: "U123",
+        channel: "C001",
+        text: "<@B123> what is the weather?",
+        ts: "1234567890.123456",
+      }, say);
+
+      expect(bus.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: "what is the weather?",
+          metadata: expect.objectContaining({
+            source: "slack",
+            slackUserId: "U123",
+          }),
+        }),
+      );
+    });
+
+    it("strips bot mention from app_mention text", async () => {
+      await bridge.start(testConfig);
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:paired:U123", JSON.stringify({
+        slackUserId: "U123",
+        slackUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      const say = vi.fn();
+      await mockAppInstance!._triggerEvent("app_mention", {
+        user: "U123",
+        channel: "C001",
+        text: "<@B456> hello bot",
+        ts: "1234567890.123456",
+      }, say);
+
+      expect(bus.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: "hello bot",
+        }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Slash Commands
+  // -------------------------------------------------------------------------
+
+  describe("slash command handling", () => {
+    it("routes /otterbot command to COO", async () => {
+      await bridge.start(testConfig);
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:paired:U123", JSON.stringify({
+        slackUserId: "U123",
+        slackUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      const ack = vi.fn();
+      const say = vi.fn();
+      await mockAppInstance!._triggerCommand("/otterbot", {
+        user_id: "U123",
+        user_name: "alice",
+        channel_id: "C001",
+        text: "remind me to buy milk",
+      }, ack, say);
+
+      expect(ack).toHaveBeenCalled();
+      expect(bus.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: "remind me to buy milk",
+          metadata: expect.objectContaining({
+            source: "slack",
+          }),
+        }),
+      );
+    });
+
+    it("shows usage when command has no text", async () => {
+      await bridge.start(testConfig);
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:paired:U123", JSON.stringify({
+        slackUserId: "U123",
+        slackUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      const ack = vi.fn();
+      const say = vi.fn();
+      await mockAppInstance!._triggerCommand("/otterbot", {
+        user_id: "U123",
+        user_name: "alice",
+        channel_id: "C001",
+        text: "",
+      }, ack, say);
+
+      expect(say).toHaveBeenCalledWith(expect.stringContaining("Usage"));
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("generates pairing code for unpaired slash command user", async () => {
+      await bridge.start(testConfig);
+
+      const ack = vi.fn();
+      const say = vi.fn();
+      await mockAppInstance!._triggerCommand("/otterbot", {
+        user_id: "U999",
+        user_name: "stranger",
+        channel_id: "C001",
+        text: "hello",
+      }, ack, say);
+
+      expect(say).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining("approve this code"),
+        }),
+      );
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Outbound Messages (COO → Slack)
+  // -------------------------------------------------------------------------
+
+  describe("outbound messages", () => {
+    it("sends COO responses back to Slack", async () => {
+      await bridge.start(testConfig);
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:paired:U123", JSON.stringify({
+        slackUserId: "U123",
+        slackUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+      setConfig("slack:require_mention", "false");
+
+      const say = vi.fn();
+      await mockAppInstance!._triggerMessage(
+        {
+          user: "U123",
+          channel: "D456",
+          channel_type: "im",
+          text: "hello",
+          ts: "1234567890.123456",
+        },
+        say,
+      );
+
+      const conversationId = bus.send.mock.calls[0]?.[0]?.conversationId;
+      expect(conversationId).toBeTruthy();
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "resp-1",
+        fromAgentId: "coo",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "Hello from COO!",
+        metadata: {},
+        conversationId,
+        timestamp: new Date().toISOString(),
+      });
+
+      // Wait for async operation
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockAppInstance!.client.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: "D456",
+          text: "Hello from COO!",
+          thread_ts: "1234567890.123456",
+        }),
+      );
+    });
+
+    it("ignores messages not from COO", async () => {
+      await bridge.start(testConfig);
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "msg-1",
+        fromAgentId: "some-agent",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "Not from COO",
+        metadata: {},
+        conversationId: "conv-1",
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(mockAppInstance!.client.chat.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("ignores COO messages addressed to another agent", async () => {
+      await bridge.start(testConfig);
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "msg-1",
+        fromAgentId: "coo",
+        toAgentId: "some-agent",
+        type: MessageType.Chat,
+        content: "For another agent",
+        metadata: {},
+        conversationId: "conv-1",
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(mockAppInstance!.client.chat.postMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getAvailableChannels
+  // -------------------------------------------------------------------------
+
+  describe("getAvailableChannels", () => {
+    it("returns available channels from Slack API", async () => {
+      await bridge.start(testConfig);
+      const channels = await bridge.getAvailableChannels();
+
+      expect(channels).toEqual([
+        { id: "C001", name: "general" },
+        { id: "C002", name: "random" },
+      ]);
+    });
+
+    it("returns empty array when not started", async () => {
+      const channels = await bridge.getAvailableChannels();
+      expect(channels).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reaction Events
+  // -------------------------------------------------------------------------
+
+  describe("reaction handling", () => {
+    it("logs reactions from paired users", async () => {
+      await bridge.start(testConfig);
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("slack:paired:U123", JSON.stringify({
+        slackUserId: "U123",
+        slackUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await mockAppInstance!._triggerEvent("reaction_added", {
+        user: "U123",
+        reaction: "thumbsup",
+        item: { ts: "1234567890.123456" },
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(":thumbsup:"),
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("ignores reactions from unpaired users", async () => {
+      await bridge.start(testConfig);
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await mockAppInstance!._triggerEvent("reaction_added", {
+        user: "U999",
+        reaction: "thumbsup",
+        item: { ts: "1234567890.123456" },
+      });
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/packages/server/src/slack/pairing.ts
+++ b/packages/server/src/slack/pairing.ts
@@ -1,0 +1,178 @@
+import { randomBytes } from "node:crypto";
+import { like } from "drizzle-orm";
+import { getDb, schema } from "../db/index.js";
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateCode(): string {
+  return randomBytes(3).toString("hex").toUpperCase(); // 6-char hex
+}
+
+const PAIRING_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export interface PendingPairing {
+  code: string;
+  slackUserId: string;
+  slackUsername: string;
+  createdAt: string;
+}
+
+export interface PairedUser {
+  slackUserId: string;
+  slackUsername: string;
+  pairedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Config-prefix query helper
+// ---------------------------------------------------------------------------
+
+function getConfigsByPrefix(prefix: string): Array<{ key: string; value: string }> {
+  const db = getDb();
+  return db
+    .select({ key: schema.config.key, value: schema.config.value })
+    .from(schema.config)
+    .where(like(schema.config.key, `${prefix}%`))
+    .all();
+}
+
+// ---------------------------------------------------------------------------
+// Pairing code management
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a pairing code for a Slack user.
+ * Only one active code per user — generating a new one deletes the old.
+ */
+export function generatePairingCode(slackUserId: string, slackUsername: string): string {
+  // Remove any existing code for this user
+  const existing = getConfigsByPrefix("slack:pairing:");
+  for (const row of existing) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (data.slackUserId === slackUserId) {
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+
+  const code = generateCode();
+  const data: PendingPairing = {
+    code,
+    slackUserId,
+    slackUsername,
+    createdAt: new Date().toISOString(),
+  };
+  setConfig(`slack:pairing:${code}`, JSON.stringify(data));
+  return code;
+}
+
+/**
+ * Check whether a Slack user is paired.
+ */
+export function isPaired(slackUserId: string): boolean {
+  return !!getConfig(`slack:paired:${slackUserId}`);
+}
+
+/**
+ * Get paired user info.
+ */
+export function getPairedUser(slackUserId: string): PairedUser | null {
+  const raw = getConfig(`slack:paired:${slackUserId}`);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as PairedUser;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Approve a pending pairing by code.
+ * Returns the paired user info, or null if the code is invalid/expired.
+ */
+export function approvePairing(code: string): PairedUser | null {
+  const raw = getConfig(`slack:pairing:${code}`);
+  if (!raw) return null;
+
+  let pending: PendingPairing;
+  try {
+    pending = JSON.parse(raw) as PendingPairing;
+  } catch {
+    return null;
+  }
+
+  // Check expiry
+  if (Date.now() - new Date(pending.createdAt).getTime() > PAIRING_TTL_MS) {
+    deleteConfig(`slack:pairing:${code}`);
+    return null;
+  }
+
+  const paired: PairedUser = {
+    slackUserId: pending.slackUserId,
+    slackUsername: pending.slackUsername,
+    pairedAt: new Date().toISOString(),
+  };
+
+  setConfig(`slack:paired:${pending.slackUserId}`, JSON.stringify(paired));
+  deleteConfig(`slack:pairing:${code}`);
+  return paired;
+}
+
+/**
+ * Reject (delete) a pending pairing code.
+ */
+export function rejectPairing(code: string): boolean {
+  const raw = getConfig(`slack:pairing:${code}`);
+  if (!raw) return false;
+  deleteConfig(`slack:pairing:${code}`);
+  return true;
+}
+
+/**
+ * Revoke a paired user's access.
+ */
+export function revokePairing(slackUserId: string): boolean {
+  const raw = getConfig(`slack:paired:${slackUserId}`);
+  if (!raw) return false;
+  deleteConfig(`slack:paired:${slackUserId}`);
+  return true;
+}
+
+/**
+ * List all paired users.
+ */
+export function listPairedUsers(): PairedUser[] {
+  const rows = getConfigsByPrefix("slack:paired:");
+  const users: PairedUser[] = [];
+  for (const row of rows) {
+    try {
+      users.push(JSON.parse(row.value) as PairedUser);
+    } catch { /* ignore malformed */ }
+  }
+  return users;
+}
+
+/**
+ * List all pending (non-expired) pairing codes.
+ */
+export function listPendingPairings(): PendingPairing[] {
+  const rows = getConfigsByPrefix("slack:pairing:");
+  const now = Date.now();
+  const pending: PendingPairing[] = [];
+  for (const row of rows) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (now - new Date(data.createdAt).getTime() <= PAIRING_TTL_MS) {
+        pending.push(data);
+      } else {
+        // Clean up expired
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+  return pending;
+}

--- a/packages/server/src/slack/slack-bridge.ts
+++ b/packages/server/src/slack/slack-bridge.ts
@@ -1,0 +1,449 @@
+import { nanoid } from "nanoid";
+import { eq } from "drizzle-orm";
+import { Server } from "socket.io";
+import type { ServerToClientEvents, ClientToServerEvents } from "@otterbot/shared";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage, Conversation } from "@otterbot/shared";
+import { MessageBus } from "../bus/message-bus.js";
+import { COO } from "../agents/coo.js";
+import { getDb, schema } from "../db/index.js";
+import { getConfig } from "../auth/auth.js";
+import { isPaired, generatePairingCode } from "./pairing.js";
+import type { SlackAvailableChannel } from "./slack-settings.js";
+
+type TypedServer = Server<ClientToServerEvents, ServerToClientEvents>;
+
+// ---------------------------------------------------------------------------
+// Slack Bridge
+// ---------------------------------------------------------------------------
+
+const SLACK_MAX_LENGTH = 4000;
+
+interface PendingResponse {
+  channelId: string;
+  threadTs?: string;
+  conversationId: string;
+}
+
+export class SlackBridge {
+  private app: unknown | null = null;
+  private bus: MessageBus;
+  private coo: COO;
+  private io: TypedServer;
+  private pendingResponses = new Map<string, PendingResponse>();
+  private broadcastHandler: ((message: BusMessage) => void) | null = null;
+  /** Map of `{slackUserId}:{channelId}` → conversationId */
+  private conversationMap = new Map<string, string>();
+  /** Cached Bolt module */
+  private bolt: typeof import("@slack/bolt") | null = null;
+
+  constructor(deps: { bus: MessageBus; coo: COO; io: TypedServer }) {
+    this.bus = deps.bus;
+    this.coo = deps.coo;
+    this.io = deps.io;
+  }
+
+  async start(config: {
+    botToken: string;
+    signingSecret: string;
+    appToken: string;
+  }): Promise<void> {
+    if (this.app) {
+      await this.stop();
+    }
+
+    // Dynamic import so the rest of the codebase isn't affected when
+    // @slack/bolt is not installed.
+    const bolt = await import("@slack/bolt");
+    this.bolt = bolt;
+
+    const app = new bolt.App({
+      token: config.botToken,
+      signingSecret: config.signingSecret,
+      appToken: config.appToken,
+      socketMode: true,
+    });
+
+    // Handle messages
+    app.message(async ({ message, say }) => {
+      await this.handleMessage(message, say);
+    });
+
+    // Handle app_mention events (when bot is mentioned in channels)
+    app.event("app_mention", async ({ event, say }) => {
+      await this.handleAppMention(event, say);
+    });
+
+    // Handle reaction_added events
+    app.event("reaction_added", async ({ event }) => {
+      await this.handleReactionAdded(event);
+    });
+
+    // Handle slash commands — /otterbot
+    app.command("/otterbot", async ({ command, ack, say }) => {
+      await ack();
+      await this.handleSlashCommand(command, say);
+    });
+
+    // Subscribe to bus broadcasts to intercept COO responses
+    this.broadcastHandler = (message: BusMessage) => {
+      this.handleBusMessage(message);
+    };
+    this.bus.onBroadcast(this.broadcastHandler);
+
+    await app.start();
+    this.app = app;
+
+    console.log("[Slack] Bridge started");
+    this.io.emit("slack:status", { status: "connected" });
+  }
+
+  async stop(): Promise<void> {
+    this.pendingResponses.clear();
+
+    if (this.broadcastHandler) {
+      this.bus.offBroadcast(this.broadcastHandler);
+      this.broadcastHandler = null;
+    }
+
+    if (this.app) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (this.app as any).stop();
+      this.app = null;
+      this.bolt = null;
+      this.io.emit("slack:status", { status: "disconnected" });
+    }
+  }
+
+  async getAvailableChannels(): Promise<SlackAvailableChannel[]> {
+    if (!this.app) return [];
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client = (this.app as any).client;
+      const result = await client.conversations.list({
+        types: "public_channel,private_channel",
+        exclude_archived: true,
+        limit: 200,
+      });
+
+      const channels: SlackAvailableChannel[] = [];
+      for (const ch of result.channels ?? []) {
+        if (ch.id && ch.name) {
+          channels.push({ id: ch.id, name: ch.name });
+        }
+      }
+      return channels;
+    } catch (err) {
+      console.error("[Slack] Failed to list channels:", err);
+      return [];
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Inbound: Slack → COO
+  // -------------------------------------------------------------------------
+
+  private async handleMessage(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    message: any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    say: any,
+  ): Promise<void> {
+    // Ignore bot messages and message_changed/deleted subtypes
+    if (message.bot_id || message.subtype) return;
+
+    const slackUserId: string = message.user;
+    const channelId: string = message.channel;
+    const threadTs: string | undefined = message.thread_ts ?? message.ts;
+
+    // Check if this is a DM (im) or channel message
+    const isDM = message.channel_type === "im";
+
+    const requireMention = getConfig("slack:require_mention") !== "false";
+
+    // In channels, only respond to @mentions (unless require_mention is off)
+    if (!isDM && requireMention) {
+      // The message event doesn't include mention data — only app_mention does.
+      // So in channels with requireMention, we rely on the app_mention handler.
+      return;
+    }
+
+    // Channel whitelist: if set, only respond in allowed channels (DMs always allowed)
+    if (!isDM) {
+      const raw = getConfig("slack:allowed_channels");
+      if (raw) {
+        try {
+          const allowed: string[] = JSON.parse(raw);
+          if (allowed.length > 0 && !allowed.includes(channelId)) {
+            return;
+          }
+        } catch { /* ignore parse errors */ }
+      }
+    }
+
+    const slackUsername = slackUserId; // Will be resolved later if needed
+
+    // Check pairing
+    if (!isPaired(slackUserId)) {
+      const code = generatePairingCode(slackUserId, slackUsername);
+      await say({
+        text: `I don't recognize you yet. To pair with me, ask my owner to approve this code in the Otterbot dashboard:\n\n*\`${code}\`*\n\nThis code expires in 1 hour.`,
+        thread_ts: threadTs,
+      });
+      this.io.emit("slack:pairing-request", {
+        code,
+        slackUserId,
+        slackUsername,
+      });
+      return;
+    }
+
+    // Extract content
+    let content: string = message.text ?? "";
+    if (!content.trim()) return;
+
+    await this.routeToCOO(channelId, threadTs, slackUserId, content, say);
+  }
+
+  private async handleAppMention(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    event: any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    say: any,
+  ): Promise<void> {
+    const slackUserId: string = event.user;
+    const channelId: string = event.channel;
+    const threadTs: string | undefined = event.thread_ts ?? event.ts;
+
+    // Channel whitelist
+    const raw = getConfig("slack:allowed_channels");
+    if (raw) {
+      try {
+        const allowed: string[] = JSON.parse(raw);
+        if (allowed.length > 0 && !allowed.includes(channelId)) {
+          return;
+        }
+      } catch { /* ignore */ }
+    }
+
+    const slackUsername = slackUserId;
+
+    if (!isPaired(slackUserId)) {
+      const code = generatePairingCode(slackUserId, slackUsername);
+      await say({
+        text: `I don't recognize you yet. To pair with me, ask my owner to approve this code in the Otterbot dashboard:\n\n*\`${code}\`*\n\nThis code expires in 1 hour.`,
+        thread_ts: threadTs,
+      });
+      this.io.emit("slack:pairing-request", {
+        code,
+        slackUserId,
+        slackUsername,
+      });
+      return;
+    }
+
+    // Strip bot mention from text
+    let content: string = event.text ?? "";
+    content = content.replace(/<@[A-Z0-9]+>/g, "").trim();
+    if (!content) return;
+
+    await this.routeToCOO(channelId, threadTs, slackUserId, content, say);
+  }
+
+  private async handleReactionAdded(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    event: any,
+  ): Promise<void> {
+    // Only track reactions from paired users for now
+    const slackUserId: string = event.user;
+    if (!isPaired(slackUserId)) return;
+
+    // Log the reaction — can be expanded to trigger specific actions
+    console.log(
+      `[Slack] Reaction :${event.reaction}: from ${slackUserId} on item ${event.item?.ts ?? "unknown"}`,
+    );
+  }
+
+  private async handleSlashCommand(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    command: any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    say: any,
+  ): Promise<void> {
+    const slackUserId: string = command.user_id;
+    const channelId: string = command.channel_id;
+    const text: string = command.text?.trim() ?? "";
+
+    if (!isPaired(slackUserId)) {
+      const code = generatePairingCode(slackUserId, command.user_name ?? slackUserId);
+      await say({
+        text: `I don't recognize you yet. To pair with me, ask my owner to approve this code in the Otterbot dashboard:\n\n*\`${code}\`*\n\nThis code expires in 1 hour.`,
+      });
+      this.io.emit("slack:pairing-request", {
+        code,
+        slackUserId,
+        slackUsername: command.user_name ?? slackUserId,
+      });
+      return;
+    }
+
+    if (!text) {
+      await say("Usage: `/otterbot <message>` — Send a message to Otterbot.");
+      return;
+    }
+
+    await this.routeToCOO(channelId, undefined, slackUserId, text, say);
+  }
+
+  private async routeToCOO(
+    channelId: string,
+    threadTs: string | undefined,
+    slackUserId: string,
+    content: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _say: any,
+  ): Promise<void> {
+    const convKey = `${slackUserId}:${channelId}`;
+
+    const db = getDb();
+    let conversationId = this.conversationMap.get(convKey);
+
+    if (!conversationId) {
+      conversationId = nanoid();
+      const now = new Date().toISOString();
+      const title = `Slack: ${slackUserId} — ${content.slice(0, 60)}`;
+      const conversation: Conversation = {
+        id: conversationId,
+        title,
+        projectId: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      db.insert(schema.conversations).values(conversation).run();
+      this.coo.startNewConversation(conversationId, null, null);
+      this.io.emit("conversation:created", conversation);
+      this.conversationMap.set(convKey, conversationId);
+    } else {
+      db.update(schema.conversations)
+        .set({ updatedAt: new Date().toISOString() })
+        .where(eq(schema.conversations.id, conversationId))
+        .run();
+    }
+
+    // Track pending response
+    this.pendingResponses.set(conversationId, {
+      channelId,
+      threadTs,
+      conversationId,
+    });
+
+    // Send to COO via bus
+    this.bus.send({
+      fromAgentId: null,
+      toAgentId: "coo",
+      type: MessageType.Chat,
+      content,
+      conversationId,
+      metadata: {
+        source: "slack",
+        slackUserId,
+        slackChannelId: channelId,
+        slackThreadTs: threadTs,
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound: COO → Slack
+  // -------------------------------------------------------------------------
+
+  private handleBusMessage(message: BusMessage): void {
+    if (message.fromAgentId !== "coo" || message.toAgentId !== null) return;
+
+    const conversationId = message.conversationId;
+    if (!conversationId) return;
+
+    const pending = this.pendingResponses.get(conversationId);
+    if (!pending) return;
+
+    this.pendingResponses.delete(conversationId);
+
+    this.sendSlackMessage(pending.channelId, message.content, pending.threadTs).catch(
+      (err) => {
+        console.error("[Slack] Error sending reply:", err);
+      },
+    );
+  }
+
+  private async sendSlackMessage(
+    channelId: string,
+    content: string,
+    threadTs?: string,
+  ): Promise<void> {
+    if (!this.app) return;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = (this.app as any).client;
+    const chunks = splitMessage(content, SLACK_MAX_LENGTH);
+
+    for (const chunk of chunks) {
+      await client.chat.postMessage({
+        channel: channelId,
+        text: chunk,
+        thread_ts: threadTs,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message splitting
+// ---------------------------------------------------------------------------
+
+function splitMessage(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLength) {
+    let splitIdx = -1;
+
+    // Try to split at paragraph boundary
+    const paragraphIdx = remaining.lastIndexOf("\n\n", maxLength);
+    if (paragraphIdx > maxLength * 0.3) {
+      splitIdx = paragraphIdx;
+    }
+
+    // Try sentence boundary
+    if (splitIdx === -1) {
+      const sentenceMatch = remaining.slice(0, maxLength).match(/.*[.!?]\s/s);
+      if (sentenceMatch) {
+        splitIdx = sentenceMatch[0].length;
+      }
+    }
+
+    // Hard cut at newline
+    if (splitIdx === -1) {
+      const newlineIdx = remaining.lastIndexOf("\n", maxLength);
+      if (newlineIdx > maxLength * 0.3) {
+        splitIdx = newlineIdx;
+      }
+    }
+
+    // Final fallback: hard cut
+    if (splitIdx === -1) {
+      splitIdx = maxLength;
+    }
+
+    chunks.push(remaining.slice(0, splitIdx).trimEnd());
+    remaining = remaining.slice(splitIdx).trimStart();
+  }
+
+  if (remaining) {
+    chunks.push(remaining);
+  }
+
+  return chunks;
+}

--- a/packages/server/src/slack/slack-settings.ts
+++ b/packages/server/src/slack/slack-settings.ts
@@ -1,0 +1,141 @@
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+import { listPairedUsers, listPendingPairings } from "./pairing.js";
+import type { PairedUser, PendingPairing } from "./pairing.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SlackAvailableChannel {
+  id: string;
+  name: string;
+}
+
+export interface SlackSettingsResponse {
+  enabled: boolean;
+  botTokenSet: boolean;
+  signingSecretSet: boolean;
+  appTokenSet: boolean;
+  requireMention: boolean;
+  botUsername: string | null;
+  allowedChannels: string[];
+  availableChannels: SlackAvailableChannel[];
+  pairedUsers: PairedUser[];
+  pendingPairings: PendingPairing[];
+}
+
+export interface SlackTestResult {
+  ok: boolean;
+  error?: string;
+  latencyMs?: number;
+  botUsername?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Settings CRUD
+// ---------------------------------------------------------------------------
+
+export function getSlackSettings(availableChannels: SlackAvailableChannel[] = []): SlackSettingsResponse {
+  const raw = getConfig("slack:allowed_channels");
+  let allowedChannels: string[] = [];
+  if (raw) {
+    try { allowedChannels = JSON.parse(raw); } catch { /* ignore */ }
+  }
+
+  return {
+    enabled: getConfig("slack:enabled") === "true",
+    botTokenSet: !!getConfig("slack:bot_token"),
+    signingSecretSet: !!getConfig("slack:signing_secret"),
+    appTokenSet: !!getConfig("slack:app_token"),
+    requireMention: getConfig("slack:require_mention") !== "false", // default true
+    botUsername: getConfig("slack:bot_username") ?? null,
+    allowedChannels,
+    availableChannels,
+    pairedUsers: listPairedUsers(),
+    pendingPairings: listPendingPairings(),
+  };
+}
+
+export function updateSlackSettings(data: {
+  enabled?: boolean;
+  botToken?: string;
+  signingSecret?: string;
+  appToken?: string;
+  requireMention?: boolean;
+  allowedChannels?: string[];
+}): void {
+  if (data.enabled !== undefined) {
+    setConfig("slack:enabled", data.enabled ? "true" : "false");
+  }
+  if (data.botToken !== undefined) {
+    if (data.botToken === "") {
+      deleteConfig("slack:bot_token");
+      deleteConfig("slack:bot_username");
+    } else {
+      setConfig("slack:bot_token", data.botToken);
+    }
+  }
+  if (data.signingSecret !== undefined) {
+    if (data.signingSecret === "") {
+      deleteConfig("slack:signing_secret");
+    } else {
+      setConfig("slack:signing_secret", data.signingSecret);
+    }
+  }
+  if (data.appToken !== undefined) {
+    if (data.appToken === "") {
+      deleteConfig("slack:app_token");
+    } else {
+      setConfig("slack:app_token", data.appToken);
+    }
+  }
+  if (data.requireMention !== undefined) {
+    setConfig("slack:require_mention", data.requireMention ? "true" : "false");
+  }
+  if (data.allowedChannels !== undefined) {
+    setConfig("slack:allowed_channels", JSON.stringify(data.allowedChannels));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connection test
+// ---------------------------------------------------------------------------
+
+export async function testSlackConnection(): Promise<SlackTestResult> {
+  const token = getConfig("slack:bot_token");
+  if (!token) return { ok: false, error: "Slack bot token not configured." };
+
+  const start = Date.now();
+
+  try {
+    const response = await fetch("https://slack.com/api/auth.test", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    const data = await response.json() as { ok: boolean; user?: string; error?: string };
+
+    if (!data.ok) {
+      return { ok: false, error: data.error ?? "Authentication failed" };
+    }
+
+    const username = data.user ?? undefined;
+    if (username) {
+      setConfig("slack:bot_username", username);
+    }
+
+    return {
+      ok: true,
+      latencyMs: Date.now() - start,
+      botUsername: username,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -54,6 +54,8 @@ export interface ServerToClientEvents {
   "matrix:status": (data: { status: "connected" | "disconnected" | "error"; userId?: string }) => void;
   "irc:status": (data: { status: "connected" | "disconnected" | "error"; nickname?: string }) => void;
   "teams:status": (data: { status: "connected" | "disconnected" | "error" }) => void;
+  "slack:pairing-request": (data: { code: string; slackUserId: string; slackUsername: string }) => void;
+  "slack:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
 }
 
 /** Events emitted from client to server */

--- a/packages/web/src/components/settings/ChannelsSection.tsx
+++ b/packages/web/src/components/settings/ChannelsSection.tsx
@@ -16,6 +16,7 @@ const CHANNELS = [
     name: "Slack",
     description: "Integrate with Slack workspaces",
     icon: "S",
+    settingsSection: "slack" as const,
   },
   {
     name: "Discord",
@@ -29,12 +30,17 @@ export function ChannelsSection() {
   const discordEnabled = useSettingsStore((s) => s.discordEnabled);
   const discordTokenSet = useSettingsStore((s) => s.discordTokenSet);
   const loadDiscordSettings = useSettingsStore((s) => s.loadDiscordSettings);
+  const slackEnabled = useSettingsStore((s) => s.slackEnabled);
+  const slackBotTokenSet = useSettingsStore((s) => s.slackBotTokenSet);
+  const loadSlackSettings = useSettingsStore((s) => s.loadSlackSettings);
 
   useEffect(() => {
     loadDiscordSettings();
+    loadSlackSettings();
   }, []);
 
   const isDiscordConnected = discordEnabled && discordTokenSet;
+  const isSlackConnected = slackEnabled && slackBotTokenSet;
 
   return (
     <div className="p-5 space-y-4">
@@ -47,7 +53,7 @@ export function ChannelsSection() {
 
       <div className="grid grid-cols-2 gap-3">
         {CHANNELS.map((channel) => {
-          const connected = channel.name === "Discord" && isDiscordConnected;
+          const connected = (channel.name === "Discord" && isDiscordConnected) || (channel.name === "Slack" && isSlackConnected);
           return (
             <div
               key={channel.name}

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -19,6 +19,7 @@ import { ScheduledTasksSection } from "./ScheduledTasksSection";
 import { EmailSection } from "./EmailSection";
 import { GitHubTab } from "./GitHubTab";
 import { DiscordSection } from "./DiscordSection";
+import { SlackSection } from "./SlackSection";
 import { GoogleSection } from "./GoogleSection";
 import { SecuritySection } from "./SecuritySection";
 import { ModulesSection } from "./ModulesSection";
@@ -54,6 +55,7 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
     if (activeSection === "google") return <GoogleSection />;
     if (activeSection === "github") return <GitHubTab />;
     if (activeSection === "discord") return <DiscordSection />;
+    if (activeSection === "slack") return <SlackSection />;
     if (activeSection === "security") return <SecuritySection />;
     if (activeSection === "soul") return <SoulTab />;
     if (activeSection === "memory") return <MemoryTab />;

--- a/packages/web/src/components/settings/SlackSection.tsx
+++ b/packages/web/src/components/settings/SlackSection.tsx
@@ -1,0 +1,457 @@
+import { useState, useEffect, useMemo } from "react";
+import { cn } from "../../lib/utils";
+import { useSettingsStore } from "../../stores/settings-store";
+import { getSocket } from "../../lib/socket";
+
+export function SlackSection() {
+  const enabled = useSettingsStore((s) => s.slackEnabled);
+  const botTokenSet = useSettingsStore((s) => s.slackBotTokenSet);
+  const signingSecretSet = useSettingsStore((s) => s.slackSigningSecretSet);
+  const appTokenSet = useSettingsStore((s) => s.slackAppTokenSet);
+  const requireMention = useSettingsStore((s) => s.slackRequireMention);
+  const botUsername = useSettingsStore((s) => s.slackBotUsername);
+  const allowedChannels = useSettingsStore((s) => s.slackAllowedChannels);
+  const availableChannels = useSettingsStore((s) => s.slackAvailableChannels);
+  const pairedUsers = useSettingsStore((s) => s.slackPairedUsers);
+  const pendingPairings = useSettingsStore((s) => s.slackPendingPairings);
+  const testResult = useSettingsStore((s) => s.slackTestResult);
+  const loadSlackSettings = useSettingsStore((s) => s.loadSlackSettings);
+  const updateSlackSettings = useSettingsStore((s) => s.updateSlackSettings);
+  const testSlackConnection = useSettingsStore((s) => s.testSlackConnection);
+  const approveSlackPairing = useSettingsStore((s) => s.approveSlackPairing);
+  const rejectSlackPairing = useSettingsStore((s) => s.rejectSlackPairing);
+  const revokeSlackUser = useSettingsStore((s) => s.revokeSlackUser);
+
+  const [localBotToken, setLocalBotToken] = useState("");
+  const [localSigningSecret, setLocalSigningSecret] = useState("");
+  const [localAppToken, setLocalAppToken] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [savingChannels, setSavingChannels] = useState(false);
+  const [selectedChannels, setSelectedChannels] = useState<Set<string>>(new Set());
+  const [botStatus, setBotStatus] = useState<"connected" | "disconnected" | "error">("disconnected");
+
+  useEffect(() => {
+    loadSlackSettings();
+  }, []);
+
+  // Listen for real-time Slack events
+  useEffect(() => {
+    const socket = getSocket();
+
+    const handleStatus = (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => {
+      setBotStatus(data.status);
+      if (data.status === "connected") {
+        loadSlackSettings();
+      }
+    };
+
+    const handlePairingRequest = () => {
+      loadSlackSettings();
+    };
+
+    socket.on("slack:status", handleStatus);
+    socket.on("slack:pairing-request", handlePairingRequest);
+
+    return () => {
+      socket.off("slack:status", handleStatus);
+      socket.off("slack:pairing-request", handlePairingRequest);
+    };
+  }, []);
+
+  // Sync local selectedChannels when allowedChannels loads
+  useEffect(() => {
+    setSelectedChannels(new Set(allowedChannels));
+  }, [allowedChannels]);
+
+  const handleToggleChannel = (channelId: string) => {
+    setSelectedChannels((prev) => {
+      const next = new Set(prev);
+      if (next.has(channelId)) {
+        next.delete(channelId);
+      } else {
+        next.add(channelId);
+      }
+      return next;
+    });
+  };
+
+  const handleSaveChannels = async () => {
+    setSavingChannels(true);
+    await updateSlackSettings({ allowedChannels: [...selectedChannels] });
+    setSavingChannels(false);
+  };
+
+  const channelsChanged = useMemo(() => {
+    if (selectedChannels.size !== allowedChannels.length) return true;
+    return allowedChannels.some((id) => !selectedChannels.has(id));
+  }, [selectedChannels, allowedChannels]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    const data: { botToken?: string; signingSecret?: string; appToken?: string } = {};
+    if (localBotToken) data.botToken = localBotToken;
+    if (localSigningSecret) data.signingSecret = localSigningSecret;
+    if (localAppToken) data.appToken = localAppToken;
+    await updateSlackSettings(data);
+    setLocalBotToken("");
+    setLocalSigningSecret("");
+    setLocalAppToken("");
+    setSaving(false);
+  };
+
+  const handleToggleEnabled = async () => {
+    await updateSlackSettings({ enabled: !enabled });
+  };
+
+  const handleToggleMention = async () => {
+    await updateSlackSettings({ requireMention: !requireMention });
+  };
+
+  const handleTest = () => {
+    testSlackConnection();
+  };
+
+  const handleClearTokens = async () => {
+    setSaving(true);
+    await updateSlackSettings({ botToken: "", signingSecret: "", appToken: "" });
+    setLocalBotToken("");
+    setLocalSigningSecret("");
+    setLocalAppToken("");
+    setSaving(false);
+  };
+
+  const allTokensSet = botTokenSet && signingSecretSet && appTokenSet;
+
+  return (
+    <div className="p-5 space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Connect Otterbot to Slack. Uses Socket Mode for real-time events. Users must pair with the bot before it responds to their messages.
+      </p>
+
+      {/* Enable toggle */}
+      <label className="flex items-center gap-3 cursor-pointer">
+        <button
+          onClick={handleToggleEnabled}
+          className={cn(
+            "relative w-9 h-5 rounded-full transition-colors",
+            enabled ? "bg-primary" : "bg-secondary",
+          )}
+        >
+          <span
+            className={cn(
+              "absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform",
+              enabled && "translate-x-4",
+            )}
+          />
+        </button>
+        <span className="text-sm">Enable Slack integration</span>
+      </label>
+
+      {/* Connection section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <div>
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Bot Token (xoxb-...)
+            {botTokenSet && (
+              <span className="ml-2 text-green-500 normal-case tracking-normal">Set</span>
+            )}
+          </label>
+          <input
+            type="password"
+            value={localBotToken}
+            onChange={(e) => setLocalBotToken(e.target.value)}
+            placeholder={botTokenSet ? "Enter new token to change" : "Paste your bot token"}
+            className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+          />
+        </div>
+
+        <div>
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Signing Secret
+            {signingSecretSet && (
+              <span className="ml-2 text-green-500 normal-case tracking-normal">Set</span>
+            )}
+          </label>
+          <input
+            type="password"
+            value={localSigningSecret}
+            onChange={(e) => setLocalSigningSecret(e.target.value)}
+            placeholder={signingSecretSet ? "Enter new secret to change" : "Paste your signing secret"}
+            className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+          />
+        </div>
+
+        <div>
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            App-Level Token (xapp-...)
+            {appTokenSet && (
+              <span className="ml-2 text-green-500 normal-case tracking-normal">Set</span>
+            )}
+          </label>
+          <input
+            type="password"
+            value={localAppToken}
+            onChange={(e) => setLocalAppToken(e.target.value)}
+            placeholder={appTokenSet ? "Enter new token to change" : "Paste your app-level token"}
+            className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+          />
+          <p className="text-[10px] text-muted-foreground mt-1">
+            Create a Slack app at{" "}
+            <a
+              href="https://api.slack.com/apps"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              api.slack.com/apps
+            </a>
+            . Enable Socket Mode and add required scopes.
+          </p>
+        </div>
+
+        {botUsername && (
+          <div className="text-xs text-muted-foreground">
+            Bot: <span className="text-foreground font-medium">{botUsername}</span>
+            {enabled && allTokensSet && (
+              <span className={cn(
+                "ml-2 text-[10px] px-1.5 py-0.5 rounded",
+                botStatus === "connected"
+                  ? "text-green-500 bg-green-500/10"
+                  : botStatus === "error"
+                    ? "text-red-500 bg-red-500/10"
+                    : "text-muted-foreground bg-muted",
+              )}>
+                {botStatus === "connected" ? "Online" : botStatus === "error" ? "Error" : "Offline"}
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 pt-1">
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="text-xs bg-primary text-primary-foreground px-3 py-1.5 rounded-md hover:bg-primary/90 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+          <button
+            onClick={handleTest}
+            disabled={testResult?.testing || !botTokenSet}
+            className="text-xs bg-secondary text-foreground px-3 py-1.5 rounded-md hover:bg-secondary/80 disabled:opacity-50"
+          >
+            {testResult?.testing ? "Testing..." : "Test Connection"}
+          </button>
+          {allTokensSet && (
+            <button
+              onClick={handleClearTokens}
+              disabled={saving}
+              className="text-xs text-red-500 hover:text-red-400 px-2 py-1.5"
+            >
+              Clear
+            </button>
+          )}
+
+          {testResult && !testResult.testing && (
+            <span
+              className={cn(
+                "text-xs",
+                testResult.ok ? "text-green-500" : "text-red-500",
+              )}
+            >
+              {testResult.ok
+                ? "\u2713 Connected"
+                : `\u2717 ${testResult.error ?? "Failed"}`}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Behavior section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Behavior
+        </label>
+        <label className="flex items-center gap-3 cursor-pointer">
+          <button
+            onClick={handleToggleMention}
+            className={cn(
+              "relative w-9 h-5 rounded-full transition-colors",
+              requireMention ? "bg-primary" : "bg-secondary",
+            )}
+          >
+            <span
+              className={cn(
+                "absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform",
+                requireMention && "translate-x-4",
+              )}
+            />
+          </button>
+          <div>
+            <span className="text-sm">Require @mention in channels</span>
+            <p className="text-[10px] text-muted-foreground">
+              When enabled, the bot only responds to messages that @mention it in channels. DMs always work.
+            </p>
+          </div>
+        </label>
+      </div>
+
+      {/* Allowed Channels section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Allowed Channels
+          {selectedChannels.size > 0 && (
+            <span className="ml-2 normal-case tracking-normal text-foreground">
+              {selectedChannels.size}
+            </span>
+          )}
+        </label>
+        <p className="text-[10px] text-muted-foreground">
+          When set, the bot only responds in these channels. DMs are always allowed.
+        </p>
+
+        {availableChannels.length === 0 ? (
+          <p className="text-[10px] text-muted-foreground italic">
+            Connect the bot to see available channels.
+          </p>
+        ) : (
+          <div className="space-y-1 max-h-64 overflow-y-auto">
+            {availableChannels.map((ch) => (
+              <label
+                key={ch.id}
+                className="flex items-center gap-2 cursor-pointer hover:bg-secondary/50 rounded px-2 py-1"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedChannels.has(ch.id)}
+                  onChange={() => handleToggleChannel(ch.id)}
+                  className="rounded border-border"
+                />
+                <span className="text-xs">#{ch.name}</span>
+              </label>
+            ))}
+          </div>
+        )}
+
+        {availableChannels.length > 0 && channelsChanged && (
+          <button
+            onClick={handleSaveChannels}
+            disabled={savingChannels}
+            className="text-xs bg-primary text-primary-foreground px-3 py-1.5 rounded-md hover:bg-primary/90 disabled:opacity-50"
+          >
+            {savingChannels ? "Saving..." : "Save"}
+          </button>
+        )}
+      </div>
+
+      {/* Paired Users section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Paired Users
+          <span className="ml-2 normal-case tracking-normal text-foreground">
+            {pairedUsers.length}
+          </span>
+        </label>
+
+        {pairedUsers.length === 0 ? (
+          <p className="text-[10px] text-muted-foreground">
+            No users have been paired yet. When someone messages the bot, they'll receive a pairing code to approve here.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {pairedUsers.map((user) => (
+              <div
+                key={user.slackUserId}
+                className="flex items-center justify-between bg-secondary rounded-md px-3 py-2"
+              >
+                <div>
+                  <span className="text-xs font-medium">{user.slackUsername}</span>
+                  <span className="text-[10px] text-muted-foreground ml-2">
+                    Paired {new Date(user.pairedAt).toLocaleDateString()}
+                  </span>
+                </div>
+                <button
+                  onClick={() => revokeSlackUser(user.slackUserId)}
+                  className="text-[10px] text-red-500 hover:text-red-400 px-2 py-1"
+                >
+                  Revoke
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Pending Pairings section */}
+      {pendingPairings.length > 0 && (
+        <div className="border border-border rounded-lg p-4 space-y-3">
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Pending Pairings
+            <span className="ml-2 normal-case tracking-normal text-yellow-500">
+              {pendingPairings.length}
+            </span>
+          </label>
+
+          <div className="space-y-2">
+            {pendingPairings.map((pairing) => (
+              <div
+                key={pairing.code}
+                className="flex items-center justify-between bg-secondary rounded-md px-3 py-2"
+              >
+                <div>
+                  <span className="text-xs font-medium">{pairing.slackUsername}</span>
+                  <code className="text-[10px] bg-muted px-1.5 py-0.5 rounded ml-2 font-mono">
+                    {pairing.code}
+                  </code>
+                  <span className="text-[10px] text-muted-foreground ml-2">
+                    {new Date(pairing.createdAt).toLocaleTimeString()}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => approveSlackPairing(pairing.code)}
+                    className="text-[10px] text-green-500 hover:text-green-400 bg-green-500/10 px-2 py-1 rounded"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => rejectSlackPairing(pairing.code)}
+                    className="text-[10px] text-red-500 hover:text-red-400 px-2 py-1"
+                  >
+                    Reject
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Setup instructions */}
+      <div className="text-[10px] text-muted-foreground space-y-1">
+        <p>
+          <strong>How to set up the Slack bot:</strong>
+        </p>
+        <ol className="list-decimal list-inside space-y-0.5">
+          <li>
+            Go to{" "}
+            <a
+              href="https://api.slack.com/apps"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              api.slack.com/apps
+            </a>{" "}
+            and create a new app
+          </li>
+          <li>Enable Socket Mode in "Socket Mode" settings and generate an App-Level Token (xapp-...)</li>
+          <li>Under "OAuth & Permissions", add bot scopes: chat:write, channels:read, groups:read, im:history, mpim:history, app_mentions:read, reactions:read, commands</li>
+          <li>Under "Event Subscriptions", subscribe to: message.im, message.mpim, app_mention, reaction_added</li>
+          <li>Optionally create a slash command "/otterbot" under "Slash Commands"</li>
+          <li>Install the app to your workspace and copy the Bot Token (xoxb-...) and Signing Secret</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/settings-nav.ts
+++ b/packages/web/src/components/settings/settings-nav.ts
@@ -19,6 +19,7 @@ export type SettingsSection =
   | "google"
   | "github"
   | "discord"
+  | "slack"
   | "security";
 
 export interface NavItem {
@@ -75,6 +76,7 @@ export const SETTINGS_NAV: NavGroup[] = [
       { id: "email", label: "Email Setup" },
       { id: "github", label: "GitHub" },
       { id: "discord", label: "Discord" },
+      { id: "slack", label: "Slack" },
     ],
   },
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@otterbot/shared':
         specifier: workspace:*
         version: link:../shared
+      '@slack/bolt':
+        specifier: ^4.6.0
+        version: 4.6.0(@types/express@5.0.6)
       ai:
         specifier: ^4.1.61
         version: 4.3.19(react@19.2.4)(zod@3.25.76)
@@ -1704,6 +1707,32 @@ packages:
     resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
+  '@slack/bolt@4.6.0':
+    resolution: {integrity: sha512-xPgfUs2+OXSugz54Ky07pA890+Qydk22SYToi8uGpXeHSt1JWwFJkRyd/9Vlg5I1AdfdpGXExDpwnbuN9Q/2dQ==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+    peerDependencies:
+      '@types/express': ^5.0.0
+
+  '@slack/logger@4.0.0':
+    resolution: {integrity: sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/oauth@3.0.4':
+    resolution: {integrity: sha512-+8H0g7mbrHndEUbYCP7uYyBCbwqmm3E6Mo3nfsDvZZW74zKk1ochfH/fWSvGInYNCVvaBUbg3RZBbTp0j8yJCg==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+
+  '@slack/socket-mode@2.0.5':
+    resolution: {integrity: sha512-VaapvmrAifeFLAFaDPfGhEwwunTKsI6bQhYzxRXw7BSujZUae5sANO76WqlVsLXuhVtCVrBWPiS2snAQR2RHJQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/types@2.20.0':
+    resolution: {integrity: sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/web-api@7.14.1':
+    resolution: {integrity: sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
@@ -1739,8 +1768,14 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
@@ -1859,11 +1894,20 @@ packages:
   '@types/events@3.0.3':
     resolution: {integrity: sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/jsonwebtoken@9.0.6':
     resolution: {integrity: sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==}
@@ -1880,6 +1924,12 @@ packages:
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
 
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1895,6 +1945,12 @@ packages:
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
@@ -2053,6 +2109,10 @@ packages:
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
   acorn@8.15.0:
@@ -2254,6 +2314,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -2316,6 +2380,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2453,12 +2521,20 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -2908,6 +2984,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
 
@@ -2916,6 +2995,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -3035,6 +3118,13 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -3056,6 +3146,10 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -3140,6 +3234,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.4.0:
     resolution: {integrity: sha512-5Ye4vHsypZRYtS01ob/iwHzGRUDELlsoCftI/OZFhcLs1M0tkGPcXldE80TAZC5yYuJMBPJQQ43UHlqbJWiX2w==}
     engines: {node: '>=20'}
@@ -3172,8 +3270,16 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -3378,6 +3484,10 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -3413,6 +3523,10 @@ packages:
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
@@ -3454,6 +3568,9 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
@@ -3493,9 +3610,16 @@ packages:
   is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
@@ -3804,6 +3928,14 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -3914,9 +4046,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -3976,6 +4116,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   netmask@2.0.2:
@@ -4053,6 +4197,10 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -4076,8 +4224,20 @@ packages:
   openssl-wrapper@0.3.4:
     resolution: {integrity: sha512-iITsrx6Ho8V3/2OVtmZzzX8wQaKAaFXEJQdzoPUZDtyf5jWFlqo+h+OhGT4TATQ47f9ACKHua8nw7Qoy85aeKQ==}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
   pac-proxy-agent@7.2.0:
@@ -4105,6 +4265,10 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
@@ -4125,6 +4289,9 @@ packages:
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -4273,6 +4440,10 @@ packages:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
     engines: {node: '>= 14'}
@@ -4301,6 +4472,14 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -4461,6 +4640,10 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rsa-pem-from-mod-exp@0.8.6:
     resolution: {integrity: sha512-c5ouQkOvGHF1qomUUDJGFcXsomeSO2gbEs6hVhMAtlkE1CuaZase/WzoaKFG/EZQuNmq6pw/EMCeEnDvOgCJYQ==}
 
@@ -4520,9 +4703,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -4859,6 +5050,10 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsscmp@1.0.6:
+    resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
+    engines: {node: '>=0.6.x'}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -4873,6 +5068,10 @@ packages:
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typed-query-selector@2.12.0:
     resolution: {integrity: sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==}
@@ -4923,6 +5122,10 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -6404,6 +6607,71 @@ snapshots:
 
   '@sapphire/snowflake@3.5.3': {}
 
+  '@slack/bolt@4.6.0(@types/express@5.0.6)':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/oauth': 3.0.4
+      '@slack/socket-mode': 2.0.5
+      '@slack/types': 2.20.0
+      '@slack/web-api': 7.14.1
+      '@types/express': 5.0.6
+      axios: 1.13.5
+      express: 5.2.1
+      path-to-regexp: 8.3.0
+      raw-body: 3.0.2
+      tsscmp: 1.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@slack/logger@4.0.0':
+    dependencies:
+      '@types/node': 22.19.11
+
+  '@slack/oauth@3.0.4':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/web-api': 7.14.1
+      '@types/jsonwebtoken': 9.0.6
+      '@types/node': 22.19.11
+      jsonwebtoken: 9.0.3
+    transitivePeerDependencies:
+      - debug
+
+  '@slack/socket-mode@2.0.5':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/web-api': 7.14.1
+      '@types/node': 22.19.11
+      '@types/ws': 8.18.1
+      eventemitter3: 5.0.4
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@slack/types@2.20.0': {}
+
+  '@slack/web-api@7.14.1':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/types': 2.20.0
+      '@types/node': 22.19.11
+      '@types/retry': 0.12.0
+      axios: 1.13.5
+      eventemitter3: 5.0.4
+      form-data: 4.0.5
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
+    transitivePeerDependencies:
+      - debug
+
   '@socket.io/component-emitter@3.1.2': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -6444,10 +6712,19 @@ snapshots:
     dependencies:
       '@types/node': 22.19.11
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.19.11
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.19.11
 
   '@types/cors@2.8.19':
     dependencies:
@@ -6588,11 +6865,26 @@ snapshots:
 
   '@types/events@3.0.3': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 22.19.11
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
   '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/jsonwebtoken@9.0.6':
     dependencies:
@@ -6610,6 +6902,10 @@ snapshots:
 
   '@types/offscreencanvas@2019.7.3': {}
 
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.13)':
     dependencies:
       '@types/react': 19.2.13
@@ -6623,6 +6919,15 @@ snapshots:
       csstype: 3.2.3
 
   '@types/retry@0.12.0': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.19.11
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.19.11
 
   '@types/stats.js@0.17.4': {}
 
@@ -6831,6 +7136,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn@8.15.0: {}
 
   adaptivecards@1.2.3: {}
@@ -7013,6 +7323,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0: {}
 
   botbuilder-core@4.23.3:
@@ -7146,6 +7470,8 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -7271,9 +7597,13 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.0.1: {}
+
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
 
@@ -7667,11 +7997,15 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.286: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -7882,6 +8216,10 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.4: {}
 
   events-universal@1.0.1:
@@ -7897,6 +8235,39 @@ snapshots:
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend-shallow@2.0.1:
     dependencies:
@@ -7998,6 +8369,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.4.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -8029,7 +8411,11 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  forwarded@0.2.0: {}
+
   fraction.js@5.3.4: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -8308,6 +8694,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   immediate@3.0.6: {}
@@ -8332,6 +8722,8 @@ snapshots:
   internmap@2.0.3: {}
 
   ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.3.0: {}
 
@@ -8378,6 +8770,8 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-electron@2.2.2: {}
+
   is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
@@ -8408,12 +8802,16 @@ snapshots:
 
   is-promise@2.2.2: {}
 
+  is-promise@4.0.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  is-stream@2.0.1: {}
 
   is-typed-array@1.1.15:
     dependencies:
@@ -8834,6 +9232,10 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   mermaid@11.12.2:
@@ -9065,9 +9467,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@3.0.0: {}
 
@@ -9115,6 +9523,8 @@ snapshots:
   napi-build-utils@2.0.0: {}
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   netmask@2.0.2: {}
 
@@ -9168,6 +9578,10 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -9200,10 +9614,21 @@ snapshots:
 
   openssl-wrapper@0.3.4: {}
 
+  p-finally@1.0.0: {}
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
 
   pac-proxy-agent@7.2.0:
     dependencies:
@@ -9248,6 +9673,8 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parseurl@1.3.3: {}
+
   partial-json@0.1.7: {}
 
   path-data-parser@0.1.0: {}
@@ -9265,6 +9692,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.6
       minipass: 7.1.2
+
+  path-to-regexp@8.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -9417,6 +9846,11 @@ snapshots:
       '@types/node': 22.19.11
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
@@ -9478,6 +9912,15 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -9698,6 +10141,16 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   rsa-pem-from-mod-exp@0.8.6: {}
 
   run-applescript@7.1.0: {}
@@ -9743,9 +10196,34 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-cookie-parser@2.7.2: {}
 
@@ -10183,6 +10661,8 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsscmp@1.0.6: {}
+
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.3
@@ -10203,6 +10683,12 @@ snapshots:
       - react
 
   type-fest@0.13.1: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-query-selector@2.12.0: {}
 
@@ -10257,6 +10743,8 @@ snapshots:
       unist-util-visit-parents: 6.0.2
 
   universalify@2.0.1: {}
+
+  unpipe@1.0.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:


### PR DESCRIPTION
## Summary

- Implements Slack chat provider integration using `@slack/bolt` SDK with Socket Mode
- Follows the existing channel adapter pattern (Discord, IRC, Teams)
- Includes full settings UI, pairing system, OAuth token management, and unit tests

### Server (`packages/server`)
- **SlackBridge** (`src/slack/slack-bridge.ts`): Handles inbound/outbound messages, `app_mention` events, `reaction_added` events, `/otterbot` slash command, thread support, and message splitting (4000 char limit)
- **Pairing** (`src/slack/pairing.ts`): 6-char hex pairing codes with 1-hour TTL, matching Discord pattern
- **Settings** (`src/slack/slack-settings.ts`): CRUD for bot token, signing secret, app-level token, require-mention toggle, channel whitelist; connection test via `auth.test` API
- **API routes** in `index.ts`: GET/PUT `/api/settings/slack`, POST test, pairing approve/reject/revoke
- **Bridge lifecycle**: start/stop integrated into server initialization, setup wizard, and graceful shutdown

### Shared (`packages/shared`)
- Added `slack:status` and `slack:pairing-request` Socket.IO events to `ServerToClientEvents`

### Web (`packages/web`)
- **SlackSection** component: Token inputs (bot token, signing secret, app-level token), enable toggle, test connection, require-mention toggle, channel whitelist, paired users management, pending pairings, setup instructions
- Updated settings store with Slack state and actions
- Added "Slack" to settings nav and SettingsPage routing
- Updated ChannelsSection to show Slack connection status

### Tests
- 24 unit tests covering: connection lifecycle, DM routing, bot/subtype filtering, pairing flow, channel whitelist, app_mention handling, slash commands, outbound messages, reactions, and available channels

## Test plan

- [x] All existing tests continue to pass (535/535)
- [x] New Slack bridge tests pass (24 tests)
- [ ] Manual: Configure Slack app with Socket Mode, verify bot connects
- [ ] Manual: Send DM to bot, verify pairing flow works
- [ ] Manual: Approve pairing in dashboard, verify messages route to COO
- [ ] Manual: Test @mention in channel, verify response in thread
- [ ] Manual: Test `/otterbot` slash command

🤖 Generated with [Claude Code](https://claude.com/claude-code)