### PR TITLE
fix: clear episodic memory logs during memory wipe

### DIFF
--- a/packages/server/src/memory/__tests__/memory-clear-all.test.ts
+++ b/packages/server/src/memory/__tests__/memory-clear-all.test.ts
@@ -2,15 +2,27 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 // --- In-memory mock DB rows ---
 let memoryRows: Array<{ id: string; category: string; content: string; source: string; agentScope: string | null; projectId: string | null; importance: number; accessCount: number; lastAccessedAt: string | null; createdAt: string; updatedAt: string }> = [];
+let episodeRows: Array<{ id: string; date: string; projectId: string | null; summary: string; keyDecisions: string[]; createdAt: string }> = [];
 let ftsRows: Array<{ id: string; content: string; category: string }> = [];
 
-const mockRun = vi.fn((sql?: any) => ({ changes: memoryRows.length }));
-const mockAll = vi.fn(() => memoryRows.map((r) => ({ id: r.id })));
+const mockDeleteRun = vi.fn(() => {
+  const count = memoryRows.length;
+  memoryRows = [];
+  return { changes: count };
+});
+const mockEpisodesDeleteRun = vi.fn(() => {
+  const count = episodeRows.length;
+  episodeRows = [];
+  return { changes: count };
+});
+
+// Track which table is being deleted from
+let deleteTarget: "memories" | "memoryEpisodes" | null = null;
 
 vi.mock("../../db/index.js", () => ({
   getDb: vi.fn(() => ({
     select: vi.fn((...cols: any[]) => ({
-      from: vi.fn(() => ({
+      from: vi.fn((table: any) => ({
         where: vi.fn(() => ({
           get: vi.fn(() => memoryRows[0] ?? null),
           all: vi.fn(() => memoryRows),
@@ -46,20 +58,24 @@ vi.mock("../../db/index.js", () => ({
         }),
       })),
     })),
-    delete: vi.fn(() => ({
-      where: vi.fn(() => ({
-        run: vi.fn(() => {
-          const count = memoryRows.length;
-          memoryRows = [];
-          return { changes: count };
-        }),
-      })),
-      run: vi.fn(() => {
-        const count = memoryRows.length;
-        memoryRows = [];
-        return { changes: count };
-      }),
-    })),
+    delete: vi.fn((table: any) => {
+      // Determine which table is being targeted based on the table reference
+      const isEpisodes = table === mockSchema.memoryEpisodes;
+      if (isEpisodes) {
+        return {
+          where: vi.fn(() => ({
+            run: mockEpisodesDeleteRun,
+          })),
+          run: mockEpisodesDeleteRun,
+        };
+      }
+      return {
+        where: vi.fn(() => ({
+          run: mockDeleteRun,
+        })),
+        run: mockDeleteRun,
+      };
+    }),
     update: vi.fn(() => ({
       set: vi.fn(() => ({
         where: vi.fn(() => ({
@@ -70,22 +86,36 @@ vi.mock("../../db/index.js", () => ({
     run: vi.fn(),
     all: vi.fn(() => []),
   })),
-  schema: {
-    memories: {
-      id: "id",
-      category: "category",
-      content: "content",
-      source: "source",
-      agentScope: "agentScope",
-      projectId: "projectId",
-      importance: "importance",
-      accessCount: "accessCount",
-      lastAccessedAt: "lastAccessedAt",
-      createdAt: "createdAt",
-      updatedAt: "updatedAt",
-    },
-  },
+  schema: null as any, // Will be replaced below
 }));
+
+const mockSchema = {
+  memories: {
+    id: "id",
+    category: "category",
+    content: "content",
+    source: "source",
+    agentScope: "agentScope",
+    projectId: "projectId",
+    importance: "importance",
+    accessCount: "accessCount",
+    lastAccessedAt: "lastAccessedAt",
+    createdAt: "createdAt",
+    updatedAt: "updatedAt",
+  },
+  memoryEpisodes: {
+    id: "ep_id",
+    date: "date",
+    projectId: "projectId",
+    summary: "summary",
+    keyDecisions: "keyDecisions",
+    createdAt: "createdAt",
+  },
+};
+
+// Patch schema onto the mock
+const dbMock = await import("../../db/index.js");
+(dbMock as any).schema = mockSchema;
 
 const mockVectorRemove = vi.fn();
 vi.mock("../vector-store.js", () => ({
@@ -106,8 +136,11 @@ describe("MemoryService.clearAll", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     memoryRows = [];
+    episodeRows = [];
     ftsRows = [];
     mockVectorRemove.mockClear();
+    mockDeleteRun.mockClear();
+    mockEpisodesDeleteRun.mockClear();
     service = new MemoryService();
   });
 
@@ -146,5 +179,41 @@ describe("MemoryService.clearAll", () => {
 
     service.clearAll();
     expect(memoryRows).toHaveLength(0);
+  });
+
+  it("clears episodic memory logs so no residual summaries persist", () => {
+    memoryRows = [
+      { id: "m1", category: "fact", content: "User prefers dark mode", source: "user", agentScope: null, projectId: null, importance: 7, accessCount: 1, lastAccessedAt: "2026-01-15", createdAt: "2026-01-10", updatedAt: "2026-01-15" },
+    ];
+    episodeRows = [
+      { id: "ep1", date: "2026-01-14", projectId: null, summary: "Discussed preferences", keyDecisions: ["dark mode"], createdAt: "2026-01-15" },
+      { id: "ep2", date: "2026-01-15", projectId: "proj1", summary: "Worked on project", keyDecisions: ["use TS"], createdAt: "2026-01-16" },
+    ];
+
+    service.clearAll();
+
+    // Memories table should be cleared
+    expect(memoryRows).toHaveLength(0);
+    // Episodes table should also be cleared
+    expect(mockEpisodesDeleteRun).toHaveBeenCalled();
+    expect(episodeRows).toHaveLength(0);
+  });
+
+  it("leaves no retrievable entries after full wipe", () => {
+    memoryRows = [
+      { id: "m1", category: "preference", content: "Likes TypeScript", source: "user", agentScope: null, projectId: null, importance: 8, accessCount: 3, lastAccessedAt: "2026-01-20", createdAt: "2026-01-01", updatedAt: "2026-01-20" },
+      { id: "m2", category: "fact", content: "Birthday is Jan 1", source: "agent", agentScope: "worker", projectId: null, importance: 6, accessCount: 1, lastAccessedAt: "2026-01-10", createdAt: "2026-01-05", updatedAt: "2026-01-10" },
+    ];
+    episodeRows = [
+      { id: "ep1", date: "2026-01-19", projectId: null, summary: "Daily summary", keyDecisions: [], createdAt: "2026-01-20" },
+    ];
+
+    service.clearAll();
+
+    // Verify all storage layers are empty
+    expect(memoryRows).toHaveLength(0);
+    expect(episodeRows).toHaveLength(0);
+    expect(mockVectorRemove).toHaveBeenCalledWith("m1");
+    expect(mockVectorRemove).toHaveBeenCalledWith("m2");
   });
 });

--- a/packages/server/src/memory/memory-service.ts
+++ b/packages/server/src/memory/memory-service.ts
@@ -325,7 +325,7 @@ export class MemoryService {
     return result.changes > 0;
   }
 
-  /** Delete all memories, clearing FTS index and vector store */
+  /** Delete all memories, clearing FTS index, vector store, and episodic logs */
   clearAll(): number {
     const db = getDb();
 
@@ -348,6 +348,13 @@ export class MemoryService {
     const vectorStore = getVectorStore();
     for (const { id } of allIds) {
       vectorStore.remove(id);
+    }
+
+    // Clear episodic memory logs (compacted daily summaries)
+    try {
+      db.delete(schema.memoryEpisodes).run();
+    } catch (err) {
+      console.warn("[MemoryService] Memory episodes clear failed:", err);
     }
 
     return result.changes;


### PR DESCRIPTION
## Summary

- **Bug**: After calling `clearAll()` to wipe memories, residual episodic memory summaries (from `memoryEpisodes` table) persisted and continued to be injected into agent context via `MemoryCompactor.getRecentEpisodes()`
- **Fix**: `MemoryService.clearAll()` now also deletes all rows from the `memoryEpisodes` table, ensuring a complete wipe with no residual data
- **Tests**: Updated test suite to verify episodic logs are cleared and no entries remain retrievable after a full wipe

Closes #0

## Test plan

- [x] All 6 `memory-clear-all` tests pass, including 2 new tests for episodic cleanup
- [x] Full test suite (639 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)