### PR TITLE
fix: move Desktop component to Header before graph

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -276,6 +276,19 @@ function MainApp() {
         <div className="flex items-center gap-1">
           <button
             onClick={() => {
+              setCenterView("desktop");
+              setSettingsOpen(false);
+            }}
+            className={`text-xs transition-colors px-2 py-1 rounded ${
+              !settingsOpen && centerView === "desktop"
+                ? "text-primary bg-primary/10"
+                : "text-muted-foreground hover:text-foreground hover:bg-secondary"
+            }`}
+          >
+            Desktop
+          </button>
+          <button
+            onClick={() => {
               setCenterView("graph");
               setSettingsOpen(false);
             }}

--- a/packages/web/src/lib/get-center-tabs.test.ts
+++ b/packages/web/src/lib/get-center-tabs.test.ts
@@ -9,7 +9,7 @@ describe("getCenterTabs", () => {
 
   it("returns global tabs when no project is active (null)", () => {
     const tabs = getCenterTabs(null);
-    expect(tabs).toEqual(["dashboard", "todos", "inbox", "calendar", "code", "usage", "desktop"]);
+    expect(tabs).toEqual(["dashboard", "todos", "inbox", "calendar", "code", "usage"]);
   });
 
   it("includes 'code' in both project and global tabs", () => {
@@ -50,10 +50,16 @@ describe("centerViewLabels", () => {
 });
 
 describe("header navigation views", () => {
-  it("graph and live3d are both valid CenterView values with labels", () => {
-    // The header provides direct navigation to graph and live3d views
-    // (outside the tab bar). Both must remain valid CenterView values.
+  it("graph, live3d, and desktop are all valid CenterView values with labels", () => {
+    // The header provides direct navigation to graph, live3d, and desktop views
+    // (outside the tab bar). All must remain valid CenterView values.
     expect(centerViewLabels["graph"]).toBeDefined();
     expect(centerViewLabels["live3d"]).toBeDefined();
+    expect(centerViewLabels["desktop"]).toBeDefined();
+  });
+
+  it("desktop is not in the center tab bar (moved to header)", () => {
+    expect(getCenterTabs(null)).not.toContain("desktop");
+    expect(getCenterTabs("proj-1")).not.toContain("desktop");
   });
 });

--- a/packages/web/src/lib/get-center-tabs.ts
+++ b/packages/web/src/lib/get-center-tabs.ts
@@ -30,7 +30,7 @@ export const centerViewLabels: Record<CenterView, string> = {
 };
 
 const projectTabs: CenterView[] = ["dashboard", "kanban", "charter", "files", "code", "settings"];
-const globalTabs: CenterView[] = ["dashboard", "todos", "inbox", "calendar", "code", "usage", "desktop"];
+const globalTabs: CenterView[] = ["dashboard", "todos", "inbox", "calendar", "code", "usage"];
 
 export function getCenterTabs(activeProjectId: string | null): CenterView[] {
   return activeProjectId ? projectTabs : globalTabs;


### PR DESCRIPTION
Implemented UI change moving `Desktop` component into `Header` so it appears before the graph. All tests pass (607 tests). Closes #173.