### PR TITLE
feat: add Telegram chat provider integration

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -39,6 +39,7 @@
     "matrix-js-sdk": "^34.11.1",
     "nanoid": "^5.0.9",
     "node-pty": "^1.1.0",
+    "node-telegram-bot-api": "^0.67.0",
     "ollama-ai-provider": "^1.2.0",
     "playwright": "^1.50.0",
     "puppeteer": "^24.2.0",
@@ -61,6 +62,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.13.1",
+    "@types/node-telegram-bot-api": "^0.64.13",
     "@types/ws": "^8.5.13",
     "@types/yauzl": "^2.10.3",
     "@types/yazl": "^3.3.0",

--- a/packages/server/src/telegram/__tests__/telegram-bridge.test.ts
+++ b/packages/server/src/telegram/__tests__/telegram-bridge.test.ts
@@ -1,0 +1,610 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventEmitter } from "events";
+import { migrateDb, resetDb } from "../../db/index.js";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage } from "@otterbot/shared";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Mock node-telegram-bot-api
+// ---------------------------------------------------------------------------
+
+class MockTelegramBot extends EventEmitter {
+  token: string;
+  options: Record<string, unknown>;
+  pollingActive = true;
+  sentMessages: Array<{ chatId: number; text: string; options?: Record<string, unknown> }> = [];
+  chatActions: Array<{ chatId: number; action: string }> = [];
+  sentPhotos: Array<{ chatId: number; photo: unknown; options?: Record<string, unknown> }> = [];
+  sentDocuments: Array<{ chatId: number; doc: unknown; options?: Record<string, unknown> }> = [];
+
+  constructor(token: string, options?: Record<string, unknown>) {
+    super();
+    this.token = token;
+    this.options = options ?? {};
+  }
+
+  async getMe() {
+    return { id: 12345, is_bot: true, first_name: "OtterBot", username: "otterbot_test" };
+  }
+
+  async sendMessage(chatId: number, text: string, options?: Record<string, unknown>) {
+    this.sentMessages.push({ chatId, text, options });
+    return { message_id: Math.floor(Math.random() * 100000), chat: { id: chatId }, text };
+  }
+
+  async sendChatAction(chatId: number, action: string) {
+    this.chatActions.push({ chatId, action });
+  }
+
+  async sendPhoto(chatId: number, photo: unknown, options?: Record<string, unknown>) {
+    this.sentPhotos.push({ chatId, photo, options });
+    return { message_id: Math.floor(Math.random() * 100000) };
+  }
+
+  async sendDocument(chatId: number, doc: unknown, options?: Record<string, unknown>) {
+    this.sentDocuments.push({ chatId, doc, options });
+    return { message_id: Math.floor(Math.random() * 100000) };
+  }
+
+  async stopPolling() {
+    this.pollingActive = false;
+  }
+
+  // Test helper to simulate an incoming message
+  simulateMessage(msg: Record<string, unknown>) {
+    this.emit("message", msg);
+  }
+}
+
+let mockBotInstance: MockTelegramBot | null = null;
+
+vi.mock("node-telegram-bot-api", () => ({
+  default: class extends MockTelegramBot {
+    constructor(token: string, options?: Record<string, unknown>) {
+      super(token, options);
+      mockBotInstance = this;
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+// Import after mocking
+const { TelegramBridge } = await import("../telegram-bridge.js");
+
+interface SendParams {
+  fromAgentId: string | null;
+  toAgentId: string | null;
+  type: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  conversationId?: string;
+}
+
+function createMockBus() {
+  const broadcastHandlers: ((message: BusMessage) => void)[] = [];
+  const sent: SendParams[] = [];
+
+  const bus = {
+    send: vi.fn((params: SendParams) => {
+      sent.push(params);
+      const message: BusMessage = {
+        id: "test-msg-id",
+        fromAgentId: params.fromAgentId,
+        toAgentId: params.toAgentId,
+        type: params.type as BusMessage["type"],
+        content: params.content,
+        metadata: params.metadata ?? {},
+        conversationId: params.conversationId,
+        timestamp: new Date().toISOString(),
+      };
+      return message;
+    }),
+    onBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      broadcastHandlers.push(handler);
+    }),
+    offBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      const idx = broadcastHandlers.indexOf(handler);
+      if (idx >= 0) broadcastHandlers.splice(idx, 1);
+    }),
+    _broadcastHandlers: broadcastHandlers,
+    _sent: sent,
+  };
+
+  return bus;
+}
+
+function createMockCoo() {
+  return {
+    startNewConversation: vi.fn(),
+  };
+}
+
+function createMockIo() {
+  return {
+    emit: vi.fn(),
+  };
+}
+
+describe("TelegramBridge", () => {
+  let tmpDir: string;
+  let bus: ReturnType<typeof createMockBus>;
+  let coo: ReturnType<typeof createMockCoo>;
+  let io: ReturnType<typeof createMockIo>;
+  let bridge: InstanceType<typeof TelegramBridge>;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-telegram-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+
+    bus = createMockBus();
+    coo = createMockCoo();
+    io = createMockIo();
+    mockBotInstance = null;
+
+    bridge = new TelegramBridge({
+      bus: bus as any,
+      coo: coo as any,
+      io: io as any,
+    });
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // Connection & Lifecycle
+  // -------------------------------------------------------------------------
+
+  describe("connection initialization", () => {
+    it("starts the bot with polling", async () => {
+      await bridge.start("test-token");
+
+      expect(mockBotInstance).not.toBeNull();
+      expect(mockBotInstance!.pollingActive).toBe(true);
+    });
+
+    it("emits connected status on start", async () => {
+      await bridge.start("test-token");
+
+      expect(io.emit).toHaveBeenCalledWith("telegram:status", {
+        status: "connected",
+        botUsername: "otterbot_test",
+      });
+    });
+
+    it("subscribes to bus broadcasts", async () => {
+      await bridge.start("test-token");
+      expect(bus.onBroadcast).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("cleanup on stop", () => {
+    it("stops bot polling", async () => {
+      await bridge.start("test-token");
+      const bot = mockBotInstance!;
+      await bridge.stop();
+
+      expect(bot.pollingActive).toBe(false);
+    });
+
+    it("unsubscribes from bus broadcasts", async () => {
+      await bridge.start("test-token");
+      await bridge.stop();
+      expect(bus.offBroadcast).toHaveBeenCalledOnce();
+    });
+
+    it("emits disconnected status", async () => {
+      await bridge.start("test-token");
+      await bridge.stop();
+
+      expect(io.emit).toHaveBeenCalledWith("telegram:status", {
+        status: "disconnected",
+      });
+    });
+
+    it("can restart after stop", async () => {
+      await bridge.start("test-token");
+      await bridge.stop();
+      await bridge.start("test-token");
+
+      expect(mockBotInstance!.pollingActive).toBe(true);
+      expect(io.emit).toHaveBeenCalledWith("telegram:status", {
+        status: "connected",
+        botUsername: "otterbot_test",
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Inbound Messages (Telegram → COO)
+  // -------------------------------------------------------------------------
+
+  describe("message handling", () => {
+    it("routes messages from paired users to COO", async () => {
+      await bridge.start("test-token");
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("telegram:paired:111", JSON.stringify({
+        telegramUserId: "111",
+        telegramUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      mockBotInstance!.simulateMessage({
+        message_id: 1,
+        from: { id: 111, is_bot: false, first_name: "Alice", username: "alice" },
+        chat: { id: 222 },
+        text: "hello there",
+        date: Math.floor(Date.now() / 1000),
+      });
+
+      // Wait for async handler
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(bus.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromAgentId: null,
+          toAgentId: "coo",
+          type: MessageType.Chat,
+          content: "hello there",
+          metadata: expect.objectContaining({
+            source: "telegram",
+            telegramUserId: "111",
+            telegramChatId: "222",
+          }),
+        }),
+      );
+    });
+
+    it("ignores messages from bots", async () => {
+      await bridge.start("test-token");
+
+      mockBotInstance!.simulateMessage({
+        message_id: 1,
+        from: { id: 111, is_bot: true, first_name: "BotUser" },
+        chat: { id: 222 },
+        text: "bot message",
+        date: Math.floor(Date.now() / 1000),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("ignores messages without text", async () => {
+      await bridge.start("test-token");
+
+      mockBotInstance!.simulateMessage({
+        message_id: 1,
+        from: { id: 111, is_bot: false, first_name: "Alice" },
+        chat: { id: 222 },
+        date: Math.floor(Date.now() / 1000),
+        // no text field - sticker or media only
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("generates pairing code for unpaired users", async () => {
+      await bridge.start("test-token");
+
+      mockBotInstance!.simulateMessage({
+        message_id: 1,
+        from: { id: 999, is_bot: false, first_name: "Stranger", username: "stranger" },
+        chat: { id: 222 },
+        text: "hello",
+        date: Math.floor(Date.now() / 1000),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockBotInstance!.sentMessages).toHaveLength(1);
+      expect(mockBotInstance!.sentMessages[0]!.text).toContain("approve this code");
+      expect(io.emit).toHaveBeenCalledWith(
+        "telegram:pairing-request",
+        expect.objectContaining({
+          telegramUserId: "999",
+        }),
+      );
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("creates a conversation for new messages", async () => {
+      await bridge.start("test-token");
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("telegram:paired:111", JSON.stringify({
+        telegramUserId: "111",
+        telegramUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      mockBotInstance!.simulateMessage({
+        message_id: 1,
+        from: { id: 111, is_bot: false, first_name: "Alice", username: "alice" },
+        chat: { id: 222 },
+        text: "hello",
+        date: Math.floor(Date.now() / 1000),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(coo.startNewConversation).toHaveBeenCalledOnce();
+      expect(io.emit).toHaveBeenCalledWith(
+        "conversation:created",
+        expect.objectContaining({
+          title: expect.stringContaining("Telegram:"),
+        }),
+      );
+    });
+
+    it("reuses conversation for same user+chat", async () => {
+      await bridge.start("test-token");
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("telegram:paired:111", JSON.stringify({
+        telegramUserId: "111",
+        telegramUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      mockBotInstance!.simulateMessage({
+        message_id: 1,
+        from: { id: 111, is_bot: false, first_name: "Alice", username: "alice" },
+        chat: { id: 222 },
+        text: "first",
+        date: Math.floor(Date.now() / 1000),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      mockBotInstance!.simulateMessage({
+        message_id: 2,
+        from: { id: 111, is_bot: false, first_name: "Alice", username: "alice" },
+        chat: { id: 222 },
+        text: "second",
+        date: Math.floor(Date.now() / 1000),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(coo.startNewConversation).toHaveBeenCalledOnce();
+      expect(bus.send).toHaveBeenCalledTimes(2);
+    });
+
+    it("handles /start command with welcome message", async () => {
+      await bridge.start("test-token");
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("telegram:paired:111", JSON.stringify({
+        telegramUserId: "111",
+        telegramUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      mockBotInstance!.simulateMessage({
+        message_id: 1,
+        from: { id: 111, is_bot: false, first_name: "Alice", username: "alice" },
+        chat: { id: 222 },
+        text: "/start",
+        date: Math.floor(Date.now() / 1000),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockBotInstance!.sentMessages).toHaveLength(1);
+      expect(mockBotInstance!.sentMessages[0]!.text).toContain("Otterbot");
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("strips command prefix and forwards arguments", async () => {
+      await bridge.start("test-token");
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("telegram:paired:111", JSON.stringify({
+        telegramUserId: "111",
+        telegramUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      mockBotInstance!.simulateMessage({
+        message_id: 1,
+        from: { id: 111, is_bot: false, first_name: "Alice", username: "alice" },
+        chat: { id: 222 },
+        text: "/ask what is the weather?",
+        date: Math.floor(Date.now() / 1000),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(bus.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: "what is the weather?",
+        }),
+      );
+    });
+
+    it("sends typing indicator on message receipt", async () => {
+      await bridge.start("test-token");
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("telegram:paired:111", JSON.stringify({
+        telegramUserId: "111",
+        telegramUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      mockBotInstance!.simulateMessage({
+        message_id: 1,
+        from: { id: 111, is_bot: false, first_name: "Alice", username: "alice" },
+        chat: { id: 222 },
+        text: "hello",
+        date: Math.floor(Date.now() / 1000),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockBotInstance!.chatActions).toContainEqual({
+        chatId: 222,
+        action: "typing",
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Outbound Messages (COO → Telegram)
+  // -------------------------------------------------------------------------
+
+  describe("outbound messages", () => {
+    it("sends COO responses back to Telegram", async () => {
+      await bridge.start("test-token");
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("telegram:paired:111", JSON.stringify({
+        telegramUserId: "111",
+        telegramUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      mockBotInstance!.simulateMessage({
+        message_id: 42,
+        from: { id: 111, is_bot: false, first_name: "Alice", username: "alice" },
+        chat: { id: 222 },
+        text: "hello",
+        date: Math.floor(Date.now() / 1000),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const conversationId = bus.send.mock.calls[0]?.[0]?.conversationId;
+      expect(conversationId).toBeTruthy();
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "resp-1",
+        fromAgentId: "coo",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "Hello from COO!",
+        metadata: {},
+        conversationId,
+        timestamp: new Date().toISOString(),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const reply = mockBotInstance!.sentMessages.find((m) => m.text === "Hello from COO!");
+      expect(reply).toBeDefined();
+      expect(reply!.chatId).toBe(222);
+      expect(reply!.options).toEqual(
+        expect.objectContaining({ reply_to_message_id: 42 }),
+      );
+    });
+
+    it("ignores messages not from COO", async () => {
+      await bridge.start("test-token");
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "msg-1",
+        fromAgentId: "some-agent",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "Not from COO",
+        metadata: {},
+        conversationId: "conv-1",
+        timestamp: new Date().toISOString(),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const reply = mockBotInstance!.sentMessages.find((m) => m.text === "Not from COO");
+      expect(reply).toBeUndefined();
+    });
+
+    it("ignores COO messages addressed to another agent", async () => {
+      await bridge.start("test-token");
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "msg-1",
+        fromAgentId: "coo",
+        toAgentId: "some-agent",
+        type: MessageType.Chat,
+        content: "For another agent",
+        metadata: {},
+        conversationId: "conv-1",
+        timestamp: new Date().toISOString(),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const reply = mockBotInstance!.sentMessages.find((m) => m.text === "For another agent");
+      expect(reply).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Media & Inline Keyboards
+  // -------------------------------------------------------------------------
+
+  describe("media sending", () => {
+    it("can send photos", async () => {
+      await bridge.start("test-token");
+
+      await bridge.sendPhoto(222, "https://example.com/photo.jpg", "A photo");
+
+      expect(mockBotInstance!.sentPhotos).toHaveLength(1);
+      expect(mockBotInstance!.sentPhotos[0]).toEqual({
+        chatId: 222,
+        photo: "https://example.com/photo.jpg",
+        options: { caption: "A photo" },
+      });
+    });
+
+    it("can send documents", async () => {
+      await bridge.start("test-token");
+
+      await bridge.sendDocument(222, "https://example.com/doc.pdf", "A document");
+
+      expect(mockBotInstance!.sentDocuments).toHaveLength(1);
+      expect(mockBotInstance!.sentDocuments[0]).toEqual({
+        chatId: 222,
+        doc: "https://example.com/doc.pdf",
+        options: { caption: "A document" },
+      });
+    });
+
+    it("can send inline keyboards", async () => {
+      await bridge.start("test-token");
+
+      const keyboard = [[
+        { text: "Yes", callback_data: "yes" },
+        { text: "No", callback_data: "no" },
+      ]];
+
+      await bridge.sendMessageWithKeyboard(222, "Choose:", keyboard);
+
+      const msg = mockBotInstance!.sentMessages.find((m) => m.text === "Choose:");
+      expect(msg).toBeDefined();
+      expect(msg!.options).toEqual({
+        reply_markup: { inline_keyboard: keyboard },
+      });
+    });
+  });
+});

--- a/packages/server/src/telegram/pairing.ts
+++ b/packages/server/src/telegram/pairing.ts
@@ -1,0 +1,178 @@
+import { randomBytes } from "node:crypto";
+import { like } from "drizzle-orm";
+import { getDb, schema } from "../db/index.js";
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateCode(): string {
+  return randomBytes(3).toString("hex").toUpperCase(); // 6-char hex
+}
+
+const PAIRING_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export interface PendingPairing {
+  code: string;
+  telegramUserId: string;
+  telegramUsername: string;
+  createdAt: string;
+}
+
+export interface PairedUser {
+  telegramUserId: string;
+  telegramUsername: string;
+  pairedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Config-prefix query helper
+// ---------------------------------------------------------------------------
+
+function getConfigsByPrefix(prefix: string): Array<{ key: string; value: string }> {
+  const db = getDb();
+  return db
+    .select({ key: schema.config.key, value: schema.config.value })
+    .from(schema.config)
+    .where(like(schema.config.key, `${prefix}%`))
+    .all();
+}
+
+// ---------------------------------------------------------------------------
+// Pairing code management
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a pairing code for a Telegram user.
+ * Only one active code per user — generating a new one deletes the old.
+ */
+export function generatePairingCode(telegramUserId: string, telegramUsername: string): string {
+  // Remove any existing code for this user
+  const existing = getConfigsByPrefix("telegram:pairing:");
+  for (const row of existing) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (data.telegramUserId === telegramUserId) {
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+
+  const code = generateCode();
+  const data: PendingPairing = {
+    code,
+    telegramUserId,
+    telegramUsername,
+    createdAt: new Date().toISOString(),
+  };
+  setConfig(`telegram:pairing:${code}`, JSON.stringify(data));
+  return code;
+}
+
+/**
+ * Check whether a Telegram user is paired.
+ */
+export function isPaired(telegramUserId: string): boolean {
+  return !!getConfig(`telegram:paired:${telegramUserId}`);
+}
+
+/**
+ * Get paired user info.
+ */
+export function getPairedUser(telegramUserId: string): PairedUser | null {
+  const raw = getConfig(`telegram:paired:${telegramUserId}`);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as PairedUser;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Approve a pending pairing by code.
+ * Returns the paired user info, or null if the code is invalid/expired.
+ */
+export function approvePairing(code: string): PairedUser | null {
+  const raw = getConfig(`telegram:pairing:${code}`);
+  if (!raw) return null;
+
+  let pending: PendingPairing;
+  try {
+    pending = JSON.parse(raw) as PendingPairing;
+  } catch {
+    return null;
+  }
+
+  // Check expiry
+  if (Date.now() - new Date(pending.createdAt).getTime() > PAIRING_TTL_MS) {
+    deleteConfig(`telegram:pairing:${code}`);
+    return null;
+  }
+
+  const paired: PairedUser = {
+    telegramUserId: pending.telegramUserId,
+    telegramUsername: pending.telegramUsername,
+    pairedAt: new Date().toISOString(),
+  };
+
+  setConfig(`telegram:paired:${pending.telegramUserId}`, JSON.stringify(paired));
+  deleteConfig(`telegram:pairing:${code}`);
+  return paired;
+}
+
+/**
+ * Reject (delete) a pending pairing code.
+ */
+export function rejectPairing(code: string): boolean {
+  const raw = getConfig(`telegram:pairing:${code}`);
+  if (!raw) return false;
+  deleteConfig(`telegram:pairing:${code}`);
+  return true;
+}
+
+/**
+ * Revoke a paired user's access.
+ */
+export function revokePairing(telegramUserId: string): boolean {
+  const raw = getConfig(`telegram:paired:${telegramUserId}`);
+  if (!raw) return false;
+  deleteConfig(`telegram:paired:${telegramUserId}`);
+  return true;
+}
+
+/**
+ * List all paired users.
+ */
+export function listPairedUsers(): PairedUser[] {
+  const rows = getConfigsByPrefix("telegram:paired:");
+  const users: PairedUser[] = [];
+  for (const row of rows) {
+    try {
+      users.push(JSON.parse(row.value) as PairedUser);
+    } catch { /* ignore malformed */ }
+  }
+  return users;
+}
+
+/**
+ * List all pending (non-expired) pairing codes.
+ */
+export function listPendingPairings(): PendingPairing[] {
+  const rows = getConfigsByPrefix("telegram:pairing:");
+  const now = Date.now();
+  const pending: PendingPairing[] = [];
+  for (const row of rows) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (now - new Date(data.createdAt).getTime() <= PAIRING_TTL_MS) {
+        pending.push(data);
+      } else {
+        // Clean up expired
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+  return pending;
+}

--- a/packages/server/src/telegram/telegram-bridge.ts
+++ b/packages/server/src/telegram/telegram-bridge.ts
@@ -1,0 +1,390 @@
+import TelegramBot from "node-telegram-bot-api";
+import type {
+  Message as TelegramMessage,
+  SendMessageOptions,
+  InlineKeyboardButton,
+} from "node-telegram-bot-api";
+import { nanoid } from "nanoid";
+import { eq } from "drizzle-orm";
+import { Server } from "socket.io";
+import type { ServerToClientEvents, ClientToServerEvents } from "@otterbot/shared";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage, Conversation } from "@otterbot/shared";
+import { MessageBus } from "../bus/message-bus.js";
+import { COO } from "../agents/coo.js";
+import { getDb, schema } from "../db/index.js";
+import { isPaired, generatePairingCode, listPairedUsers } from "./pairing.js";
+
+type TypedServer = Server<ClientToServerEvents, ServerToClientEvents>;
+
+// ---------------------------------------------------------------------------
+// Telegram Bridge
+// ---------------------------------------------------------------------------
+
+const TELEGRAM_MAX_LENGTH = 4096;
+const TYPING_INTERVAL_MS = 4000;
+
+interface PendingResponse {
+  chatId: number;
+  messageId: number;
+  conversationId: string;
+  typingTimer: ReturnType<typeof setInterval>;
+}
+
+export class TelegramBridge {
+  private bot: TelegramBot | null = null;
+  private bus: MessageBus;
+  private coo: COO;
+  private io: TypedServer;
+  private pendingResponses = new Map<string, PendingResponse>();
+  private broadcastHandler: ((message: BusMessage) => void) | null = null;
+  /** Map of `{telegramUserId}:{chatId}` → conversationId */
+  private conversationMap = new Map<string, string>();
+  /** Map of conversationId → chatId (for sending unsolicited messages) */
+  private chatMap = new Map<string, number>();
+  /** Cached default chat ID for the first paired user (fallback delivery) */
+  private defaultChatId: number | null = null;
+
+  constructor(deps: { bus: MessageBus; coo: COO; io: TypedServer }) {
+    this.bus = deps.bus;
+    this.coo = deps.coo;
+    this.io = deps.io;
+  }
+
+  async start(token: string): Promise<void> {
+    if (this.bot) {
+      await this.stop();
+    }
+
+    this.bot = new TelegramBot(token, { polling: true });
+
+    const me = await this.bot.getMe();
+    console.log(`[Telegram] Logged in as @${me.username}`);
+    this.io.emit("telegram:status", {
+      status: "connected",
+      botUsername: me.username ?? me.first_name,
+    });
+
+    this.bot.on("message", (message) => {
+      this.handleMessage(message).catch((err) => {
+        console.error("[Telegram] Error handling message:", err);
+      });
+    });
+
+    this.bot.on("polling_error", (error) => {
+      console.error("[Telegram] Polling error:", error);
+      this.io.emit("telegram:status", { status: "error" });
+    });
+
+    // Subscribe to bus broadcasts to intercept COO responses
+    this.broadcastHandler = (message: BusMessage) => {
+      this.handleBusMessage(message);
+    };
+    this.bus.onBroadcast(this.broadcastHandler);
+  }
+
+  async stop(): Promise<void> {
+    // Clean up pending responses
+    for (const [, pending] of this.pendingResponses) {
+      clearInterval(pending.typingTimer);
+    }
+    this.pendingResponses.clear();
+
+    // Unsubscribe from bus
+    if (this.broadcastHandler) {
+      this.bus.offBroadcast(this.broadcastHandler);
+      this.broadcastHandler = null;
+    }
+
+    // Clear cached default chat
+    this.defaultChatId = null;
+
+    // Stop bot polling
+    if (this.bot) {
+      await this.bot.stopPolling();
+      this.bot = null;
+      this.io.emit("telegram:status", { status: "disconnected" });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Public: send media / inline keyboards
+  // -------------------------------------------------------------------------
+
+  async sendPhoto(chatId: number, photo: string | Buffer, caption?: string): Promise<void> {
+    if (!this.bot) return;
+    await this.bot.sendPhoto(chatId, photo, { caption });
+  }
+
+  async sendDocument(chatId: number, doc: string | Buffer, caption?: string): Promise<void> {
+    if (!this.bot) return;
+    await this.bot.sendDocument(chatId, doc, { caption });
+  }
+
+  async sendMessageWithKeyboard(
+    chatId: number,
+    text: string,
+    keyboard: InlineKeyboardButton[][],
+  ): Promise<void> {
+    if (!this.bot) return;
+    const opts: SendMessageOptions = {
+      reply_markup: { inline_keyboard: keyboard },
+    };
+    await this.bot.sendMessage(chatId, text, opts);
+  }
+
+  // -------------------------------------------------------------------------
+  // Inbound: Telegram → COO
+  // -------------------------------------------------------------------------
+
+  private async handleMessage(message: TelegramMessage): Promise<void> {
+    // Ignore messages without text (stickers, media-only, etc.)
+    if (!message.text) return;
+    // Ignore messages from bots
+    if (message.from?.is_bot) return;
+
+    const telegramUserId = String(message.from!.id);
+    const telegramUsername =
+      message.from!.username ?? message.from!.first_name ?? "Unknown";
+    const chatId = message.chat.id;
+
+    // Check pairing
+    if (!isPaired(telegramUserId)) {
+      const code = generatePairingCode(telegramUserId, telegramUsername);
+      await this.bot!.sendMessage(
+        chatId,
+        `I don't recognize you yet. To pair with me, ask my owner to approve this code in the Otterbot dashboard:\n\n*\`${code}\`*\n\nThis code expires in 1 hour.`,
+        { parse_mode: "Markdown" },
+      );
+      this.io.emit("telegram:pairing-request", {
+        code,
+        telegramUserId,
+        telegramUsername,
+      });
+      return;
+    }
+
+    // Handle /start command
+    let content = message.text;
+    if (content === "/start") {
+      await this.bot!.sendMessage(chatId, "Hello! I'm Otterbot. How can I help you?");
+      return;
+    }
+
+    // Strip bot commands prefix for forwarding (e.g., /ask something → something)
+    if (content.startsWith("/")) {
+      const spaceIdx = content.indexOf(" ");
+      if (spaceIdx === -1) {
+        // Command with no arguments — just forward the command name
+        content = content.slice(1);
+      } else {
+        content = content.slice(spaceIdx + 1).trim();
+      }
+    }
+
+    if (!content) return;
+
+    // Route to COO
+    await this.routeToCOO(message, telegramUserId, chatId, content);
+  }
+
+  private async routeToCOO(
+    telegramMessage: TelegramMessage,
+    telegramUserId: string,
+    chatId: number,
+    content: string,
+  ): Promise<void> {
+    const convKey = `${telegramUserId}:${chatId}`;
+
+    const db = getDb();
+    let conversationId = this.conversationMap.get(convKey);
+
+    if (!conversationId) {
+      // Create a new conversation for this Telegram chat
+      conversationId = nanoid();
+      const now = new Date().toISOString();
+      const senderName =
+        telegramMessage.from?.username ??
+        telegramMessage.from?.first_name ??
+        "Unknown";
+      const title = `Telegram: ${senderName} — ${content.slice(0, 60)}`;
+      const conversation: Conversation = {
+        id: conversationId,
+        title,
+        projectId: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      db.insert(schema.conversations).values(conversation).run();
+      this.coo.startNewConversation(conversationId, null, null);
+      this.io.emit("conversation:created", conversation);
+      this.conversationMap.set(convKey, conversationId);
+    } else {
+      // Update timestamp
+      db.update(schema.conversations)
+        .set({ updatedAt: new Date().toISOString() })
+        .where(eq(schema.conversations.id, conversationId))
+        .run();
+    }
+
+    // Start typing indicator
+    this.chatMap.set(conversationId, chatId);
+    const sendTyping = () => {
+      this.bot?.sendChatAction(chatId, "typing").catch(() => { /* ignore */ });
+    };
+    sendTyping();
+    const typingTimer = setInterval(sendTyping, TYPING_INTERVAL_MS);
+
+    // Track pending response
+    this.pendingResponses.set(conversationId, {
+      chatId,
+      messageId: telegramMessage.message_id,
+      conversationId,
+      typingTimer,
+    });
+
+    // Send to COO via bus
+    this.bus.send({
+      fromAgentId: null, // External user
+      toAgentId: "coo",
+      type: MessageType.Chat,
+      content,
+      conversationId,
+      metadata: {
+        source: "telegram",
+        telegramUserId,
+        telegramChatId: String(chatId),
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound: COO → Telegram
+  // -------------------------------------------------------------------------
+
+  private handleBusMessage(message: BusMessage): void {
+    // Only care about COO → CEO (null) responses
+    if (message.fromAgentId !== "coo" || message.toAgentId !== null) return;
+
+    const conversationId = message.conversationId;
+
+    // Direct reply to a Telegram-originated message
+    if (conversationId) {
+      const pending = this.pendingResponses.get(conversationId);
+      if (pending) {
+        clearInterval(pending.typingTimer);
+        this.pendingResponses.delete(conversationId);
+
+        this.sendTelegramReply(pending.chatId, pending.messageId, message.content).catch(
+          (err) => {
+            console.error("[Telegram] Error sending reply:", err);
+          },
+        );
+        return;
+      }
+
+      // Unsolicited message to a known Telegram chat
+      const chatId = this.chatMap.get(conversationId);
+      if (chatId) {
+        this.sendToChat(chatId, message.content).catch((err) => {
+          console.error("[Telegram] Error sending unsolicited message:", err);
+        });
+        return;
+      }
+    }
+
+    // Fallback: send to first paired user's chat
+    const fallbackChatId = this.getDefaultChatId();
+    if (fallbackChatId) {
+      this.sendToChat(fallbackChatId, message.content).catch((err) => {
+        console.error("[Telegram] Error sending DM fallback:", err);
+      });
+    } else {
+      console.warn(
+        "[Telegram] DM fallback: no chat available (no paired users or bot not ready)",
+      );
+    }
+  }
+
+  private getDefaultChatId(): number | null {
+    if (this.defaultChatId) return this.defaultChatId;
+    // We don't have a way to look up Telegram chat IDs for paired users
+    // without them messaging first. Return null if no chat is cached.
+    return null;
+  }
+
+  private async sendTelegramReply(
+    chatId: number,
+    replyToMessageId: number,
+    content: string,
+  ): Promise<void> {
+    if (!this.bot) return;
+    const chunks = splitMessage(content, TELEGRAM_MAX_LENGTH);
+    for (let i = 0; i < chunks.length; i++) {
+      const opts: SendMessageOptions = {};
+      if (i === 0) {
+        opts.reply_to_message_id = replyToMessageId;
+      }
+      await this.bot.sendMessage(chatId, chunks[i]!, opts);
+    }
+  }
+
+  private async sendToChat(chatId: number, content: string): Promise<void> {
+    if (!this.bot) return;
+    const chunks = splitMessage(content, TELEGRAM_MAX_LENGTH);
+    for (const chunk of chunks) {
+      await this.bot.sendMessage(chatId, chunk);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message splitting
+// ---------------------------------------------------------------------------
+
+function splitMessage(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLength) {
+    let splitIdx = -1;
+
+    // Try to split at paragraph boundary
+    const paragraphIdx = remaining.lastIndexOf("\n\n", maxLength);
+    if (paragraphIdx > maxLength * 0.3) {
+      splitIdx = paragraphIdx;
+    }
+
+    // Try sentence boundary
+    if (splitIdx === -1) {
+      const sentenceMatch = remaining.slice(0, maxLength).match(/.*[.!?]\s/s);
+      if (sentenceMatch) {
+        splitIdx = sentenceMatch[0].length;
+      }
+    }
+
+    // Hard cut at newline
+    if (splitIdx === -1) {
+      const newlineIdx = remaining.lastIndexOf("\n", maxLength);
+      if (newlineIdx > maxLength * 0.3) {
+        splitIdx = newlineIdx;
+      }
+    }
+
+    // Final fallback: hard cut
+    if (splitIdx === -1) {
+      splitIdx = maxLength;
+    }
+
+    chunks.push(remaining.slice(0, splitIdx).trimEnd());
+    remaining = remaining.slice(splitIdx).trimStart();
+  }
+
+  if (remaining) {
+    chunks.push(remaining);
+  }
+
+  return chunks;
+}

--- a/packages/server/src/telegram/telegram-settings.ts
+++ b/packages/server/src/telegram/telegram-settings.ts
@@ -1,0 +1,84 @@
+import TelegramBot from "node-telegram-bot-api";
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+import { listPairedUsers, listPendingPairings } from "./pairing.js";
+import type { PairedUser, PendingPairing } from "./pairing.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TelegramSettingsResponse {
+  enabled: boolean;
+  tokenSet: boolean;
+  botUsername: string | null;
+  pairedUsers: PairedUser[];
+  pendingPairings: PendingPairing[];
+}
+
+export interface TelegramTestResult {
+  ok: boolean;
+  error?: string;
+  latencyMs?: number;
+  botUsername?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Settings CRUD
+// ---------------------------------------------------------------------------
+
+export function getTelegramSettings(): TelegramSettingsResponse {
+  return {
+    enabled: getConfig("telegram:enabled") === "true",
+    tokenSet: !!getConfig("telegram:bot_token"),
+    botUsername: getConfig("telegram:bot_username") ?? null,
+    pairedUsers: listPairedUsers(),
+    pendingPairings: listPendingPairings(),
+  };
+}
+
+export function updateTelegramSettings(data: {
+  enabled?: boolean;
+  botToken?: string;
+}): void {
+  if (data.enabled !== undefined) {
+    setConfig("telegram:enabled", data.enabled ? "true" : "false");
+  }
+  if (data.botToken !== undefined) {
+    if (data.botToken === "") {
+      deleteConfig("telegram:bot_token");
+      deleteConfig("telegram:bot_username");
+    } else {
+      setConfig("telegram:bot_token", data.botToken);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connection test
+// ---------------------------------------------------------------------------
+
+export async function testTelegramConnection(): Promise<TelegramTestResult> {
+  const token = getConfig("telegram:bot_token");
+  if (!token) return { ok: false, error: "Telegram bot token not configured." };
+
+  const start = Date.now();
+  const bot = new TelegramBot(token);
+
+  try {
+    const me = await bot.getMe();
+    const username = me.username ?? undefined;
+    if (username) {
+      setConfig("telegram:bot_username", username);
+    }
+    return {
+      ok: true,
+      latencyMs: Date.now() - start,
+      botUsername: username,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -56,6 +56,8 @@ export interface ServerToClientEvents {
   "teams:status": (data: { status: "connected" | "disconnected" | "error" }) => void;
   "slack:pairing-request": (data: { code: string; slackUserId: string; slackUsername: string }) => void;
   "slack:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
+  "telegram:pairing-request": (data: { code: string; telegramUserId: string; telegramUsername: string }) => void;
+  "telegram:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
 }
 
 /** Events emitted from client to server */

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -39,7 +39,7 @@ export interface AgentModelOverride {
 }
 
 /** Supported messaging-platform chat provider types. */
-export type ChatProviderType = "discord" | "matrix" | "irc" | "teams";
+export type ChatProviderType = "discord" | "matrix" | "irc" | "teams" | "telegram";
 
 /** Settings common to all chat provider bridges. */
 export interface ChatProviderSettings {

--- a/packages/web/src/components/settings/ChannelsSection.tsx
+++ b/packages/web/src/components/settings/ChannelsSection.tsx
@@ -11,6 +11,7 @@ const CHANNELS = [
     name: "Telegram",
     description: "Connect to Telegram bots and channels",
     icon: "T",
+    settingsSection: "telegram" as const,
   },
   {
     name: "Slack",
@@ -30,16 +31,21 @@ export function ChannelsSection() {
   const discordEnabled = useSettingsStore((s) => s.discordEnabled);
   const discordTokenSet = useSettingsStore((s) => s.discordTokenSet);
   const loadDiscordSettings = useSettingsStore((s) => s.loadDiscordSettings);
+  const telegramEnabled = useSettingsStore((s) => s.telegramEnabled);
+  const telegramTokenSet = useSettingsStore((s) => s.telegramTokenSet);
+  const loadTelegramSettings = useSettingsStore((s) => s.loadTelegramSettings);
   const slackEnabled = useSettingsStore((s) => s.slackEnabled);
   const slackBotTokenSet = useSettingsStore((s) => s.slackBotTokenSet);
   const loadSlackSettings = useSettingsStore((s) => s.loadSlackSettings);
 
   useEffect(() => {
     loadDiscordSettings();
+    loadTelegramSettings();
     loadSlackSettings();
   }, []);
 
   const isDiscordConnected = discordEnabled && discordTokenSet;
+  const isTelegramConnected = telegramEnabled && telegramTokenSet;
   const isSlackConnected = slackEnabled && slackBotTokenSet;
 
   return (
@@ -53,7 +59,7 @@ export function ChannelsSection() {
 
       <div className="grid grid-cols-2 gap-3">
         {CHANNELS.map((channel) => {
-          const connected = (channel.name === "Discord" && isDiscordConnected) || (channel.name === "Slack" && isSlackConnected);
+          const connected = (channel.name === "Discord" && isDiscordConnected) || (channel.name === "Telegram" && isTelegramConnected) || (channel.name === "Slack" && isSlackConnected);
           return (
             <div
               key={channel.name}

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -20,6 +20,7 @@ import { EmailSection } from "./EmailSection";
 import { GitHubTab } from "./GitHubTab";
 import { DiscordSection } from "./DiscordSection";
 import { SlackSection } from "./SlackSection";
+import { TelegramSection } from "./TelegramSection";
 import { GoogleSection } from "./GoogleSection";
 import { SecuritySection } from "./SecuritySection";
 import { ModulesSection } from "./ModulesSection";
@@ -55,6 +56,7 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
     if (activeSection === "google") return <GoogleSection />;
     if (activeSection === "github") return <GitHubTab />;
     if (activeSection === "discord") return <DiscordSection />;
+    if (activeSection === "telegram") return <TelegramSection />;
     if (activeSection === "slack") return <SlackSection />;
     if (activeSection === "security") return <SecuritySection />;
     if (activeSection === "soul") return <SoulTab />;

--- a/packages/web/src/components/settings/TelegramSection.tsx
+++ b/packages/web/src/components/settings/TelegramSection.tsx
@@ -1,0 +1,304 @@
+import { useState, useEffect } from "react";
+import { cn } from "../../lib/utils";
+import { useSettingsStore } from "../../stores/settings-store";
+import { getSocket } from "../../lib/socket";
+
+export function TelegramSection() {
+  const enabled = useSettingsStore((s) => s.telegramEnabled);
+  const tokenSet = useSettingsStore((s) => s.telegramTokenSet);
+  const botUsername = useSettingsStore((s) => s.telegramBotUsername);
+  const pairedUsers = useSettingsStore((s) => s.telegramPairedUsers);
+  const pendingPairings = useSettingsStore((s) => s.telegramPendingPairings);
+  const testResult = useSettingsStore((s) => s.telegramTestResult);
+  const loadTelegramSettings = useSettingsStore((s) => s.loadTelegramSettings);
+  const updateTelegramSettings = useSettingsStore((s) => s.updateTelegramSettings);
+  const testTelegramConnection = useSettingsStore((s) => s.testTelegramConnection);
+  const approveTelegramPairing = useSettingsStore((s) => s.approveTelegramPairing);
+  const rejectTelegramPairing = useSettingsStore((s) => s.rejectTelegramPairing);
+  const revokeTelegramUser = useSettingsStore((s) => s.revokeTelegramUser);
+
+  const [localToken, setLocalToken] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [botStatus, setBotStatus] = useState<"connected" | "disconnected" | "error">("disconnected");
+
+  useEffect(() => {
+    loadTelegramSettings();
+  }, []);
+
+  // Listen for real-time Telegram events
+  useEffect(() => {
+    const socket = getSocket();
+
+    const handleStatus = (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => {
+      setBotStatus(data.status);
+      if (data.status === "connected") {
+        loadTelegramSettings();
+      }
+    };
+
+    const handlePairingRequest = () => {
+      loadTelegramSettings();
+    };
+
+    socket.on("telegram:status", handleStatus);
+    socket.on("telegram:pairing-request", handlePairingRequest);
+
+    return () => {
+      socket.off("telegram:status", handleStatus);
+      socket.off("telegram:pairing-request", handlePairingRequest);
+    };
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    const data: { enabled?: boolean; botToken?: string } = {};
+    if (localToken) {
+      data.botToken = localToken;
+    }
+    await updateTelegramSettings(data);
+    setLocalToken("");
+    setSaving(false);
+  };
+
+  const handleToggleEnabled = async () => {
+    await updateTelegramSettings({ enabled: !enabled });
+  };
+
+  const handleTest = () => {
+    testTelegramConnection();
+  };
+
+  const handleClearToken = async () => {
+    setSaving(true);
+    await updateTelegramSettings({ botToken: "" });
+    setLocalToken("");
+    setSaving(false);
+  };
+
+  return (
+    <div className="p-5 space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Connect Otterbot to Telegram. Users must pair with the bot before it
+        responds to their messages.
+      </p>
+
+      {/* Enable toggle */}
+      <label className="flex items-center gap-3 cursor-pointer">
+        <button
+          onClick={handleToggleEnabled}
+          className={cn(
+            "relative w-9 h-5 rounded-full transition-colors",
+            enabled ? "bg-primary" : "bg-secondary",
+          )}
+        >
+          <span
+            className={cn(
+              "absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform",
+              enabled && "translate-x-4",
+            )}
+          />
+        </button>
+        <span className="text-sm">Enable Telegram integration</span>
+      </label>
+
+      {/* Connection section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <div>
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Bot Token
+            {tokenSet && (
+              <span className="ml-2 text-green-500 normal-case tracking-normal">
+                Set
+              </span>
+            )}
+          </label>
+          <input
+            type="password"
+            value={localToken}
+            onChange={(e) => setLocalToken(e.target.value)}
+            placeholder={
+              tokenSet ? "Enter new token to change" : "Paste your bot token"
+            }
+            className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+          />
+          <p className="text-[10px] text-muted-foreground mt-1">
+            Create a bot via{" "}
+            <a
+              href="https://t.me/BotFather"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              @BotFather
+            </a>{" "}
+            on Telegram and paste the token here.
+          </p>
+        </div>
+
+        {botUsername && (
+          <div className="text-xs text-muted-foreground">
+            Bot: <span className="text-foreground font-medium">@{botUsername}</span>
+            {enabled && tokenSet && (
+              <span className={cn(
+                "ml-2 text-[10px] px-1.5 py-0.5 rounded",
+                botStatus === "connected"
+                  ? "text-green-500 bg-green-500/10"
+                  : botStatus === "error"
+                    ? "text-red-500 bg-red-500/10"
+                    : "text-muted-foreground bg-muted",
+              )}>
+                {botStatus === "connected" ? "Online" : botStatus === "error" ? "Error" : "Offline"}
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 pt-1">
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="text-xs bg-primary text-primary-foreground px-3 py-1.5 rounded-md hover:bg-primary/90 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+          <button
+            onClick={handleTest}
+            disabled={testResult?.testing || !tokenSet}
+            className="text-xs bg-secondary text-foreground px-3 py-1.5 rounded-md hover:bg-secondary/80 disabled:opacity-50"
+          >
+            {testResult?.testing ? "Testing..." : "Test Connection"}
+          </button>
+          {tokenSet && (
+            <button
+              onClick={handleClearToken}
+              disabled={saving}
+              className="text-xs text-red-500 hover:text-red-400 px-2 py-1.5"
+            >
+              Clear
+            </button>
+          )}
+
+          {testResult && !testResult.testing && (
+            <span
+              className={cn(
+                "text-xs",
+                testResult.ok ? "text-green-500" : "text-red-500",
+              )}
+            >
+              {testResult.ok
+                ? "\u2713 Connected"
+                : `\u2717 ${testResult.error ?? "Failed"}`}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Paired Users section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Paired Users
+          <span className="ml-2 normal-case tracking-normal text-foreground">
+            {pairedUsers.length}
+          </span>
+        </label>
+
+        {pairedUsers.length === 0 ? (
+          <p className="text-[10px] text-muted-foreground">
+            No users have been paired yet. When someone messages the bot, they'll receive a pairing code to approve here.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {pairedUsers.map((user) => (
+              <div
+                key={user.telegramUserId}
+                className="flex items-center justify-between bg-secondary rounded-md px-3 py-2"
+              >
+                <div>
+                  <span className="text-xs font-medium">{user.telegramUsername}</span>
+                  <span className="text-[10px] text-muted-foreground ml-2">
+                    Paired {new Date(user.pairedAt).toLocaleDateString()}
+                  </span>
+                </div>
+                <button
+                  onClick={() => revokeTelegramUser(user.telegramUserId)}
+                  className="text-[10px] text-red-500 hover:text-red-400 px-2 py-1"
+                >
+                  Revoke
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Pending Pairings section */}
+      {pendingPairings.length > 0 && (
+        <div className="border border-border rounded-lg p-4 space-y-3">
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Pending Pairings
+            <span className="ml-2 normal-case tracking-normal text-yellow-500">
+              {pendingPairings.length}
+            </span>
+          </label>
+
+          <div className="space-y-2">
+            {pendingPairings.map((pairing) => (
+              <div
+                key={pairing.code}
+                className="flex items-center justify-between bg-secondary rounded-md px-3 py-2"
+              >
+                <div>
+                  <span className="text-xs font-medium">{pairing.telegramUsername}</span>
+                  <code className="text-[10px] bg-muted px-1.5 py-0.5 rounded ml-2 font-mono">
+                    {pairing.code}
+                  </code>
+                  <span className="text-[10px] text-muted-foreground ml-2">
+                    {new Date(pairing.createdAt).toLocaleTimeString()}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => approveTelegramPairing(pairing.code)}
+                    className="text-[10px] text-green-500 hover:text-green-400 bg-green-500/10 px-2 py-1 rounded"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => rejectTelegramPairing(pairing.code)}
+                    className="text-[10px] text-red-500 hover:text-red-400 px-2 py-1"
+                  >
+                    Reject
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Setup instructions */}
+      <div className="text-[10px] text-muted-foreground space-y-1">
+        <p>
+          <strong>How to set up the Telegram bot:</strong>
+        </p>
+        <ol className="list-decimal list-inside space-y-0.5">
+          <li>
+            Open Telegram and search for{" "}
+            <a
+              href="https://t.me/BotFather"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              @BotFather
+            </a>
+          </li>
+          <li>Send /newbot and follow the prompts to create a new bot</li>
+          <li>Copy the bot token and paste it above</li>
+          <li>Start a conversation with your new bot on Telegram</li>
+          <li>Approve the pairing code that appears in the dashboard</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/settings-nav.ts
+++ b/packages/web/src/components/settings/settings-nav.ts
@@ -19,6 +19,7 @@ export type SettingsSection =
   | "google"
   | "github"
   | "discord"
+  | "telegram"
   | "slack"
   | "security";
 
@@ -76,6 +77,7 @@ export const SETTINGS_NAV: NavGroup[] = [
       { id: "email", label: "Email Setup" },
       { id: "github", label: "GitHub" },
       { id: "discord", label: "Discord" },
+      { id: "telegram", label: "Telegram" },
       { id: "slack", label: "Slack" },
     ],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      node-telegram-bot-api:
+        specifier: ^0.67.0
+        version: 0.67.0(request@2.88.2)
       ollama-ai-provider:
         specifier: ^1.2.0
         version: 1.2.0(zod@3.25.76)
@@ -157,6 +160,9 @@ importers:
       '@types/node':
         specifier: ^22.13.1
         version: 22.19.11
+      '@types/node-telegram-bot-api':
+        specifier: ^0.64.13
+        version: 0.64.13
       '@types/ws':
         specifier: ^8.5.13
         version: 8.18.1
@@ -553,6 +559,16 @@ packages:
 
   '@chevrotain/utils@11.0.3':
     resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
+
+  '@cypress/request-promise@5.0.0':
+    resolution: {integrity: sha512-eKdYVpa9cBEw2kTBlHeu1PP16Blwtum6QHg/u9s/MoHkZfuo1pRGka1VlUHXF5kdew82BvOJVVGk0x8X0nbp+w==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      '@cypress/request': ^3.0.0
+
+  '@cypress/request@3.0.10':
+    resolution: {integrity: sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==}
+    engines: {node: '>= 6'}
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
@@ -1802,6 +1818,9 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/caseless@0.12.5':
+    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1949,6 +1968,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node-telegram-bot-api@0.64.13':
+    resolution: {integrity: sha512-/d3sYpZq4sDwKWAm9XsIsb8MclclJ1yPXZC7uAzZRrJIFY8yg/63oNrLf9CBTlaS/XGR1N66BwibfJQGiWVsqg==}
+
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
 
@@ -1974,6 +1996,9 @@ packages:
   '@types/react@19.2.13':
     resolution: {integrity: sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==}
 
+  '@types/request@2.48.13':
+    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
@@ -1988,6 +2013,9 @@ packages:
 
   '@types/three@0.182.0':
     resolution: {integrity: sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2176,6 +2204,9 @@ packages:
       ajv:
         optional: true
 
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
@@ -2214,6 +2245,25 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findindex@2.2.4:
+    resolution: {integrity: sha512-LLm4mhxa9v8j0A/RPnpQAP4svXToJFh+Hp1pNYl5ZD5qpB4zdx/D4YjpVcETkhFbUKWO3iGMVLvrOnnmkAJT6A==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2224,6 +2274,10 @@ packages:
 
   ast-v8-to-istanbul@0.3.11:
     resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -2245,6 +2299,12 @@ packages:
 
   avvio@9.1.0:
     resolution: {integrity: sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==}
+
+  aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
@@ -2323,6 +2383,9 @@ packages:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   better-sqlite3-multiple-ciphers@11.10.0:
     resolution: {integrity: sha512-/dKO3lKuJFbmuzh80uN2cmMsz8iyTskGB2l/fd9X6rt1P3EPIOvRUIxD7Qim8gLygUPB/u+db8byZGumOOdp3g==}
 
@@ -2342,8 +2405,14 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
+  bl@1.2.3:
+    resolution: {integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -2448,6 +2517,9 @@ packages:
 
   caniuse-lite@1.0.30001769:
     resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2577,6 +2649,12 @@ packages:
 
   core-js@3.48.0:
     resolution: {integrity: sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==}
+
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -2773,6 +2851,10 @@ packages:
   dagre-d3-es@7.0.13:
     resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==}
 
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -2781,8 +2863,28 @@ packages:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
 
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
   dayjs@1.11.19:
     resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
+
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -3012,6 +3114,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -3060,6 +3165,10 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  es-abstract@1.24.1:
+    resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
+    engines: {node: '>= 0.4'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -3077,6 +3186,14 @@ packages:
 
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
   es-toolkit@1.44.0:
@@ -3153,6 +3270,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventemitter3@3.1.2:
+    resolution: {integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
@@ -3194,6 +3314,10 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
+  extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
 
@@ -3206,6 +3330,9 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-json-stringify@6.3.0:
     resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
@@ -3250,6 +3377,10 @@ packages:
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
+  file-type@3.9.0:
+    resolution: {integrity: sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==}
+    engines: {node: '>=0.10.0'}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
@@ -3293,6 +3424,17 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+
+  form-data@2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
+
+  form-data@2.5.5:
+    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
+    engines: {node: '>= 0.12'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -3335,6 +3477,13 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
   gaxios@7.1.3:
     resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
     engines: {node: '>=18'}
@@ -3372,12 +3521,19 @@ packages:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
 
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
+
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -3452,12 +3608,29 @@ packages:
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
+  har-schema@2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+
+  har-validator@5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -3507,6 +3680,14 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http-signature@1.2.0:
+    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
+
+  http-signature@1.4.0:
+    resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
+    engines: {node: '>=0.10'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -3544,6 +3725,10 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
@@ -3576,12 +3761,28 @@ packages:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
     engines: {node: '>= 0.4'}
 
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -3589,6 +3790,14 @@ packages:
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
   is-decimal@2.0.1:
@@ -3610,6 +3819,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -3630,6 +3843,18 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -3648,17 +3873,54 @@ packages:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
 
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
 
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -3673,6 +3935,9 @@ packages:
 
   isomorphic-textencoder@1.0.1:
     resolution: {integrity: sha512-676hESgHullDdHDsj469hr+7t3i/neBKU9J7q1T4RHaWwLAsaQnywC0D1dIUId0YZ+JtVrShzuBk1soo0+GVcQ==}
+
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -3719,6 +3984,9 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -3732,6 +4000,9 @@ packages:
 
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -3758,6 +4029,14 @@ packages:
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
+
+  jsprim@1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
+
+  jsprim@2.0.2:
+    resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
+    engines: {'0': node >=0.6.0}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -4089,6 +4368,11 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
@@ -4188,9 +4472,16 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  node-telegram-bot-api@0.67.0:
+    resolution: {integrity: sha512-gO7o/dPcdFSUuFuPiAYBxV7bcN+vQL3pfaHN8P4z8fPtFstN05xVmhMFOth57DANGDKBpzW3rMRo7debOlUI1w==}
+    engines: {node: '>=0.12'}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4206,6 +4497,10 @@ packages:
 
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
   obug@2.1.1:
@@ -4254,6 +4549,10 @@ packages:
 
   openssl-wrapper@0.3.4:
     resolution: {integrity: sha512-iITsrx6Ho8V3/2OVtmZzzX8wQaKAaFXEJQdzoPUZDtyf5jWFlqo+h+OhGT4TATQ47f9ACKHua8nw7Qoy85aeKQ==}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
@@ -4333,6 +4632,9 @@ packages:
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   phonemizer@1.2.1:
     resolution: {integrity: sha512-v0KJ4mi2T4Q7eJQ0W15Xd4G9k4kICSXE8bpDeJ8jisL4RyJhNWsweKTOi88QXFc4r4LZlz5jVL5lCHhkpdT71A==}
@@ -4451,6 +4753,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
@@ -4482,8 +4787,18 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  pump@2.0.1:
+    resolution: {integrity: sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   puppeteer-core@24.37.3:
     resolution: {integrity: sha512-fokQ8gv+hNgsRWqVuP5rUjGp+wzV5aMTP3fcm8ekNabmLGlJdFHas1OdMscAH9Gzq4Qcf7cfI/Pe6wEcAqQhqg==}
@@ -4494,9 +4809,20 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
+
+  qs@6.5.5:
+    resolution: {integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==}
+    engines: {node: '>=0.6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4568,6 +4894,9 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -4596,8 +4925,16 @@ packages:
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
 
   rehype-highlight@7.0.2:
     resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
@@ -4614,6 +4951,17 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  request-promise-core@1.1.3:
+    resolution: {integrity: sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      request: ^2.34
+
+  request@2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -4621,6 +4969,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
@@ -4688,8 +5039,19 @@ packages:
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
+  safe-array-concat@1.1.3:
+    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
+    engines: {node: '>=0.4'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
 
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
@@ -4751,6 +5113,14 @@ packages:
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
   setprototypeof@1.2.0:
@@ -4855,6 +5225,11 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -4874,6 +5249,14 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stealthy-require@1.1.1:
+    resolution: {integrity: sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==}
+    engines: {node: '>=0.10.0'}
+
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
 
@@ -4887,6 +5270,21 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string.prototype.trim@1.2.10:
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.9:
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -5034,6 +5432,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -5045,6 +5450,18 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
+
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -5096,6 +5513,9 @@ packages:
   tunnel-rat@0.1.2:
     resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
@@ -5103,6 +5523,22 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.7:
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
 
   typed-query-selector@2.12.0:
     resolution: {integrity: sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==}
@@ -5114,6 +5550,10 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -5150,6 +5590,10 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -5163,6 +5607,12 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
@@ -5190,6 +5640,11 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -5197,6 +5652,10 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -5352,6 +5811,18 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
 
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
@@ -5828,6 +6299,37 @@ snapshots:
   '@chevrotain/types@11.0.3': {}
 
   '@chevrotain/utils@11.0.3': {}
+
+  '@cypress/request-promise@5.0.0(@cypress/request@3.0.10)(request@2.88.2)':
+    dependencies:
+      '@cypress/request': 3.0.10
+      bluebird: 3.7.2
+      request-promise-core: 1.1.3(request@2.88.2)
+      stealthy-require: 1.1.1
+      tough-cookie: 4.1.4
+    transitivePeerDependencies:
+      - request
+
+  '@cypress/request@3.0.10':
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 4.0.5
+      http-signature: 1.4.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      performance-now: 2.1.0
+      qs: 6.14.2
+      safe-buffer: 5.2.1
+      tough-cookie: 5.1.2
+      tunnel-agent: 0.6.0
+      uuid: 8.3.2
 
   '@dimforge/rapier3d-compat@0.12.0': {}
 
@@ -6773,6 +7275,8 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 22.19.11
 
+  '@types/caseless@0.12.5': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -6952,6 +7456,11 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node-telegram-bot-api@0.64.13':
+    dependencies:
+      '@types/node': 22.19.11
+      '@types/request': 2.48.13
+
   '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
@@ -6973,6 +7482,13 @@ snapshots:
   '@types/react@19.2.13':
     dependencies:
       csstype: 3.2.3
+
+  '@types/request@2.48.13':
+    dependencies:
+      '@types/caseless': 0.12.5
+      '@types/node': 22.19.11
+      '@types/tough-cookie': 4.0.5
+      form-data: 2.5.5
 
   '@types/retry@0.12.0': {}
 
@@ -6996,6 +7512,8 @@ snapshots:
       '@webgpu/types': 0.1.69
       fflate: 0.8.2
       meshoptimizer: 0.22.0
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -7219,6 +7737,13 @@ snapshots:
     optionalDependencies:
       ajv: 8.17.1
 
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -7253,6 +7778,36 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array.prototype.findindex@2.2.4:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
+
   assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
@@ -7264,6 +7819,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  async-function@1.0.0: {}
 
   asynckit@0.4.0: {}
 
@@ -7286,6 +7843,10 @@ snapshots:
     dependencies:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
+
+  aws-sign2@0.7.0: {}
+
+  aws4@1.13.2: {}
 
   axios@1.13.5:
     dependencies:
@@ -7350,6 +7911,10 @@ snapshots:
 
   basic-ftp@5.1.0: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   better-sqlite3-multiple-ciphers@11.10.0:
     dependencies:
       bindings: 1.5.0
@@ -7373,11 +7938,18 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
+  bl@1.2.3:
+    dependencies:
+      readable-stream: 2.3.8
+      safe-buffer: 5.2.1
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bluebird@3.7.2: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -7557,6 +8129,8 @@ snapshots:
 
   caniuse-lite@1.0.30001769: {}
 
+  caseless@0.12.0: {}
+
   ccount@2.0.1: {}
 
   chai@5.3.3:
@@ -7666,6 +8240,10 @@ snapshots:
   cookie@1.1.1: {}
 
   core-js@3.48.0: {}
+
+  core-util-is@1.0.2: {}
+
+  core-util-is@1.0.3: {}
 
   cors@2.8.6:
     dependencies:
@@ -7893,11 +8471,37 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.17.23
 
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
+
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@6.0.2: {}
 
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
   dayjs@1.11.19: {}
+
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
 
   debug@4.4.3:
     dependencies:
@@ -8049,6 +8653,11 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -8107,6 +8716,63 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-abstract@1.24.1:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.3
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.10
+      string.prototype.trimend: 1.0.9
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.7
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.20
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -8123,6 +8789,16 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.2
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   es-toolkit@1.44.0: {}
 
@@ -8274,6 +8950,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter3@3.1.2: {}
+
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
@@ -8341,6 +9019,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extsprintf@1.3.0: {}
+
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
@@ -8354,6 +9034,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
 
   fast-json-stringify@6.3.0:
     dependencies:
@@ -8413,6 +9095,8 @@ snapshots:
 
   fflate@0.8.2: {}
 
+  file-type@3.9.0: {}
+
   file-uri-to-path@1.0.0: {}
 
   filename-reserved-regex@3.0.0: {}
@@ -8455,6 +9139,23 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forever-agent@0.6.1: {}
+
+  form-data@2.3.3:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+
+  form-data@2.5.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -8490,6 +9191,17 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.2
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
 
   gaxios@7.1.3:
     dependencies:
@@ -8547,6 +9259,12 @@ snapshots:
     dependencies:
       pump: 3.0.3
 
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -8558,6 +9276,10 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
 
   github-from-package@0.0.0: {}
 
@@ -8658,11 +9380,24 @@ snapshots:
 
   hachure-fill@0.5.2: {}
 
+  har-schema@2.0.0: {}
+
+  har-validator@5.1.5:
+    dependencies:
+      ajv: 6.14.0
+      har-schema: 2.0.0
+
+  has-bigints@1.1.0: {}
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -8739,6 +9474,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-signature@1.2.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.18.0
+
+  http-signature@1.4.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 2.0.2
+      sshpk: 1.18.0
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -8772,6 +9519,12 @@ snapshots:
   ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
 
   internmap@1.0.1: {}
 
@@ -8810,17 +9563,51 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
   is-arrayish@0.2.1: {}
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
 
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
   is-callable@1.2.7: {}
 
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
   is-decimal@2.0.1: {}
 
@@ -8831,6 +9618,10 @@ snapshots:
   is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -8852,6 +9643,15 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-map@2.0.3: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -8867,15 +9667,49 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
   is-stream@2.0.1: {}
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
 
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.20
 
+  is-typedarray@1.0.0: {}
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isarray@1.0.0: {}
+
+  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -8888,6 +9722,8 @@ snapshots:
   isomorphic-textencoder@1.0.1:
     dependencies:
       fast-text-encoding: 1.0.6
+
+  isstream@0.1.2: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -8936,6 +9772,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsbn@0.1.1: {}
+
   jsesc@3.1.0: {}
 
   json-bigint@1.0.0:
@@ -8947,6 +9785,8 @@ snapshots:
   json-schema-ref-resolver@3.0.0:
     dependencies:
       dequal: 2.0.3
+
+  json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -8980,6 +9820,20 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.7.4
+
+  jsprim@1.4.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+
+  jsprim@2.0.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
 
   jwa@2.0.1:
     dependencies:
@@ -9533,6 +10387,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@1.6.0: {}
+
   mime@3.0.0: {}
 
   mimic-response@3.1.0: {}
@@ -9608,7 +10464,24 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  node-telegram-bot-api@0.67.0(request@2.88.2):
+    dependencies:
+      '@cypress/request': 3.0.10
+      '@cypress/request-promise': 5.0.0(@cypress/request@3.0.10)(request@2.88.2)
+      array.prototype.findindex: 2.2.4
+      bl: 1.2.3
+      debug: 3.2.7
+      eventemitter3: 3.1.2
+      file-type: 3.9.0
+      mime: 1.6.0
+      pump: 2.0.1
+    transitivePeerDependencies:
+      - request
+      - supports-color
+
   normalize-path@3.0.0: {}
+
+  oauth-sign@0.9.0: {}
 
   object-assign@4.1.1: {}
 
@@ -9617,6 +10490,15 @@ snapshots:
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
 
   obug@2.1.1: {}
 
@@ -9669,6 +10551,12 @@ snapshots:
       wsl-utils: 0.1.0
 
   openssl-wrapper@0.3.4: {}
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
 
   p-finally@1.0.0: {}
 
@@ -9756,6 +10644,8 @@ snapshots:
   pathval@2.0.1: {}
 
   pend@1.2.0: {}
+
+  performance-now@2.1.0: {}
 
   phonemizer@1.2.1: {}
 
@@ -9874,6 +10764,8 @@ snapshots:
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
 
+  process-nextick-args@2.0.1: {}
+
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
@@ -9922,10 +10814,21 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
+  pump@2.0.1:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode@2.3.1: {}
 
   puppeteer-core@24.37.3:
     dependencies:
@@ -9961,9 +10864,17 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
+
+  qs@6.5.5: {}
+
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -10038,6 +10949,16 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -10076,7 +10997,27 @@ snapshots:
 
   redux@5.0.1: {}
 
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
   regenerator-runtime@0.14.1: {}
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
 
   rehype-highlight@7.0.2:
     dependencies:
@@ -10120,9 +11061,39 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  request-promise-core@1.1.3(request@2.88.2):
+    dependencies:
+      lodash: 4.17.23
+      request: 2.88.2
+
+  request@2.88.2:
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.5
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  requires-port@1.0.0: {}
 
   reselect@5.1.1: {}
 
@@ -10217,7 +11188,22 @@ snapshots:
 
   rw@1.3.3: {}
 
+  safe-array-concat@1.1.3:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
 
   safe-regex-test@1.1.0:
     dependencies:
@@ -10291,6 +11277,19 @@ snapshots:
       get-intrinsic: 1.3.0
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
 
   setprototypeof@1.2.0: {}
 
@@ -10450,6 +11449,18 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+
   stackback@0.0.2: {}
 
   stats-gl@2.4.2(@types/three@0.182.0)(three@0.182.0):
@@ -10462,6 +11473,13 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  stealthy-require@1.1.1: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
 
   stream-browserify@3.0.0:
     dependencies:
@@ -10488,6 +11506,33 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
+
+  string.prototype.trim@1.2.10:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
+      es-object-atoms: 1.1.1
+      has-property-descriptors: 1.0.2
+
+  string.prototype.trimend@1.0.9:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -10681,6 +11726,12 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -10688,6 +11739,22 @@ snapshots:
   toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@2.5.0:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
 
   tr46@0.0.3: {}
 
@@ -10738,6 +11805,8 @@ snapshots:
       - immer
       - react
 
+  tweetnacl@0.14.5: {}
+
   type-fest@0.13.1: {}
 
   type-is@2.0.1:
@@ -10746,11 +11815,51 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.7:
+    dependencies:
+      call-bind: 1.0.8
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
   typed-query-selector@2.12.0: {}
 
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
 
@@ -10798,6 +11907,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  universalify@0.2.0: {}
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
@@ -10807,6 +11918,15 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   url-template@2.0.8: {}
 
@@ -10830,9 +11950,17 @@ snapshots:
 
   uuid@11.1.0: {}
 
+  uuid@3.4.0: {}
+
   uuid@8.3.2: {}
 
   vary@1.1.2: {}
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
 
   vfile-message@4.0.3:
     dependencies:
@@ -11007,6 +12135,37 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.2
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.20
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
 
   which-typed-array@1.1.20:
     dependencies:


### PR DESCRIPTION
## Summary
- Implements Telegram bridge using `node-telegram-bot-api` with polling, following the existing channel adapter pattern (Discord, Slack, IRC, etc.)
- Supports text messages, media (photos, documents), inline keyboards, and Telegram command handling (`/start`, `/ask`, etc.)
- Adds full settings UI with bot token configuration, connection testing, user pairing, and real-time status via Socket.IO
- Includes 22 unit tests covering connection lifecycle, inbound/outbound message routing, pairing flow, command handling, and media sending

Closes #134

## Test plan
- [x] All 22 new Telegram bridge tests pass
- [x] All existing 573 tests continue to pass (no regressions)
- [ ] Manual test: create a Telegram bot via @BotFather, paste token in settings UI, verify connection test works
- [ ] Manual test: message the bot from Telegram, approve pairing code in dashboard, verify messages route through COO
- [ ] Manual test: verify media sending (photos, documents) and inline keyboard rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)