### PR TITLE
feat: add Mattermost chat provider

### DIFF
--- a/packages/server/src/mattermost/__tests__/mattermost-bridge.test.ts
+++ b/packages/server/src/mattermost/__tests__/mattermost-bridge.test.ts
@@ -1,0 +1,850 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventEmitter } from "events";
+import { migrateDb, resetDb } from "../../db/index.js";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage } from "@otterbot/shared";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+class MockWebSocket extends EventEmitter {
+  static OPEN = 1;
+  readyState = MockWebSocket.OPEN;
+  sentMessages: string[] = [];
+
+  constructor(_url: string) {
+    super();
+    // Simulate async open
+    setTimeout(() => this.emit("open"), 0);
+  }
+
+  send(data: string) {
+    this.sentMessages.push(data);
+  }
+
+  close() {
+    this.readyState = 3; // CLOSED
+    this.emit("close");
+  }
+
+  removeAllListeners() {
+    super.removeAllListeners();
+    return this;
+  }
+
+  // Test helper: simulate incoming message
+  _receive(data: Record<string, unknown>) {
+    this.emit("message", JSON.stringify(data));
+  }
+}
+
+let mockWsInstance: MockWebSocket | null = null;
+
+vi.mock("ws", () => ({
+  default: class extends MockWebSocket {
+    constructor(url: string) {
+      super(url);
+      mockWsInstance = this;
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock fetch (global)
+// ---------------------------------------------------------------------------
+
+const mockFetchResponses = new Map<string, { ok: boolean; status: number; body: unknown }>();
+
+function setFetchResponse(urlPattern: string, response: { ok?: boolean; status?: number; body: unknown }) {
+  mockFetchResponses.set(urlPattern, {
+    ok: response.ok ?? true,
+    status: response.status ?? 200,
+    body: response.body,
+  });
+}
+
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
+  const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+  for (const [pattern, response] of mockFetchResponses) {
+    if (url.includes(pattern)) {
+      return {
+        ok: response.ok,
+        status: response.status,
+        json: async () => response.body,
+        text: async () => JSON.stringify(response.body),
+      } as Response;
+    }
+  }
+
+  return { ok: false, status: 404, json: async () => ({}), text: async () => "Not found" } as Response;
+}) as typeof fetch;
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+const { MattermostBridge } = await import("../mattermost-bridge.js");
+
+interface SendParams {
+  fromAgentId: string | null;
+  toAgentId: string | null;
+  type: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  conversationId?: string;
+}
+
+function createMockBus() {
+  const broadcastHandlers: ((message: BusMessage) => void)[] = [];
+  const sent: SendParams[] = [];
+
+  const bus = {
+    send: vi.fn((params: SendParams) => {
+      sent.push(params);
+      const message: BusMessage = {
+        id: "test-msg-id",
+        fromAgentId: params.fromAgentId,
+        toAgentId: params.toAgentId,
+        type: params.type as BusMessage["type"],
+        content: params.content,
+        metadata: params.metadata ?? {},
+        conversationId: params.conversationId,
+        timestamp: new Date().toISOString(),
+      };
+      return message;
+    }),
+    onBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      broadcastHandlers.push(handler);
+    }),
+    offBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      const idx = broadcastHandlers.indexOf(handler);
+      if (idx >= 0) broadcastHandlers.splice(idx, 1);
+    }),
+    _broadcastHandlers: broadcastHandlers,
+    _sent: sent,
+  };
+
+  return bus;
+}
+
+function createMockCoo() {
+  return {
+    startNewConversation: vi.fn(),
+  };
+}
+
+function createMockIo() {
+  return {
+    emit: vi.fn(),
+  };
+}
+
+const testConfig = {
+  serverUrl: "https://mm.example.com",
+  token: "test-bot-token",
+};
+
+describe("MattermostBridge", () => {
+  let tmpDir: string;
+  let bus: ReturnType<typeof createMockBus>;
+  let coo: ReturnType<typeof createMockCoo>;
+  let io: ReturnType<typeof createMockIo>;
+  let bridge: InstanceType<typeof MattermostBridge>;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-mattermost-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+
+    bus = createMockBus();
+    coo = createMockCoo();
+    io = createMockIo();
+    mockWsInstance = null;
+    mockFetchResponses.clear();
+
+    // Default: /users/me returns the bot user
+    setFetchResponse("/api/v4/users/me", {
+      body: { id: "bot-user-id", username: "otterbot" },
+    });
+
+    bridge = new MattermostBridge({
+      bus: bus as any,
+      coo: coo as any,
+      io: io as any,
+    });
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+    mockFetchResponses.clear();
+  });
+
+  // -------------------------------------------------------------------------
+  // Connection & Lifecycle
+  // -------------------------------------------------------------------------
+
+  describe("connection initialization", () => {
+    it("authenticates and opens WebSocket", async () => {
+      await bridge.start(testConfig);
+
+      // Wait for WS open event
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockWsInstance).not.toBeNull();
+      // Should have sent auth challenge
+      expect(mockWsInstance!.sentMessages.length).toBeGreaterThanOrEqual(1);
+      const authMsg = JSON.parse(mockWsInstance!.sentMessages[0]!);
+      expect(authMsg.action).toBe("authentication_challenge");
+      expect(authMsg.data.token).toBe("test-bot-token");
+    });
+
+    it("emits connected status on WebSocket open", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(io.emit).toHaveBeenCalledWith("mattermost:status", {
+        status: "connected",
+        botUsername: "otterbot",
+      });
+    });
+
+    it("subscribes to bus broadcasts", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(bus.onBroadcast).toHaveBeenCalledOnce();
+    });
+
+    it("throws on auth failure", async () => {
+      setFetchResponse("/api/v4/users/me", {
+        ok: false,
+        status: 401,
+        body: { message: "Invalid token" },
+      });
+
+      await expect(bridge.start(testConfig)).rejects.toThrow("Mattermost auth failed");
+    });
+  });
+
+  describe("cleanup on stop", () => {
+    it("closes WebSocket", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const ws = mockWsInstance!;
+      await bridge.stop();
+
+      expect(ws.readyState).toBe(3); // CLOSED
+    });
+
+    it("unsubscribes from bus broadcasts", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+      await bridge.stop();
+
+      expect(bus.offBroadcast).toHaveBeenCalledOnce();
+    });
+
+    it("emits disconnected status", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+      await bridge.stop();
+
+      expect(io.emit).toHaveBeenCalledWith("mattermost:status", {
+        status: "disconnected",
+      });
+    });
+
+    it("can restart after stop", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+      await bridge.stop();
+
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockWsInstance).not.toBeNull();
+      expect(io.emit).toHaveBeenCalledWith("mattermost:status", {
+        status: "connected",
+        botUsername: "otterbot",
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Inbound Messages (Mattermost → COO)
+  // -------------------------------------------------------------------------
+
+  describe("message handling", () => {
+    it("routes DM messages to COO", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Pair the user
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("mattermost:paired:user123", JSON.stringify({
+        mattermostUserId: "user123",
+        mattermostUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+      setConfig("mattermost:require_mention", "false");
+
+      // Mock user lookup
+      setFetchResponse("/api/v4/users/user123", {
+        body: { username: "alice" },
+      });
+      // Mock post creation (for any replies)
+      setFetchResponse("/api/v4/posts", { body: { id: "post-resp" } });
+
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post1",
+            user_id: "user123",
+            channel_id: "dm-channel",
+            message: "hello there",
+            root_id: "",
+          }),
+          channel_type: "D",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(bus.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromAgentId: null,
+          toAgentId: "coo",
+          type: MessageType.Chat,
+          content: "hello there",
+          metadata: expect.objectContaining({
+            source: "mattermost",
+            mattermostUserId: "user123",
+            mattermostChannelId: "dm-channel",
+          }),
+        }),
+      );
+    });
+
+    it("ignores bot's own messages", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post1",
+            user_id: "bot-user-id",
+            channel_id: "ch1",
+            message: "bot message",
+            root_id: "",
+          }),
+          channel_type: "O",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("ignores messages from other bots", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post1",
+            user_id: "other-bot",
+            channel_id: "ch1",
+            message: "another bot",
+            root_id: "",
+            props: { from_bot: "true" },
+          }),
+          channel_type: "O",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("generates pairing code for unpaired users", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("mattermost:require_mention", "false");
+
+      // Mock user lookup and post creation
+      setFetchResponse("/api/v4/users/unknown-user", {
+        body: { username: "stranger" },
+      });
+      setFetchResponse("/api/v4/posts", { body: { id: "post-resp" } });
+
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post1",
+            user_id: "unknown-user",
+            channel_id: "dm-channel",
+            message: "hello",
+            root_id: "",
+          }),
+          channel_type: "D",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should have posted a pairing code reply
+      const fetchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const postCalls = fetchCalls.filter(
+        (c: unknown[]) => typeof c[0] === "string" && c[0].includes("/api/v4/posts") && (c[1] as RequestInit)?.method === "POST",
+      );
+      expect(postCalls.length).toBeGreaterThanOrEqual(1);
+
+      expect(io.emit).toHaveBeenCalledWith(
+        "mattermost:pairing-request",
+        expect.objectContaining({
+          mattermostUserId: "unknown-user",
+        }),
+      );
+
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("creates a conversation for new messages", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("mattermost:paired:user123", JSON.stringify({
+        mattermostUserId: "user123",
+        mattermostUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+      setConfig("mattermost:require_mention", "false");
+
+      setFetchResponse("/api/v4/users/user123", { body: { username: "alice" } });
+      setFetchResponse("/api/v4/posts", { body: { id: "post-resp" } });
+
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post1",
+            user_id: "user123",
+            channel_id: "dm-channel",
+            message: "hello",
+            root_id: "",
+          }),
+          channel_type: "D",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(coo.startNewConversation).toHaveBeenCalledOnce();
+      expect(io.emit).toHaveBeenCalledWith(
+        "conversation:created",
+        expect.objectContaining({
+          title: expect.stringContaining("Mattermost:"),
+        }),
+      );
+    });
+
+    it("reuses conversation for same user+channel", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("mattermost:paired:user123", JSON.stringify({
+        mattermostUserId: "user123",
+        mattermostUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+      setConfig("mattermost:require_mention", "false");
+
+      setFetchResponse("/api/v4/users/user123", { body: { username: "alice" } });
+      setFetchResponse("/api/v4/posts", { body: { id: "post-resp" } });
+
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post1",
+            user_id: "user123",
+            channel_id: "dm-channel",
+            message: "first",
+            root_id: "",
+          }),
+          channel_type: "D",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post2",
+            user_id: "user123",
+            channel_id: "dm-channel",
+            message: "second",
+            root_id: "",
+          }),
+          channel_type: "D",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(coo.startNewConversation).toHaveBeenCalledOnce();
+      expect(bus.send).toHaveBeenCalledTimes(2);
+    });
+
+    it("ignores channel messages when requireMention is true (default)", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("mattermost:paired:user123", JSON.stringify({
+        mattermostUserId: "user123",
+        mattermostUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+
+      setFetchResponse("/api/v4/users/user123", { body: { username: "alice" } });
+
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post1",
+            user_id: "user123",
+            channel_id: "ch1",
+            message: "hello in channel",
+            root_id: "",
+          }),
+          channel_type: "O",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("responds to @mention in channels", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("mattermost:paired:user123", JSON.stringify({
+        mattermostUserId: "user123",
+        mattermostUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+      setConfig("mattermost:bot_username", "otterbot");
+
+      setFetchResponse("/api/v4/users/user123", { body: { username: "alice" } });
+      setFetchResponse("/api/v4/posts", { body: { id: "post-resp" } });
+
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post1",
+            user_id: "user123",
+            channel_id: "ch1",
+            message: "@otterbot what is the weather?",
+            root_id: "",
+          }),
+          channel_type: "O",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(bus.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: "what is the weather?",
+        }),
+      );
+    });
+
+    it("respects allowed channels whitelist", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("mattermost:paired:user123", JSON.stringify({
+        mattermostUserId: "user123",
+        mattermostUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+      setConfig("mattermost:require_mention", "false");
+      setConfig("mattermost:allowed_channels", JSON.stringify(["ch-allowed"]));
+
+      setFetchResponse("/api/v4/users/user123", { body: { username: "alice" } });
+      setFetchResponse("/api/v4/posts", { body: { id: "post-resp" } });
+
+      // Not in allowed channels
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post1",
+            user_id: "user123",
+            channel_id: "ch-blocked",
+            message: "hello",
+            root_id: "",
+          }),
+          channel_type: "O",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(bus.send).not.toHaveBeenCalled();
+
+      // In allowed channels
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post2",
+            user_id: "user123",
+            channel_id: "ch-allowed",
+            message: "hello",
+            root_id: "",
+          }),
+          channel_type: "O",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(bus.send).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Outbound Messages (COO → Mattermost)
+  // -------------------------------------------------------------------------
+
+  describe("outbound messages", () => {
+    it("sends COO responses back to Mattermost", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("mattermost:paired:user123", JSON.stringify({
+        mattermostUserId: "user123",
+        mattermostUsername: "alice",
+        pairedAt: new Date().toISOString(),
+      }));
+      setConfig("mattermost:require_mention", "false");
+
+      setFetchResponse("/api/v4/users/user123", { body: { username: "alice" } });
+      setFetchResponse("/api/v4/posts", { body: { id: "post-resp" } });
+
+      // Trigger an inbound message first
+      mockWsInstance!._receive({
+        event: "posted",
+        data: {
+          post: JSON.stringify({
+            id: "post1",
+            user_id: "user123",
+            channel_id: "dm-channel",
+            message: "hello",
+            root_id: "",
+          }),
+          channel_type: "D",
+        },
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const conversationId = bus.send.mock.calls[0]?.[0]?.conversationId;
+      expect(conversationId).toBeTruthy();
+
+      // Reset fetch mock call tracking
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockClear();
+      setFetchResponse("/api/v4/posts", { body: { id: "reply-post" } });
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "resp-1",
+        fromAgentId: "coo",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "Hello from COO!",
+        metadata: {},
+        conversationId,
+        timestamp: new Date().toISOString(),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const fetchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const postCalls = fetchCalls.filter(
+        (c: unknown[]) => typeof c[0] === "string" && c[0].includes("/api/v4/posts") && (c[1] as RequestInit)?.method === "POST",
+      );
+      expect(postCalls.length).toBeGreaterThanOrEqual(1);
+
+      const postBody = JSON.parse((postCalls[0]![1] as RequestInit).body as string);
+      expect(postBody.channel_id).toBe("dm-channel");
+      expect(postBody.message).toBe("Hello from COO!");
+      expect(postBody.root_id).toBe("post1"); // threaded reply
+    });
+
+    it("ignores messages not from COO", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockClear();
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "msg-1",
+        fromAgentId: "some-agent",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "Not from COO",
+        metadata: {},
+        conversationId: "conv-1",
+        timestamp: new Date().toISOString(),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const fetchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const postCalls = fetchCalls.filter(
+        (c: unknown[]) => typeof c[0] === "string" && c[0].includes("/api/v4/posts"),
+      );
+      expect(postCalls.length).toBe(0);
+    });
+
+    it("ignores COO messages addressed to another agent", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockClear();
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "msg-1",
+        fromAgentId: "coo",
+        toAgentId: "some-agent",
+        type: MessageType.Chat,
+        content: "For another agent",
+        metadata: {},
+        conversationId: "conv-1",
+        timestamp: new Date().toISOString(),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const fetchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const postCalls = fetchCalls.filter(
+        (c: unknown[]) => typeof c[0] === "string" && c[0].includes("/api/v4/posts"),
+      );
+      expect(postCalls.length).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getAvailableChannels
+  // -------------------------------------------------------------------------
+
+  describe("getAvailableChannels", () => {
+    it("returns empty array when not started", async () => {
+      const channels = await bridge.getAvailableChannels();
+      expect(channels).toEqual([]);
+    });
+
+    it("returns empty array when no default team configured", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const channels = await bridge.getAvailableChannels();
+      expect(channels).toEqual([]);
+    });
+
+    it("returns available channels for configured team", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const { setConfig } = await import("../../auth/auth.js");
+      setConfig("mattermost:default_team", "myteam");
+
+      setFetchResponse("/api/v4/teams/name/myteam", {
+        body: { id: "team-id", display_name: "My Team" },
+      });
+      setFetchResponse("/teams/team-id/channels", {
+        body: [
+          { id: "ch1", name: "town-square", display_name: "Town Square", type: "O" },
+          { id: "ch2", name: "off-topic", display_name: "Off-Topic", type: "O" },
+          { id: "dm1", name: "dm-channel", display_name: "DM", type: "D" },
+        ],
+      });
+
+      const channels = await bridge.getAvailableChannels();
+      expect(channels).toEqual([
+        { id: "ch1", name: "town-square", displayName: "Town Square", teamName: "My Team" },
+        { id: "ch2", name: "off-topic", displayName: "Off-Topic", teamName: "My Team" },
+      ]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error cases
+  // -------------------------------------------------------------------------
+
+  describe("error handling", () => {
+    it("emits error status on WebSocket error", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      mockWsInstance!.emit("error", new Error("connection failed"));
+
+      expect(io.emit).toHaveBeenCalledWith("mattermost:status", {
+        status: "error",
+      });
+    });
+
+    it("emits disconnected status on WebSocket close", async () => {
+      await bridge.start(testConfig);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Clear previous emit calls
+      io.emit.mockClear();
+
+      mockWsInstance!.emit("close");
+
+      expect(io.emit).toHaveBeenCalledWith("mattermost:status", {
+        status: "disconnected",
+      });
+    });
+  });
+});

--- a/packages/server/src/mattermost/mattermost-bridge.ts
+++ b/packages/server/src/mattermost/mattermost-bridge.ts
@@ -1,0 +1,525 @@
+import WebSocket from "ws";
+import { nanoid } from "nanoid";
+import { eq } from "drizzle-orm";
+import { Server } from "socket.io";
+import type { ServerToClientEvents, ClientToServerEvents } from "@otterbot/shared";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage, Conversation } from "@otterbot/shared";
+import { MessageBus } from "../bus/message-bus.js";
+import { COO } from "../agents/coo.js";
+import { getDb, schema } from "../db/index.js";
+import { getConfig } from "../auth/auth.js";
+import { isPaired, generatePairingCode, listPairedUsers } from "./pairing.js";
+import type { MattermostAvailableChannel } from "./mattermost-settings.js";
+
+type TypedServer = Server<ClientToServerEvents, ServerToClientEvents>;
+
+// ---------------------------------------------------------------------------
+// Mattermost Bridge
+// ---------------------------------------------------------------------------
+
+const MM_MAX_LENGTH = 16383;
+
+export interface MattermostConfig {
+  serverUrl: string;
+  token: string;
+  defaultTeam?: string;
+}
+
+interface PendingResponse {
+  channelId: string;
+  postId: string;
+  rootId: string;
+  conversationId: string;
+}
+
+export class MattermostBridge {
+  private ws: WebSocket | null = null;
+  private bus: MessageBus;
+  private coo: COO;
+  private io: TypedServer;
+  private config: MattermostConfig | null = null;
+  private botUserId: string | null = null;
+  private broadcastHandler: ((message: BusMessage) => void) | null = null;
+  /** Map of `{mattermostUserId}:{channelId}` → conversationId */
+  private conversationMap = new Map<string, string>();
+  /** Map of conversationId → { channelId, rootId } for sending responses */
+  private channelMap = new Map<string, { channelId: string; rootId: string }>();
+  private pendingResponses = new Map<string, PendingResponse>();
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private seqNum = 1;
+
+  constructor(deps: { bus: MessageBus; coo: COO; io: TypedServer }) {
+    this.bus = deps.bus;
+    this.coo = deps.coo;
+    this.io = deps.io;
+  }
+
+  async start(config: MattermostConfig): Promise<void> {
+    if (this.ws) {
+      await this.stop();
+    }
+
+    this.config = config;
+
+    // Validate token by fetching bot user
+    const meRes = await fetch(`${config.serverUrl}/api/v4/users/me`, {
+      headers: { Authorization: `Bearer ${config.token}` },
+    });
+
+    if (!meRes.ok) {
+      throw new Error(`Mattermost auth failed: HTTP ${meRes.status}`);
+    }
+
+    const me = (await meRes.json()) as { id: string; username: string };
+    this.botUserId = me.id;
+
+    // Open WebSocket
+    const wsUrl = config.serverUrl.replace(/^http/, "ws") + "/api/v4/websocket";
+    this.ws = new WebSocket(wsUrl);
+
+    this.ws.on("open", () => {
+      // Authenticate over WebSocket
+      this.ws!.send(JSON.stringify({
+        seq: this.seqNum++,
+        action: "authentication_challenge",
+        data: { token: config.token },
+      }));
+
+      console.log(`[Mattermost] Connected as ${me.username}`);
+      this.io.emit("mattermost:status", {
+        status: "connected",
+        botUsername: me.username,
+      });
+    });
+
+    this.ws.on("message", (raw: WebSocket.Data) => {
+      try {
+        const event = JSON.parse(raw.toString());
+        if (event.event === "posted") {
+          this.handlePostedEvent(event).catch((err) => {
+            console.error("[Mattermost] Error handling posted event:", err);
+          });
+        }
+      } catch { /* ignore non-JSON frames */ }
+    });
+
+    this.ws.on("close", () => {
+      console.log("[Mattermost] WebSocket closed");
+      this.io.emit("mattermost:status", { status: "disconnected" });
+      this.scheduleReconnect();
+    });
+
+    this.ws.on("error", (error) => {
+      console.error("[Mattermost] WebSocket error:", error);
+      this.io.emit("mattermost:status", { status: "error" });
+    });
+
+    // Subscribe to bus broadcasts to intercept COO responses
+    this.broadcastHandler = (message: BusMessage) => {
+      this.handleBusMessage(message);
+    };
+    this.bus.onBroadcast(this.broadcastHandler);
+  }
+
+  async stop(): Promise<void> {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    this.pendingResponses.clear();
+
+    // Unsubscribe from bus
+    if (this.broadcastHandler) {
+      this.bus.offBroadcast(this.broadcastHandler);
+      this.broadcastHandler = null;
+    }
+
+    // Close WebSocket
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      this.ws.close();
+      this.ws = null;
+      this.io.emit("mattermost:status", { status: "disconnected" });
+    }
+
+    this.config = null;
+    this.botUserId = null;
+  }
+
+  async getAvailableChannels(): Promise<MattermostAvailableChannel[]> {
+    if (!this.config || !this.botUserId) return [];
+
+    const defaultTeam = getConfig("mattermost:default_team");
+    if (!defaultTeam) return [];
+
+    try {
+      // Resolve team name → team ID
+      const teamRes = await fetch(
+        `${this.config.serverUrl}/api/v4/teams/name/${encodeURIComponent(defaultTeam)}`,
+        { headers: { Authorization: `Bearer ${this.config.token}` } },
+      );
+      if (!teamRes.ok) return [];
+      const team = (await teamRes.json()) as { id: string; display_name: string };
+
+      // Fetch channels the bot belongs to
+      const chRes = await fetch(
+        `${this.config.serverUrl}/api/v4/users/${this.botUserId}/teams/${team.id}/channels`,
+        { headers: { Authorization: `Bearer ${this.config.token}` } },
+      );
+      if (!chRes.ok) return [];
+      const channels = (await chRes.json()) as Array<{
+        id: string;
+        name: string;
+        display_name: string;
+        type: string;
+      }>;
+
+      return channels
+        .filter((ch) => ch.type === "O" || ch.type === "P") // public or private, not DMs
+        .map((ch) => ({
+          id: ch.id,
+          name: ch.name,
+          displayName: ch.display_name,
+          teamName: team.display_name,
+        }));
+    } catch (err) {
+      console.error("[Mattermost] Error fetching channels:", err);
+      return [];
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Inbound: Mattermost → COO
+  // -------------------------------------------------------------------------
+
+  private async handlePostedEvent(event: {
+    data?: { post?: string; channel_type?: string };
+  }): Promise<void> {
+    if (!event.data?.post) return;
+
+    let post: {
+      id: string;
+      user_id: string;
+      channel_id: string;
+      message: string;
+      root_id: string;
+      props?: { from_bot?: string; override_username?: string };
+    };
+    try {
+      post = JSON.parse(event.data.post);
+    } catch {
+      return;
+    }
+
+    // Ignore own messages
+    if (post.user_id === this.botUserId) return;
+
+    // Ignore bot posts
+    if (post.props?.from_bot === "true") return;
+
+    const isDM = event.data.channel_type === "D";
+    const requireMention = getConfig("mattermost:require_mention") !== "false";
+
+    // In channels, only respond to @mentions (unless require_mention is off)
+    if (!isDM && requireMention) {
+      const botUsername = getConfig("mattermost:bot_username");
+      if (!botUsername || !post.message.includes(`@${botUsername}`)) {
+        return;
+      }
+    }
+
+    // Channel whitelist: if set, only respond in allowed channels (DMs always allowed)
+    if (!isDM) {
+      const raw = getConfig("mattermost:allowed_channels");
+      if (raw) {
+        try {
+          const allowed: string[] = JSON.parse(raw);
+          if (allowed.length > 0 && !allowed.includes(post.channel_id)) {
+            return;
+          }
+        } catch { /* ignore parse errors */ }
+      }
+    }
+
+    const mattermostUserId = post.user_id;
+
+    // Fetch username for pairing
+    let mattermostUsername = mattermostUserId;
+    if (this.config) {
+      try {
+        const userRes = await fetch(
+          `${this.config.serverUrl}/api/v4/users/${mattermostUserId}`,
+          { headers: { Authorization: `Bearer ${this.config.token}` } },
+        );
+        if (userRes.ok) {
+          const user = (await userRes.json()) as { username: string };
+          mattermostUsername = user.username;
+        }
+      } catch { /* use ID as fallback */ }
+    }
+
+    // Check pairing
+    if (!isPaired(mattermostUserId)) {
+      const code = generatePairingCode(mattermostUserId, mattermostUsername);
+      await this.createPost(
+        post.channel_id,
+        `I don't recognize you yet. To pair with me, ask my owner to approve this code in the Otterbot dashboard:\n\n**\`${code}\`**\n\nThis code expires in 1 hour.`,
+        post.root_id || post.id,
+      );
+      this.io.emit("mattermost:pairing-request", {
+        code,
+        mattermostUserId,
+        mattermostUsername,
+      });
+      return;
+    }
+
+    // Extract content — strip bot mention if present
+    let content = post.message;
+    const botUsername = getConfig("mattermost:bot_username");
+    if (botUsername) {
+      content = content.replace(new RegExp(`@${botUsername}\\b`, "g"), "").trim();
+    }
+    if (!content) return;
+
+    // Route to COO
+    await this.routeToCOO(post, mattermostUserId, mattermostUsername, content);
+  }
+
+  private async routeToCOO(
+    post: { id: string; channel_id: string; root_id: string },
+    mattermostUserId: string,
+    mattermostUsername: string,
+    content: string,
+  ): Promise<void> {
+    const channelId = post.channel_id;
+    const convKey = `${mattermostUserId}:${channelId}`;
+
+    const db = getDb();
+    let conversationId = this.conversationMap.get(convKey);
+
+    if (!conversationId) {
+      conversationId = nanoid();
+      const now = new Date().toISOString();
+      const title = `Mattermost: ${mattermostUsername} — ${content.slice(0, 60)}`;
+      const conversation: Conversation = {
+        id: conversationId,
+        title,
+        projectId: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      db.insert(schema.conversations).values(conversation).run();
+      this.coo.startNewConversation(conversationId, null, null);
+      this.io.emit("conversation:created", conversation);
+      this.conversationMap.set(convKey, conversationId);
+    } else {
+      db.update(schema.conversations)
+        .set({ updatedAt: new Date().toISOString() })
+        .where(eq(schema.conversations.id, conversationId))
+        .run();
+    }
+
+    const rootId = post.root_id || post.id;
+    this.channelMap.set(conversationId, { channelId, rootId });
+
+    // Track pending response
+    this.pendingResponses.set(conversationId, {
+      channelId,
+      postId: post.id,
+      rootId,
+      conversationId,
+    });
+
+    // Send to COO via bus
+    this.bus.send({
+      fromAgentId: null,
+      toAgentId: "coo",
+      type: MessageType.Chat,
+      content,
+      conversationId,
+      metadata: {
+        source: "mattermost",
+        mattermostUserId,
+        mattermostChannelId: channelId,
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound: COO → Mattermost
+  // -------------------------------------------------------------------------
+
+  private handleBusMessage(message: BusMessage): void {
+    // Only care about COO → CEO (null) responses
+    if (message.fromAgentId !== "coo" || message.toAgentId !== null) return;
+
+    const conversationId = message.conversationId;
+
+    if (conversationId) {
+      const pending = this.pendingResponses.get(conversationId);
+      if (pending) {
+        this.pendingResponses.delete(conversationId);
+        this.sendReply(pending.channelId, message.content, pending.rootId).catch((err) => {
+          console.error("[Mattermost] Error sending reply:", err);
+        });
+        return;
+      }
+
+      // Unsolicited message to a known Mattermost channel
+      const target = this.channelMap.get(conversationId);
+      if (target) {
+        this.sendReply(target.channelId, message.content, target.rootId).catch((err) => {
+          console.error("[Mattermost] Error sending unsolicited message:", err);
+        });
+        return;
+      }
+    }
+
+    // Fallback: send to first paired user as DM
+    this.sendFallbackDM(message.content).catch((err) => {
+      console.error("[Mattermost] Error sending DM fallback:", err);
+    });
+  }
+
+  private async sendFallbackDM(content: string): Promise<void> {
+    if (!this.config || !this.botUserId) return;
+
+    const paired = listPairedUsers();
+    if (paired.length === 0) {
+      console.warn("[Mattermost] DM fallback: no paired users");
+      return;
+    }
+
+    try {
+      // Create or get DM channel
+      const res = await fetch(`${this.config.serverUrl}/api/v4/channels/direct`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.config.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify([this.botUserId, paired[0]!.mattermostUserId]),
+      });
+      if (!res.ok) return;
+      const dm = (await res.json()) as { id: string };
+      await this.sendReply(dm.id, content);
+    } catch (err) {
+      console.error("[Mattermost] DM fallback error:", err);
+    }
+  }
+
+  private async sendReply(
+    channelId: string,
+    content: string,
+    rootId?: string,
+  ): Promise<void> {
+    if (!this.config) return;
+
+    const chunks = splitMessage(content, MM_MAX_LENGTH);
+    for (const chunk of chunks) {
+      await this.createPost(channelId, chunk, rootId);
+    }
+  }
+
+  private async createPost(
+    channelId: string,
+    message: string,
+    rootId?: string,
+  ): Promise<void> {
+    if (!this.config) return;
+
+    const body: Record<string, string> = {
+      channel_id: channelId,
+      message,
+    };
+    if (rootId) {
+      body.root_id = rootId;
+    }
+
+    const res = await fetch(`${this.config.serverUrl}/api/v4/posts`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.config.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Failed to create post: HTTP ${res.status} — ${text.slice(0, 200)}`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Reconnect
+  // -------------------------------------------------------------------------
+
+  private scheduleReconnect(): void {
+    if (!this.config || this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.config) {
+        console.log("[Mattermost] Attempting reconnect...");
+        this.start(this.config).catch((err) => {
+          console.error("[Mattermost] Reconnect failed:", err);
+          this.scheduleReconnect();
+        });
+      }
+    }, 5000);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message splitting
+// ---------------------------------------------------------------------------
+
+function splitMessage(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLength) {
+    let splitIdx = -1;
+
+    // Try to split at paragraph boundary
+    const paragraphIdx = remaining.lastIndexOf("\n\n", maxLength);
+    if (paragraphIdx > maxLength * 0.3) {
+      splitIdx = paragraphIdx;
+    }
+
+    // Try sentence boundary
+    if (splitIdx === -1) {
+      const sentenceMatch = remaining.slice(0, maxLength).match(/.*[.!?]\s/s);
+      if (sentenceMatch) {
+        splitIdx = sentenceMatch[0].length;
+      }
+    }
+
+    // Hard cut at newline
+    if (splitIdx === -1) {
+      const newlineIdx = remaining.lastIndexOf("\n", maxLength);
+      if (newlineIdx > maxLength * 0.3) {
+        splitIdx = newlineIdx;
+      }
+    }
+
+    // Final fallback: hard cut
+    if (splitIdx === -1) {
+      splitIdx = maxLength;
+    }
+
+    chunks.push(remaining.slice(0, splitIdx).trimEnd());
+    remaining = remaining.slice(splitIdx).trimStart();
+  }
+
+  if (remaining) {
+    chunks.push(remaining);
+  }
+
+  return chunks;
+}

--- a/packages/server/src/mattermost/mattermost-settings.ts
+++ b/packages/server/src/mattermost/mattermost-settings.ts
@@ -1,0 +1,144 @@
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+import { listPairedUsers, listPendingPairings } from "./pairing.js";
+import type { PairedUser, PendingPairing } from "./pairing.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MattermostAvailableChannel {
+  id: string;
+  name: string;
+  displayName: string;
+  teamName: string;
+}
+
+export interface MattermostSettingsResponse {
+  enabled: boolean;
+  tokenSet: boolean;
+  serverUrlSet: boolean;
+  serverUrl: string | null;
+  defaultTeam: string | null;
+  requireMention: boolean;
+  botUsername: string | null;
+  allowedChannels: string[];
+  availableChannels: MattermostAvailableChannel[];
+  pairedUsers: PairedUser[];
+  pendingPairings: PendingPairing[];
+}
+
+export interface MattermostTestResult {
+  ok: boolean;
+  error?: string;
+  latencyMs?: number;
+  botUsername?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Settings CRUD
+// ---------------------------------------------------------------------------
+
+export function getMattermostSettings(availableChannels: MattermostAvailableChannel[] = []): MattermostSettingsResponse {
+  const raw = getConfig("mattermost:allowed_channels");
+  let allowedChannels: string[] = [];
+  if (raw) {
+    try { allowedChannels = JSON.parse(raw); } catch { /* ignore */ }
+  }
+
+  return {
+    enabled: getConfig("mattermost:enabled") === "true",
+    tokenSet: !!getConfig("mattermost:bot_token"),
+    serverUrlSet: !!getConfig("mattermost:server_url"),
+    serverUrl: getConfig("mattermost:server_url") ?? null,
+    defaultTeam: getConfig("mattermost:default_team") ?? null,
+    requireMention: getConfig("mattermost:require_mention") !== "false", // default true
+    botUsername: getConfig("mattermost:bot_username") ?? null,
+    allowedChannels,
+    availableChannels,
+    pairedUsers: listPairedUsers(),
+    pendingPairings: listPendingPairings(),
+  };
+}
+
+export function updateMattermostSettings(data: {
+  enabled?: boolean;
+  botToken?: string;
+  serverUrl?: string;
+  defaultTeam?: string;
+  requireMention?: boolean;
+  allowedChannels?: string[];
+}): void {
+  if (data.enabled !== undefined) {
+    setConfig("mattermost:enabled", data.enabled ? "true" : "false");
+  }
+  if (data.botToken !== undefined) {
+    if (data.botToken === "") {
+      deleteConfig("mattermost:bot_token");
+      deleteConfig("mattermost:bot_username");
+    } else {
+      setConfig("mattermost:bot_token", data.botToken);
+    }
+  }
+  if (data.serverUrl !== undefined) {
+    if (data.serverUrl === "") {
+      deleteConfig("mattermost:server_url");
+    } else {
+      // Normalize: strip trailing slash
+      setConfig("mattermost:server_url", data.serverUrl.replace(/\/+$/, ""));
+    }
+  }
+  if (data.defaultTeam !== undefined) {
+    if (data.defaultTeam === "") {
+      deleteConfig("mattermost:default_team");
+    } else {
+      setConfig("mattermost:default_team", data.defaultTeam);
+    }
+  }
+  if (data.requireMention !== undefined) {
+    setConfig("mattermost:require_mention", data.requireMention ? "true" : "false");
+  }
+  if (data.allowedChannels !== undefined) {
+    setConfig("mattermost:allowed_channels", JSON.stringify(data.allowedChannels));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connection test
+// ---------------------------------------------------------------------------
+
+export async function testMattermostConnection(): Promise<MattermostTestResult> {
+  const token = getConfig("mattermost:bot_token");
+  const serverUrl = getConfig("mattermost:server_url");
+  if (!token) return { ok: false, error: "Mattermost bot token not configured." };
+  if (!serverUrl) return { ok: false, error: "Mattermost server URL not configured." };
+
+  const start = Date.now();
+
+  try {
+    const res = await fetch(`${serverUrl}/api/v4/users/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      return { ok: false, error: `HTTP ${res.status}: ${body.slice(0, 200)}` };
+    }
+
+    const user = (await res.json()) as { username?: string; id?: string };
+    const username = user.username ?? undefined;
+    if (username) {
+      setConfig("mattermost:bot_username", username);
+    }
+
+    return {
+      ok: true,
+      latencyMs: Date.now() - start,
+      botUsername: username,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/packages/server/src/mattermost/pairing.ts
+++ b/packages/server/src/mattermost/pairing.ts
@@ -1,0 +1,165 @@
+import { randomBytes } from "node:crypto";
+import { like } from "drizzle-orm";
+import { getDb, schema } from "../db/index.js";
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateCode(): string {
+  return randomBytes(3).toString("hex").toUpperCase(); // 6-char hex
+}
+
+const PAIRING_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export interface PendingPairing {
+  code: string;
+  mattermostUserId: string;
+  mattermostUsername: string;
+  createdAt: string;
+}
+
+export interface PairedUser {
+  mattermostUserId: string;
+  mattermostUsername: string;
+  pairedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Config-prefix query helper
+// ---------------------------------------------------------------------------
+
+function getConfigsByPrefix(prefix: string): Array<{ key: string; value: string }> {
+  const db = getDb();
+  return db
+    .select({ key: schema.config.key, value: schema.config.value })
+    .from(schema.config)
+    .where(like(schema.config.key, `${prefix}%`))
+    .all();
+}
+
+// ---------------------------------------------------------------------------
+// Pairing code management
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a pairing code for a Mattermost user.
+ * Only one active code per user — generating a new one deletes the old.
+ */
+export function generatePairingCode(mattermostUserId: string, mattermostUsername: string): string {
+  // Remove any existing code for this user
+  const existing = getConfigsByPrefix("mattermost:pairing:");
+  for (const row of existing) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (data.mattermostUserId === mattermostUserId) {
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+
+  const code = generateCode();
+  const data: PendingPairing = {
+    code,
+    mattermostUserId,
+    mattermostUsername,
+    createdAt: new Date().toISOString(),
+  };
+  setConfig(`mattermost:pairing:${code}`, JSON.stringify(data));
+  return code;
+}
+
+/**
+ * Check whether a Mattermost user is paired.
+ */
+export function isPaired(mattermostUserId: string): boolean {
+  return !!getConfig(`mattermost:paired:${mattermostUserId}`);
+}
+
+/**
+ * Approve a pending pairing by code.
+ * Returns the paired user info, or null if the code is invalid/expired.
+ */
+export function approvePairing(code: string): PairedUser | null {
+  const raw = getConfig(`mattermost:pairing:${code}`);
+  if (!raw) return null;
+
+  let pending: PendingPairing;
+  try {
+    pending = JSON.parse(raw) as PendingPairing;
+  } catch {
+    return null;
+  }
+
+  // Check expiry
+  if (Date.now() - new Date(pending.createdAt).getTime() > PAIRING_TTL_MS) {
+    deleteConfig(`mattermost:pairing:${code}`);
+    return null;
+  }
+
+  const paired: PairedUser = {
+    mattermostUserId: pending.mattermostUserId,
+    mattermostUsername: pending.mattermostUsername,
+    pairedAt: new Date().toISOString(),
+  };
+
+  setConfig(`mattermost:paired:${pending.mattermostUserId}`, JSON.stringify(paired));
+  deleteConfig(`mattermost:pairing:${code}`);
+  return paired;
+}
+
+/**
+ * Reject (delete) a pending pairing code.
+ */
+export function rejectPairing(code: string): boolean {
+  const raw = getConfig(`mattermost:pairing:${code}`);
+  if (!raw) return false;
+  deleteConfig(`mattermost:pairing:${code}`);
+  return true;
+}
+
+/**
+ * Revoke a paired user's access.
+ */
+export function revokePairing(mattermostUserId: string): boolean {
+  const raw = getConfig(`mattermost:paired:${mattermostUserId}`);
+  if (!raw) return false;
+  deleteConfig(`mattermost:paired:${mattermostUserId}`);
+  return true;
+}
+
+/**
+ * List all paired users.
+ */
+export function listPairedUsers(): PairedUser[] {
+  const rows = getConfigsByPrefix("mattermost:paired:");
+  const users: PairedUser[] = [];
+  for (const row of rows) {
+    try {
+      users.push(JSON.parse(row.value) as PairedUser);
+    } catch { /* ignore malformed */ }
+  }
+  return users;
+}
+
+/**
+ * List all pending (non-expired) pairing codes.
+ */
+export function listPendingPairings(): PendingPairing[] {
+  const rows = getConfigsByPrefix("mattermost:pairing:");
+  const now = Date.now();
+  const pending: PendingPairing[] = [];
+  for (const row of rows) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (now - new Date(data.createdAt).getTime() <= PAIRING_TTL_MS) {
+        pending.push(data);
+      } else {
+        // Clean up expired
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+  return pending;
+}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -59,6 +59,8 @@ export interface ServerToClientEvents {
   "teams:status": (data: { status: "connected" | "disconnected" | "error" }) => void;
   "slack:pairing-request": (data: { code: string; slackUserId: string; slackUsername: string }) => void;
   "slack:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
+  "mattermost:pairing-request": (data: { code: string; mattermostUserId: string; mattermostUsername: string }) => void;
+  "mattermost:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
   "telegram:pairing-request": (data: { code: string; telegramUserId: string; telegramUsername: string }) => void;
   "telegram:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
 }

--- a/packages/web/src/components/settings/ChannelsSection.tsx
+++ b/packages/web/src/components/settings/ChannelsSection.tsx
@@ -25,6 +25,12 @@ const CHANNELS = [
     icon: "D",
     settingsSection: "discord" as const,
   },
+  {
+    name: "Mattermost",
+    description: "Connect to Mattermost servers",
+    icon: "M",
+    settingsSection: "mattermost" as const,
+  },
 ];
 
 export function ChannelsSection() {
@@ -37,16 +43,21 @@ export function ChannelsSection() {
   const slackEnabled = useSettingsStore((s) => s.slackEnabled);
   const slackBotTokenSet = useSettingsStore((s) => s.slackBotTokenSet);
   const loadSlackSettings = useSettingsStore((s) => s.loadSlackSettings);
+  const mattermostEnabled = useSettingsStore((s) => s.mattermostEnabled);
+  const mattermostTokenSet = useSettingsStore((s) => s.mattermostTokenSet);
+  const loadMattermostSettings = useSettingsStore((s) => s.loadMattermostSettings);
 
   useEffect(() => {
     loadDiscordSettings();
     loadTelegramSettings();
     loadSlackSettings();
+    loadMattermostSettings();
   }, []);
 
   const isDiscordConnected = discordEnabled && discordTokenSet;
   const isTelegramConnected = telegramEnabled && telegramTokenSet;
   const isSlackConnected = slackEnabled && slackBotTokenSet;
+  const isMattermostConnected = mattermostEnabled && mattermostTokenSet;
 
   return (
     <div className="p-5 space-y-4">
@@ -59,7 +70,7 @@ export function ChannelsSection() {
 
       <div className="grid grid-cols-2 gap-3">
         {CHANNELS.map((channel) => {
-          const connected = (channel.name === "Discord" && isDiscordConnected) || (channel.name === "Telegram" && isTelegramConnected) || (channel.name === "Slack" && isSlackConnected);
+          const connected = (channel.name === "Discord" && isDiscordConnected) || (channel.name === "Telegram" && isTelegramConnected) || (channel.name === "Slack" && isSlackConnected) || (channel.name === "Mattermost" && isMattermostConnected);
           return (
             <div
               key={channel.name}

--- a/packages/web/src/components/settings/MattermostSection.tsx
+++ b/packages/web/src/components/settings/MattermostSection.tsx
@@ -1,0 +1,474 @@
+import { useState, useEffect, useMemo } from "react";
+import { cn } from "../../lib/utils";
+import { useSettingsStore } from "../../stores/settings-store";
+import { getSocket } from "../../lib/socket";
+
+export function MattermostSection() {
+  const enabled = useSettingsStore((s) => s.mattermostEnabled);
+  const tokenSet = useSettingsStore((s) => s.mattermostTokenSet);
+  const serverUrlSet = useSettingsStore((s) => s.mattermostServerUrlSet);
+  const serverUrl = useSettingsStore((s) => s.mattermostServerUrl);
+  const defaultTeam = useSettingsStore((s) => s.mattermostDefaultTeam);
+  const requireMention = useSettingsStore((s) => s.mattermostRequireMention);
+  const botUsername = useSettingsStore((s) => s.mattermostBotUsername);
+  const allowedChannels = useSettingsStore((s) => s.mattermostAllowedChannels);
+  const availableChannels = useSettingsStore((s) => s.mattermostAvailableChannels);
+  const pairedUsers = useSettingsStore((s) => s.mattermostPairedUsers);
+  const pendingPairings = useSettingsStore((s) => s.mattermostPendingPairings);
+  const testResult = useSettingsStore((s) => s.mattermostTestResult);
+  const loadMattermostSettings = useSettingsStore((s) => s.loadMattermostSettings);
+  const updateMattermostSettings = useSettingsStore((s) => s.updateMattermostSettings);
+  const testMattermostConnection = useSettingsStore((s) => s.testMattermostConnection);
+  const approveMattermostPairing = useSettingsStore((s) => s.approveMattermostPairing);
+  const rejectMattermostPairing = useSettingsStore((s) => s.rejectMattermostPairing);
+  const revokeMattermostUser = useSettingsStore((s) => s.revokeMattermostUser);
+
+  const [localToken, setLocalToken] = useState("");
+  const [localServerUrl, setLocalServerUrl] = useState("");
+  const [localDefaultTeam, setLocalDefaultTeam] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [savingChannels, setSavingChannels] = useState(false);
+  const [selectedChannels, setSelectedChannels] = useState<Set<string>>(new Set());
+  const [botStatus, setBotStatus] = useState<"connected" | "disconnected" | "error">("disconnected");
+
+  useEffect(() => {
+    loadMattermostSettings();
+  }, []);
+
+  // Listen for real-time Mattermost events
+  useEffect(() => {
+    const socket = getSocket();
+
+    const handleStatus = (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => {
+      setBotStatus(data.status);
+      if (data.status === "connected") {
+        loadMattermostSettings();
+      }
+    };
+
+    const handlePairingRequest = () => {
+      loadMattermostSettings();
+    };
+
+    socket.on("mattermost:status", handleStatus);
+    socket.on("mattermost:pairing-request", handlePairingRequest);
+
+    return () => {
+      socket.off("mattermost:status", handleStatus);
+      socket.off("mattermost:pairing-request", handlePairingRequest);
+    };
+  }, []);
+
+  // Sync local state from store
+  useEffect(() => {
+    setSelectedChannels(new Set(allowedChannels));
+  }, [allowedChannels]);
+
+  useEffect(() => {
+    if (serverUrl && !localServerUrl) setLocalServerUrl(serverUrl);
+  }, [serverUrl]);
+
+  useEffect(() => {
+    if (defaultTeam && !localDefaultTeam) setLocalDefaultTeam(defaultTeam);
+  }, [defaultTeam]);
+
+  // Group available channels by team
+  const channelsByTeam = useMemo(() => {
+    const groups = new Map<string, Array<{ id: string; name: string; displayName: string }>>();
+    for (const ch of availableChannels) {
+      let list = groups.get(ch.teamName);
+      if (!list) {
+        list = [];
+        groups.set(ch.teamName, list);
+      }
+      list.push({ id: ch.id, name: ch.name, displayName: ch.displayName });
+    }
+    for (const list of groups.values()) {
+      list.sort((a, b) => a.name.localeCompare(b.name));
+    }
+    return groups;
+  }, [availableChannels]);
+
+  const handleToggleChannel = (channelId: string) => {
+    setSelectedChannels((prev) => {
+      const next = new Set(prev);
+      if (next.has(channelId)) {
+        next.delete(channelId);
+      } else {
+        next.add(channelId);
+      }
+      return next;
+    });
+  };
+
+  const handleSaveChannels = async () => {
+    setSavingChannels(true);
+    await updateMattermostSettings({ allowedChannels: [...selectedChannels] });
+    setSavingChannels(false);
+  };
+
+  const channelsChanged = useMemo(() => {
+    if (selectedChannels.size !== allowedChannels.length) return true;
+    return allowedChannels.some((id) => !selectedChannels.has(id));
+  }, [selectedChannels, allowedChannels]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    const data: { botToken?: string; serverUrl?: string; defaultTeam?: string } = {};
+    if (localToken) data.botToken = localToken;
+    if (localServerUrl) data.serverUrl = localServerUrl;
+    if (localDefaultTeam !== (defaultTeam ?? "")) data.defaultTeam = localDefaultTeam;
+    await updateMattermostSettings(data);
+    setLocalToken("");
+    setSaving(false);
+  };
+
+  const handleToggleEnabled = async () => {
+    await updateMattermostSettings({ enabled: !enabled });
+  };
+
+  const handleToggleMention = async () => {
+    await updateMattermostSettings({ requireMention: !requireMention });
+  };
+
+  const handleTest = () => {
+    testMattermostConnection();
+  };
+
+  const handleClearToken = async () => {
+    setSaving(true);
+    await updateMattermostSettings({ botToken: "" });
+    setLocalToken("");
+    setSaving(false);
+  };
+
+  return (
+    <div className="p-5 space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Connect Otterbot to Mattermost. Users must pair with the bot before it
+        responds to their messages.
+      </p>
+
+      {/* Enable toggle */}
+      <label className="flex items-center gap-3 cursor-pointer">
+        <button
+          onClick={handleToggleEnabled}
+          className={cn(
+            "relative w-9 h-5 rounded-full transition-colors",
+            enabled ? "bg-primary" : "bg-secondary",
+          )}
+        >
+          <span
+            className={cn(
+              "absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform",
+              enabled && "translate-x-4",
+            )}
+          />
+        </button>
+        <span className="text-sm">Enable Mattermost integration</span>
+      </label>
+
+      {/* Connection section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <div>
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Server URL
+            {serverUrlSet && (
+              <span className="ml-2 text-green-500 normal-case tracking-normal">
+                Set
+              </span>
+            )}
+          </label>
+          <input
+            type="text"
+            value={localServerUrl}
+            onChange={(e) => setLocalServerUrl(e.target.value)}
+            placeholder="https://your-mattermost-server.com"
+            className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+          />
+        </div>
+
+        <div>
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Bot Token
+            {tokenSet && (
+              <span className="ml-2 text-green-500 normal-case tracking-normal">
+                Set
+              </span>
+            )}
+          </label>
+          <input
+            type="password"
+            value={localToken}
+            onChange={(e) => setLocalToken(e.target.value)}
+            placeholder={
+              tokenSet ? "Enter new token to change" : "Paste your bot token"
+            }
+            className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+          />
+        </div>
+
+        <div>
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Default Team
+          </label>
+          <input
+            type="text"
+            value={localDefaultTeam}
+            onChange={(e) => setLocalDefaultTeam(e.target.value)}
+            placeholder="team-name"
+            className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+          />
+          <p className="text-[10px] text-muted-foreground mt-1">
+            The team name (URL slug) used for channel discovery.
+          </p>
+        </div>
+
+        {botUsername && (
+          <div className="text-xs text-muted-foreground">
+            Bot: <span className="text-foreground font-medium">{botUsername}</span>
+            {enabled && tokenSet && serverUrlSet && (
+              <span className={cn(
+                "ml-2 text-[10px] px-1.5 py-0.5 rounded",
+                botStatus === "connected"
+                  ? "text-green-500 bg-green-500/10"
+                  : botStatus === "error"
+                    ? "text-red-500 bg-red-500/10"
+                    : "text-muted-foreground bg-muted",
+              )}>
+                {botStatus === "connected" ? "Online" : botStatus === "error" ? "Error" : "Offline"}
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 pt-1">
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="text-xs bg-primary text-primary-foreground px-3 py-1.5 rounded-md hover:bg-primary/90 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+          <button
+            onClick={handleTest}
+            disabled={testResult?.testing || !tokenSet || !serverUrlSet}
+            className="text-xs bg-secondary text-foreground px-3 py-1.5 rounded-md hover:bg-secondary/80 disabled:opacity-50"
+          >
+            {testResult?.testing ? "Testing..." : "Test Connection"}
+          </button>
+          {tokenSet && (
+            <button
+              onClick={handleClearToken}
+              disabled={saving}
+              className="text-xs text-red-500 hover:text-red-400 px-2 py-1.5"
+            >
+              Clear Token
+            </button>
+          )}
+
+          {testResult && !testResult.testing && (
+            <span
+              className={cn(
+                "text-xs",
+                testResult.ok ? "text-green-500" : "text-red-500",
+              )}
+            >
+              {testResult.ok
+                ? "\u2713 Connected"
+                : `\u2717 ${testResult.error ?? "Failed"}`}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Behavior section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Behavior
+        </label>
+        <label className="flex items-center gap-3 cursor-pointer">
+          <button
+            onClick={handleToggleMention}
+            className={cn(
+              "relative w-9 h-5 rounded-full transition-colors",
+              requireMention ? "bg-primary" : "bg-secondary",
+            )}
+          >
+            <span
+              className={cn(
+                "absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform",
+                requireMention && "translate-x-4",
+              )}
+            />
+          </button>
+          <div>
+            <span className="text-sm">Require @mention in channels</span>
+            <p className="text-[10px] text-muted-foreground">
+              When enabled, the bot only responds to messages that @mention it in public channels. DMs always work.
+            </p>
+          </div>
+        </label>
+      </div>
+
+      {/* Allowed Channels section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Allowed Channels
+          {selectedChannels.size > 0 && (
+            <span className="ml-2 normal-case tracking-normal text-foreground">
+              {selectedChannels.size}
+            </span>
+          )}
+        </label>
+        <p className="text-[10px] text-muted-foreground">
+          When set, the bot only responds in these channels. DMs are always allowed.
+        </p>
+
+        {availableChannels.length === 0 ? (
+          <p className="text-[10px] text-muted-foreground italic">
+            Connect the bot and set a default team to see available channels.
+          </p>
+        ) : (
+          <div className="space-y-3 max-h-64 overflow-y-auto">
+            {[...channelsByTeam.entries()].map(([teamName, channels]) => (
+              <div key={teamName}>
+                <div className="text-[10px] text-muted-foreground font-medium mb-1">
+                  {teamName}
+                </div>
+                <div className="space-y-1">
+                  {channels.map((ch) => (
+                    <label
+                      key={ch.id}
+                      className="flex items-center gap-2 cursor-pointer hover:bg-secondary/50 rounded px-2 py-1"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedChannels.has(ch.id)}
+                        onChange={() => handleToggleChannel(ch.id)}
+                        className="rounded border-border"
+                      />
+                      <span className="text-xs">~{ch.name}</span>
+                      {ch.displayName !== ch.name && (
+                        <span className="text-[10px] text-muted-foreground">({ch.displayName})</span>
+                      )}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {availableChannels.length > 0 && channelsChanged && (
+          <button
+            onClick={handleSaveChannels}
+            disabled={savingChannels}
+            className="text-xs bg-primary text-primary-foreground px-3 py-1.5 rounded-md hover:bg-primary/90 disabled:opacity-50"
+          >
+            {savingChannels ? "Saving..." : "Save"}
+          </button>
+        )}
+      </div>
+
+      {/* Paired Users section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Paired Users
+          <span className="ml-2 normal-case tracking-normal text-foreground">
+            {pairedUsers.length}
+          </span>
+        </label>
+
+        {pairedUsers.length === 0 ? (
+          <p className="text-[10px] text-muted-foreground">
+            No users have been paired yet. When someone messages the bot, they'll receive a pairing code to approve here.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {pairedUsers.map((user) => (
+              <div
+                key={user.mattermostUserId}
+                className="flex items-center justify-between bg-secondary rounded-md px-3 py-2"
+              >
+                <div>
+                  <span className="text-xs font-medium">{user.mattermostUsername}</span>
+                  <span className="text-[10px] text-muted-foreground ml-2">
+                    Paired {new Date(user.pairedAt).toLocaleDateString()}
+                  </span>
+                </div>
+                <button
+                  onClick={() => revokeMattermostUser(user.mattermostUserId)}
+                  className="text-[10px] text-red-500 hover:text-red-400 px-2 py-1"
+                >
+                  Revoke
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Pending Pairings section */}
+      {pendingPairings.length > 0 && (
+        <div className="border border-border rounded-lg p-4 space-y-3">
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Pending Pairings
+            <span className="ml-2 normal-case tracking-normal text-yellow-500">
+              {pendingPairings.length}
+            </span>
+          </label>
+
+          <div className="space-y-2">
+            {pendingPairings.map((pairing) => (
+              <div
+                key={pairing.code}
+                className="flex items-center justify-between bg-secondary rounded-md px-3 py-2"
+              >
+                <div>
+                  <span className="text-xs font-medium">{pairing.mattermostUsername}</span>
+                  <code className="text-[10px] bg-muted px-1.5 py-0.5 rounded ml-2 font-mono">
+                    {pairing.code}
+                  </code>
+                  <span className="text-[10px] text-muted-foreground ml-2">
+                    {new Date(pairing.createdAt).toLocaleTimeString()}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => approveMattermostPairing(pairing.code)}
+                    className="text-[10px] text-green-500 hover:text-green-400 bg-green-500/10 px-2 py-1 rounded"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => rejectMattermostPairing(pairing.code)}
+                    className="text-[10px] text-red-500 hover:text-red-400 px-2 py-1"
+                  >
+                    Reject
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Setup instructions */}
+      <div className="text-[10px] text-muted-foreground space-y-1">
+        <p>
+          <strong>How to set up the Mattermost bot:</strong>
+        </p>
+        <ol className="list-decimal list-inside space-y-0.5">
+          <li>Go to your Mattermost System Console &gt; Integrations &gt; Bot Accounts</li>
+          <li>Enable bot account creation if not already enabled</li>
+          <li>Go to Integrations &gt; Bot Accounts and create a new bot</li>
+          <li>Copy the generated access token and paste it above</li>
+          <li>Enter your Mattermost server URL (e.g., https://mattermost.example.com)</li>
+          <li>Enter the default team name (the URL slug, e.g., "myteam")</li>
+          <li>Add the bot to the channels you want it to listen in</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -20,6 +20,7 @@ import { EmailSection } from "./EmailSection";
 import { GitHubTab } from "./GitHubTab";
 import { DiscordSection } from "./DiscordSection";
 import { SlackSection } from "./SlackSection";
+import { MattermostSection } from "./MattermostSection";
 import { TelegramSection } from "./TelegramSection";
 import { GoogleSection } from "./GoogleSection";
 import { SecuritySection } from "./SecuritySection";
@@ -58,6 +59,7 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
     if (activeSection === "discord") return <DiscordSection />;
     if (activeSection === "telegram") return <TelegramSection />;
     if (activeSection === "slack") return <SlackSection />;
+    if (activeSection === "mattermost") return <MattermostSection />;
     if (activeSection === "security") return <SecuritySection />;
     if (activeSection === "soul") return <SoulTab />;
     if (activeSection === "memory") return <MemoryTab />;

--- a/packages/web/src/components/settings/settings-nav.ts
+++ b/packages/web/src/components/settings/settings-nav.ts
@@ -21,6 +21,7 @@ export type SettingsSection =
   | "discord"
   | "telegram"
   | "slack"
+  | "mattermost"
   | "security";
 
 export interface NavItem {
@@ -79,6 +80,7 @@ export const SETTINGS_NAV: NavGroup[] = [
       { id: "discord", label: "Discord" },
       { id: "telegram", label: "Telegram" },
       { id: "slack", label: "Slack" },
+      { id: "mattermost", label: "Mattermost" },
     ],
   },
   {

--- a/packages/web/src/stores/settings-store.ts
+++ b/packages/web/src/stores/settings-store.ts
@@ -198,6 +198,20 @@ interface SettingsState {
   slackPendingPairings: Array<{ code: string; slackUserId: string; slackUsername: string; createdAt: string }>;
   slackTestResult: TestResult | null;
 
+  // Mattermost
+  mattermostEnabled: boolean;
+  mattermostTokenSet: boolean;
+  mattermostServerUrlSet: boolean;
+  mattermostServerUrl: string | null;
+  mattermostDefaultTeam: string | null;
+  mattermostRequireMention: boolean;
+  mattermostBotUsername: string | null;
+  mattermostAllowedChannels: string[];
+  mattermostAvailableChannels: Array<{ id: string; name: string; displayName: string; teamName: string }>;
+  mattermostPairedUsers: Array<{ mattermostUserId: string; mattermostUsername: string; pairedAt: string }>;
+  mattermostPendingPairings: Array<{ code: string; mattermostUserId: string; mattermostUsername: string; createdAt: string }>;
+  mattermostTestResult: TestResult | null;
+
   // Google
   googleConnected: boolean;
   googleConnectedEmail: string | null;
@@ -389,6 +403,21 @@ interface SettingsState {
   rejectSlackPairing: (code: string) => Promise<void>;
   revokeSlackUser: (userId: string) => Promise<void>;
 
+  // Mattermost actions
+  loadMattermostSettings: () => Promise<void>;
+  updateMattermostSettings: (data: {
+    enabled?: boolean;
+    botToken?: string;
+    serverUrl?: string;
+    defaultTeam?: string;
+    requireMention?: boolean;
+    allowedChannels?: string[];
+  }) => Promise<void>;
+  testMattermostConnection: () => Promise<void>;
+  approveMattermostPairing: (code: string) => Promise<void>;
+  rejectMattermostPairing: (code: string) => Promise<void>;
+  revokeMattermostUser: (userId: string) => Promise<void>;
+
   // Google actions
   loadGoogleSettings: () => Promise<void>;
   updateGoogleCredentials: (data: {
@@ -509,6 +538,18 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   slackPairedUsers: [],
   slackPendingPairings: [],
   slackTestResult: null,
+  mattermostEnabled: false,
+  mattermostTokenSet: false,
+  mattermostServerUrlSet: false,
+  mattermostServerUrl: null,
+  mattermostDefaultTeam: null,
+  mattermostRequireMention: true,
+  mattermostBotUsername: null,
+  mattermostAllowedChannels: [],
+  mattermostAvailableChannels: [],
+  mattermostPairedUsers: [],
+  mattermostPendingPairings: [],
+  mattermostTestResult: null,
   googleConnected: false,
   googleConnectedEmail: null,
   googleClientIdSet: false,
@@ -1889,6 +1930,115 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       });
       if (!res.ok) throw new Error("Failed to revoke user");
       await get().loadSlackSettings();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+    }
+  },
+
+  // Mattermost actions
+
+  loadMattermostSettings: async () => {
+    try {
+      const res = await fetch("/api/settings/mattermost");
+      if (!res.ok) return;
+      const data = await res.json();
+      set({
+        mattermostEnabled: data.enabled,
+        mattermostTokenSet: data.tokenSet,
+        mattermostServerUrlSet: data.serverUrlSet,
+        mattermostServerUrl: data.serverUrl,
+        mattermostDefaultTeam: data.defaultTeam,
+        mattermostRequireMention: data.requireMention,
+        mattermostBotUsername: data.botUsername,
+        mattermostAllowedChannels: data.allowedChannels ?? [],
+        mattermostAvailableChannels: data.availableChannels ?? [],
+        mattermostPairedUsers: data.pairedUsers,
+        mattermostPendingPairings: data.pendingPairings,
+      });
+    } catch {
+      // Silently fail
+    }
+  },
+
+  updateMattermostSettings: async (data) => {
+    set({ error: null });
+    try {
+      const res = await fetch("/api/settings/mattermost", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) throw new Error("Failed to update Mattermost settings");
+      await get().loadMattermostSettings();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+    }
+  },
+
+  testMattermostConnection: async () => {
+    set({ mattermostTestResult: { ok: false, testing: true } });
+    try {
+      const res = await fetch("/api/settings/mattermost/test", {
+        method: "POST",
+      });
+      const data = await res.json();
+      set({
+        mattermostTestResult: {
+          ok: data.ok,
+          error: data.error,
+          testing: false,
+        },
+        mattermostBotUsername: data.ok ? data.botUsername : get().mattermostBotUsername,
+      });
+    } catch {
+      set({
+        mattermostTestResult: {
+          ok: false,
+          error: "Network error",
+          testing: false,
+        },
+      });
+    }
+  },
+
+  approveMattermostPairing: async (code) => {
+    set({ error: null });
+    try {
+      const res = await fetch("/api/settings/mattermost/pair/approve", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      });
+      if (!res.ok) throw new Error("Failed to approve pairing");
+      await get().loadMattermostSettings();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+    }
+  },
+
+  rejectMattermostPairing: async (code) => {
+    set({ error: null });
+    try {
+      const res = await fetch("/api/settings/mattermost/pair/reject", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      });
+      if (!res.ok) throw new Error("Failed to reject pairing");
+      await get().loadMattermostSettings();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+    }
+  },
+
+  revokeMattermostUser: async (userId) => {
+    set({ error: null });
+    try {
+      const res = await fetch(`/api/settings/mattermost/pair/${userId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to revoke user");
+      await get().loadMattermostSettings();
     } catch (err) {
       set({ error: err instanceof Error ? err.message : "Unknown error" });
     }


### PR DESCRIPTION
## Summary

- Adds a complete Mattermost channel adapter following the existing bridge pattern (Discord, Slack, etc.)
- Implements `MattermostBridge` class with WebSocket real-time events for inbound messages and REST API (`/api/v4/posts`) for outbound replies
- Supports bot token authentication, server URL configuration, default team selection, @mention filtering, channel whitelisting, and thread-aware replies
- Includes user pairing system for access control (same pattern as Discord/Slack)
- Adds full settings UI section with connection test, channel management, paired users, and setup instructions
- Registers bridge lifecycle, API routes, and socket.io events in the server
- No new dependencies — uses existing `ws` and native `fetch`

## Test plan

- [x] 25 unit tests covering connection initialization, message routing (inbound/outbound), pairing flow, channel filtering, error handling, and cleanup
- [x] All 675 tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)

Closes #N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)