### PR TITLE
feat: add Deepgram provider for STT and TTS

### DIFF
--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -267,7 +267,7 @@ export const providers = sqliteTable("providers", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   type: text("type", {
-    enum: ["anthropic", "openai", "google", "ollama", "openai-compatible", "openrouter", "github-copilot", "huggingface", "nvidia", "perplexity"],
+    enum: ["anthropic", "openai", "google", "ollama", "openai-compatible", "openrouter", "github-copilot", "huggingface", "nvidia", "perplexity", "deepgram"],
   }).notNull(),
   apiKey: text("api_key"),
   baseUrl: text("base_url"),

--- a/packages/server/src/llm/adapter.ts
+++ b/packages/server/src/llm/adapter.ts
@@ -160,6 +160,12 @@ export function resolveModel(config: LLMConfig): LanguageModel {
       return perplexity(config.model);
     }
 
+    case "deepgram":
+      throw new Error(
+        "Deepgram is a speech provider (STT/TTS) and does not support text generation. " +
+        "Configure it under TTS or STT settings instead.",
+      );
+
     default:
       throw new Error(`Unknown LLM provider: ${config.provider} (type: ${resolved.type})`);
   }

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -61,6 +61,7 @@ export const PROVIDER_TYPE_META: ProviderTypeMeta[] = [
   { type: "huggingface", label: "Hugging Face", needsApiKey: true, needsBaseUrl: false },
   { type: "nvidia", label: "NVIDIA", needsApiKey: true, needsBaseUrl: false },
   { type: "perplexity", label: "Perplexity Sonar", needsApiKey: true, needsBaseUrl: false },
+  { type: "deepgram", label: "Deepgram", needsApiKey: true, needsBaseUrl: false },
 ];
 
 // Static fallback models per provider (used when API fetch fails)
@@ -104,6 +105,7 @@ const FALLBACK_MODELS: Record<string, string[]> = {
     "sonar-reasoning",
     "sonar-reasoning-pro",
   ],
+  deepgram: [],
 };
 
 // ---------------------------------------------------------------------------
@@ -742,6 +744,11 @@ const TTS_PROVIDER_META: Record<
     needsApiKey: true,
     needsBaseUrl: true,
   },
+  deepgram: {
+    name: "Deepgram",
+    needsApiKey: true,
+    needsBaseUrl: false,
+  },
 };
 
 const TTS_VOICES: Record<string, string[]> = {
@@ -805,6 +812,20 @@ const TTS_VOICES: Record<string, string[]> = {
     "onyx",
     "nova",
     "shimmer",
+  ],
+  deepgram: [
+    "aura-asteria-en",
+    "aura-luna-en",
+    "aura-stella-en",
+    "aura-athena-en",
+    "aura-hera-en",
+    "aura-orion-en",
+    "aura-arcas-en",
+    "aura-perseus-en",
+    "aura-angus-en",
+    "aura-orpheus-en",
+    "aura-helios-en",
+    "aura-zeus-en",
   ],
 };
 
@@ -948,6 +969,11 @@ const STT_PROVIDER_META: Record<
   browser: {
     name: "Browser (Chrome/Edge)",
     needsApiKey: false,
+    needsBaseUrl: false,
+  },
+  deepgram: {
+    name: "Deepgram",
+    needsApiKey: true,
     needsBaseUrl: false,
   },
 };

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -1,4 +1,4 @@
-export type ProviderType = "anthropic" | "openai" | "google" | "ollama" | "openai-compatible" | "openrouter" | "github-copilot" | "huggingface" | "nvidia" | "perplexity";
+export type ProviderType = "anthropic" | "openai" | "google" | "ollama" | "openai-compatible" | "openrouter" | "github-copilot" | "huggingface" | "nvidia" | "perplexity" | "deepgram";
 
 export interface NamedProvider {
   id: string;


### PR DESCRIPTION
## Summary
- Added Deepgram as a speech provider with STT (speech-to-text) and TTS (text-to-speech) support
- Extended the `ProviderType` union and DB schema to include `"deepgram"`
- Added `DeepgramSTTProvider` (using Nova-3 model via REST API) and `DeepgramTTSProvider` (using Aura voices via REST API)
- Integrated Deepgram into the settings system with provider metadata, voice lists, and config key handling
- Added explicit error in LLM adapter for Deepgram since it is a speech-only provider

Closes #196

## Test plan
- [ ] Verify type-checking passes with `tsc --noEmit`
- [ ] Verify build succeeds with `pnpm build`
- [ ] Configure a Deepgram API key via the TTS/STT settings UI and test speech synthesis
- [ ] Configure a Deepgram API key via the STT settings and test transcription
- [ ] Verify existing TTS/STT providers (Kokoro, Edge TTS, Whisper, OpenAI-compatible) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)