### PR TITLE
feat: add search hint note to wizard model selection steps

### DIFF
--- a/packages/web/src/components/setup/SetupWizard.tsx
+++ b/packages/web/src/components/setup/SetupWizard.tsx
@@ -792,8 +792,12 @@ export function SetupWizard() {
                         }
                       }}
                       placeholder="Search or type a model name"
+                      aria-describedby="model-search-hint"
                       className="w-full px-3 py-2 bg-background border border-input rounded-md text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                     />
+                    <p id="model-search-hint" data-testid="model-search-hint" className="mt-1.5 text-xs text-muted-foreground">
+                      Type to search and filter available models, or enter a custom model name.
+                    </p>
                     {fetchingModels && (
                       <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
                         Loading...
@@ -1477,8 +1481,12 @@ export function SetupWizard() {
                           }
                         }}
                         placeholder="Search or type a model name"
+                        aria-describedby="opencode-model-search-hint"
                         className="w-full px-3 py-2 bg-background border border-input rounded-md text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                       />
+                      <p id="opencode-model-search-hint" data-testid="model-search-hint" className="mt-1.5 text-xs text-muted-foreground">
+                        Type to search and filter available models, or enter a custom model name.
+                      </p>
                       {openCodeFetchingModels && (
                         <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
                           Loading...

--- a/packages/web/src/components/setup/__tests__/model-search-hint.test.ts
+++ b/packages/web/src/components/setup/__tests__/model-search-hint.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Tests that the SetupWizard model selection step includes an accessible
+ * search hint note so users know the input box supports searching/filtering.
+ */
+const wizardSource = readFileSync(
+  resolve(__dirname, "../SetupWizard.tsx"),
+  "utf-8",
+);
+
+describe("SetupWizard model search hint", () => {
+  it("includes a visible hint note for the model search box", () => {
+    expect(wizardSource).toContain('data-testid="model-search-hint"');
+    expect(wizardSource).toContain(
+      "Type to search and filter available models, or enter a custom model name.",
+    );
+  });
+
+  it("links the hint to the input via aria-describedby for accessibility", () => {
+    expect(wizardSource).toContain('aria-describedby="model-search-hint"');
+    expect(wizardSource).toContain('id="model-search-hint"');
+  });
+
+  it("includes hints for both LLM and coding-agent model steps", () => {
+    expect(wizardSource).toContain('id="model-search-hint"');
+    expect(wizardSource).toContain('id="opencode-model-search-hint"');
+    expect(wizardSource).toContain('aria-describedby="opencode-model-search-hint"');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a visible, accessible hint note below each model search input in the setup wizard (both LLM provider and coding agent steps)
- The note reads: "Type to search and filter available models, or enter a custom model name."
- Uses `aria-describedby` to link each hint to its input for screen reader accessibility
- Adds unit tests verifying the hint text, `data-testid`, and aria attributes are present

Closes #133

## Test plan
- [x] All 650 existing tests pass
- [x] New `model-search-hint.test.ts` verifies hint text, accessibility attributes, and coverage of both wizard steps
- [ ] Visual check: hint appears below model search box on wizard step 2 and the coding agent step

🤖 Generated with [Claude Code](https://claude.com/claude-code)