### PR TITLE
feat: workers play random animation when busy

### DIFF
--- a/packages/web/src/components/live-view/AgentCharacter.test.tsx
+++ b/packages/web/src/components/live-view/AgentCharacter.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from "vitest";
+import type * as THREE from "three";
+
+import { findRandomClip, findClip } from "./AgentCharacter";
+
+const createMockAction = (name: string): THREE.AnimationAction => {
+  const mockAction = {
+    play: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+    fadeIn: vi.fn(),
+    fadeOut: vi.fn(),
+    getClip: vi.fn(() => ({ name })),
+  } as unknown as THREE.AnimationAction;
+  return mockAction;
+};
+
+describe("AgentCharacter helpers", () => {
+  describe("findRandomClip", () => {
+    it("returns a random matching clip when multiple matches exist", () => {
+      const actions = new Map<string, THREE.AnimationAction>();
+      actions.set("Working_A", createMockAction("Working_A"));
+      actions.set("Working_B", createMockAction("Working_B"));
+      actions.set("GenericWorking", createMockAction("GenericWorking"));
+
+      const patterns = [/Working/i, /GenericWorking/i];
+
+      const results = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        const result = findRandomClip(actions, patterns);
+        if (result) results.add(result);
+      }
+
+      expect(results.size).toBeGreaterThan(1);
+      expect(results.has("Working_A")).toBe(true);
+      expect(results.has("Working_B")).toBe(true);
+      expect(results.has("GenericWorking")).toBe(true);
+    });
+
+    it("returns undefined when no clips match patterns", () => {
+      const actions = new Map<string, THREE.AnimationAction>();
+      actions.set("Idle_A", createMockAction("Idle_A"));
+      actions.set("Idle_B", createMockAction("Idle_B"));
+
+      const patterns = [/Working/i, /Run/i];
+
+      expect(findRandomClip(actions, patterns)).toBeUndefined();
+    });
+
+    it("returns the only matching clip when exactly one matches", () => {
+      const actions = new Map<string, THREE.AnimationAction>();
+      actions.set("Working_A", createMockAction("Working_A"));
+      actions.set("Idle_A", createMockAction("Idle_A"));
+
+      const patterns = [/Working/i, /GenericWorking/i];
+
+      expect(findRandomClip(actions, patterns)).toBe("Working_A");
+    });
+
+    it("skips duplicates across patterns", () => {
+      const actions = new Map<string, THREE.AnimationAction>();
+      actions.set("Interact", createMockAction("Interact"));
+      actions.set("Working", createMockAction("Working"));
+
+      const patterns = [/Interact/i, /Working/i, /Interact/i];
+
+      const result = findRandomClip(actions, patterns);
+      expect(result).toBeDefined();
+      expect(result).not.toBe("Idle_A");
+    });
+
+    it("returns undefined for empty actions map", () => {
+      const actions = new Map<string, THREE.AnimationAction>();
+
+      expect(findRandomClip(actions, [/Working/i])).toBeUndefined();
+    });
+
+    it("ignores case in pattern matching", () => {
+      const actions = new Map<string, THREE.AnimationAction>();
+      actions.set("working_a", createMockAction("working_a"));
+      actions.set("WORKING_B", createMockAction("WORKING_B"));
+
+      const patterns = [/working/i];
+
+      const results = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        const result = findRandomClip(actions, patterns);
+        if (result) results.add(result);
+      }
+
+      expect(results.size).toBe(2);
+      expect(results.has("working_a")).toBe(true);
+      expect(results.has("WORKING_B")).toBe(true);
+    });
+  });
+
+  describe("findClip", () => {
+    it("returns first matching clip", () => {
+      const actions = new Map<string, THREE.AnimationAction>();
+      actions.set("Working_A", createMockAction("Working_A"));
+      actions.set("Working_B", createMockAction("Working_B"));
+
+      expect(findClip(actions, /Working/i)).toBe("Working_A");
+    });
+
+    it("returns undefined when no matches", () => {
+      const actions = new Map<string, THREE.AnimationAction>();
+      actions.set("Idle_A", createMockAction("Idle_A"));
+
+      expect(findClip(actions, /Working/i)).toBeUndefined();
+    });
+  });
+});

--- a/packages/web/src/components/live-view/AgentCharacter.tsx
+++ b/packages/web/src/components/live-view/AgentCharacter.tsx
@@ -26,6 +26,26 @@ const STATUS_COLORS: Record<string, string> = {
   error: "#ef4444",
 };
 
+export function findRandomClip(actions: Map<string, THREE.AnimationAction>, patterns: RegExp[]): string | undefined {
+  const candidates: string[] = [];
+  for (const pattern of patterns) {
+    for (const name of actions.keys()) {
+      if (pattern.test(name) && !candidates.includes(name)) {
+        candidates.push(name);
+      }
+    }
+  }
+  if (candidates.length === 0) return undefined;
+  return candidates[Math.floor(Math.random() * candidates.length)];
+}
+
+export function findClip(actions: Map<string, THREE.AnimationAction>, pattern: RegExp): string | undefined {
+  for (const name of actions.keys()) {
+    if (pattern.test(name)) return name;
+  }
+  return undefined;
+}
+
 export function AgentCharacter({ pack, position, label, role, status, agentId, gearConfig, rotationY = 0 }: AgentCharacterProps) {
   const groupRef = useRef<THREE.Group>(null);
   const currentRotationRef = useRef(rotationY);
@@ -210,14 +230,7 @@ function CharacterModel({ pack, status, agentId, gearConfig }: { pack: ModelPack
             findClip(actions, /Running_A/i) ??
             findClip(actions, /walk|run/i);
         } else if (effectiveStatus === "acting") {
-          targetName =
-            findClip(actions, /Working/i) ??
-            findClip(actions, /GenericWorking/i) ??
-            findClip(actions, /Interact/i) ??
-            findClip(actions, /Use_Item/i) ??
-            findClip(actions, /PickUp/i) ??
-            findClip(actions, /Idle_B/i) ??
-            findClip(actions, /idle/i);
+          targetName = findRandomClip(actions, [/Working/i, /GenericWorking/i, /Interact/i, /Use_Item/i, /PickUp/i, /Idle_B/i, /idle/i]);
         } else if (effectiveStatus === "thinking") {
           targetName =
             findClip(actions, /Idle_B/i) ??
@@ -257,13 +270,6 @@ function CharacterModel({ pack, status, agentId, gearConfig }: { pack: ModelPack
   });
 
   return <primitive object={clone} castShadow />;
-}
-
-function findClip(actions: Map<string, THREE.AnimationAction>, pattern: RegExp): string | undefined {
-  for (const name of actions.keys()) {
-    if (pattern.test(name)) return name;
-  }
-  return undefined;
 }
 
 function FallbackMesh({ role }: { role: string }) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    include: ["packages/*/src/**/*.test.ts"],
+    include: ["packages/*/src/**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Summary
- Extract `findRandomClip()` and `findClip()` as exported helper functions from `AgentCharacter`
- When a worker is in "acting" status, randomly select from available animation clips (Working, GenericWorking, Interact, Use_Item, PickUp, Idle_B, idle) instead of always using the first match
- Add comprehensive unit tests for both helper functions (8 test cases covering randomness, edge cases, deduplication, and case insensitivity)
- Update vitest config to include `.tsx` test files

Closes #168

## Test plan
- [x] All 615 existing tests pass
- [x] New `AgentCharacter.test.tsx` tests pass (8 tests)
- [x] Build completes successfully
- [ ] Visual verification: observe multiple busy workers display different animations in the 3D live view

🤖 Generated with [Claude Code](https://claude.com/claude-code)