### PR TITLE
feat: add WhatsApp chat provider with QR code pairing

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
   "engines": {
     "node": ">=20",
     "pnpm": ">=9"
+  },
+  "dependencies": {
+    "@whiskeysockets/baileys": "7.0.0-rc.9"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,6 +26,7 @@
     "@opencode-ai/sdk": "^1.2.6",
     "@otterbot/shared": "workspace:*",
     "@slack/bolt": "^4.6.0",
+    "@whiskeysockets/baileys": "7.0.0-rc.9",
     "ai": "^4.1.61",
     "better-sqlite3-multiple-ciphers": "^11.8.1",
     "discord.js": "^14.16.0",

--- a/packages/server/src/chat/registry.ts
+++ b/packages/server/src/chat/registry.ts
@@ -1,12 +1,14 @@
 import type { IChatProvider } from "./IChatProvider.js";
 import type { ChatProviderType } from "@otterbot/shared";
 import { TeamsProvider } from "./teams/TeamsProvider.js";
+import { WhatsAppProvider } from "./whatsapp/WhatsAppProvider.js";
 
 /**
  * Registry of available chat providers keyed by their type identifier.
  */
 const chatProviderFactories: Partial<Record<ChatProviderType, () => IChatProvider>> = {
   teams: () => new TeamsProvider(),
+  whatsapp: () => new WhatsAppProvider(),
 };
 
 /** Create a chat provider instance by type. */

--- a/packages/server/src/chat/whatsapp/WhatsAppProvider.ts
+++ b/packages/server/src/chat/whatsapp/WhatsAppProvider.ts
@@ -1,0 +1,24 @@
+import type { IChatProvider } from "../IChatProvider.js";
+
+/**
+ * WhatsApp chat provider (stub for registry).
+ *
+ * The actual bridge implementation lives in `../../whatsapp/whatsapp-bridge.ts`.
+ * This is a placeholder scaffold so the provider appears in the registry.
+ */
+export class WhatsAppProvider implements IChatProvider {
+  readonly id = "whatsapp" as const;
+  readonly name = "WhatsApp";
+
+  async start(): Promise<void> {
+    throw new Error("WhatsAppProvider.start() is not yet implemented — use WhatsAppBridge directly");
+  }
+
+  async stop(): Promise<void> {
+    throw new Error("WhatsAppProvider.stop() is not yet implemented — use WhatsAppBridge directly");
+  }
+
+  async sendMessage(_channelId: string, _content: string): Promise<void> {
+    throw new Error("WhatsAppProvider.sendMessage() is not yet implemented — use WhatsAppBridge directly");
+  }
+}

--- a/packages/server/src/whatsapp/__tests__/whatsapp-bridge.test.ts
+++ b/packages/server/src/whatsapp/__tests__/whatsapp-bridge.test.ts
@@ -1,0 +1,778 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventEmitter } from "events";
+import { migrateDb, resetDb } from "../../db/index.js";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage } from "@otterbot/shared";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Mock @whiskeysockets/baileys
+// ---------------------------------------------------------------------------
+
+class MockWASocket extends EventEmitter {
+  user = { id: "1234567890:0@s.whatsapp.net" };
+  sentMessages: { jid: string; content: Record<string, unknown> }[] = [];
+  ended = false;
+
+  ev = {
+    _handlers: new Map<string, ((...args: unknown[]) => void)[]>(),
+    on(event: string, handler: (...args: unknown[]) => void) {
+      const handlers = this._handlers.get(event) ?? [];
+      handlers.push(handler);
+      this._handlers.set(event, handlers);
+    },
+    off(event: string, handler: (...args: unknown[]) => void) {
+      const handlers = this._handlers.get(event) ?? [];
+      this._handlers.set(event, handlers.filter((h) => h !== handler));
+    },
+    emit(event: string, ...args: unknown[]) {
+      const handlers = this._handlers.get(event) ?? [];
+      for (const handler of handlers) {
+        handler(...args);
+      }
+    },
+  };
+
+  async sendMessage(jid: string, content: Record<string, unknown>) {
+    this.sentMessages.push({ jid, content });
+    return { key: { id: "msg-" + this.sentMessages.length } };
+  }
+
+  end() {
+    this.ended = true;
+  }
+}
+
+let mockSocket: MockWASocket;
+
+vi.mock("@whiskeysockets/baileys", () => {
+  return {
+    default: () => {
+      mockSocket = new MockWASocket();
+      return mockSocket;
+    },
+    useMultiFileAuthState: vi.fn(async () => ({
+      state: { creds: {}, keys: {} },
+      saveCreds: vi.fn(),
+    })),
+    DisconnectReason: {
+      loggedOut: 401,
+      connectionLost: 408,
+      connectionClosed: 428,
+      restartRequired: 515,
+    },
+  };
+});
+
+vi.mock("@hapi/boom", () => ({
+  Boom: class Boom extends Error {
+    output: { statusCode: number };
+    constructor(message: string, options?: { statusCode: number }) {
+      super(message);
+      this.output = { statusCode: options?.statusCode ?? 500 };
+    }
+  },
+}));
+
+// Mock config store
+const configStore = new Map<string, string>();
+
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn((key: string) => configStore.get(key)),
+  setConfig: vi.fn((key: string, value: string) => configStore.set(key, value)),
+  deleteConfig: vi.fn((key: string) => configStore.delete(key)),
+}));
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+const { WhatsAppBridge } = await import("../whatsapp-bridge.js");
+
+interface SendParams {
+  fromAgentId: string | null;
+  toAgentId: string | null;
+  type: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  conversationId?: string;
+}
+
+function createMockBus() {
+  const broadcastHandlers: ((message: BusMessage) => void)[] = [];
+  const sent: SendParams[] = [];
+
+  const bus = {
+    send: vi.fn((params: SendParams) => {
+      sent.push(params);
+      const message: BusMessage = {
+        id: "test-msg-id",
+        fromAgentId: params.fromAgentId,
+        toAgentId: params.toAgentId,
+        type: params.type as BusMessage["type"],
+        content: params.content,
+        metadata: params.metadata ?? {},
+        conversationId: params.conversationId,
+        timestamp: new Date().toISOString(),
+      };
+      return message;
+    }),
+    onBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      broadcastHandlers.push(handler);
+    }),
+    offBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      const idx = broadcastHandlers.indexOf(handler);
+      if (idx >= 0) broadcastHandlers.splice(idx, 1);
+    }),
+    _broadcastHandlers: broadcastHandlers,
+    _sent: sent,
+  };
+
+  return bus;
+}
+
+function createMockCoo() {
+  return {
+    startNewConversation: vi.fn(),
+  };
+}
+
+function createMockIo() {
+  return {
+    emit: vi.fn(),
+  };
+}
+
+describe("WhatsAppBridge", () => {
+  let tmpDir: string;
+  let bus: ReturnType<typeof createMockBus>;
+  let coo: ReturnType<typeof createMockCoo>;
+  let io: ReturnType<typeof createMockIo>;
+  let bridge: InstanceType<typeof WhatsAppBridge>;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-wa-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+
+    configStore.clear();
+
+    bus = createMockBus();
+    coo = createMockCoo();
+    io = createMockIo();
+
+    bridge = new WhatsAppBridge({
+      bus: bus as any,
+      coo: coo as any,
+      io: io as any,
+    });
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // Connection & Lifecycle
+  // -------------------------------------------------------------------------
+
+  describe("connection lifecycle", () => {
+    it("subscribes to bus broadcasts on start", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+      expect(bus.onBroadcast).toHaveBeenCalledOnce();
+    });
+
+    it("emits connected status when connection opens", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+
+      // Simulate connection open
+      mockSocket.ev.emit("connection.update", { connection: "open" });
+
+      expect(io.emit).toHaveBeenCalledWith("whatsapp:status", {
+        status: "connected",
+        phoneNumber: "1234567890",
+      });
+    });
+
+    it("emits disconnected status when logged out", async () => {
+      const { Boom } = await import("@hapi/boom");
+      await bridge.start(join(tmpDir, "auth"));
+
+      mockSocket.ev.emit("connection.update", {
+        connection: "close",
+        lastDisconnect: { error: new Boom("Logged out", { statusCode: 401 }) },
+      });
+
+      expect(io.emit).toHaveBeenCalledWith("whatsapp:status", {
+        status: "disconnected",
+      });
+    });
+
+    it("emits error status on non-logout close", async () => {
+      const { Boom } = await import("@hapi/boom");
+      await bridge.start(join(tmpDir, "auth"));
+
+      mockSocket.ev.emit("connection.update", {
+        connection: "close",
+        lastDisconnect: { error: new Boom("Connection lost", { statusCode: 408 }) },
+      });
+
+      expect(io.emit).toHaveBeenCalledWith("whatsapp:status", {
+        status: "error",
+      });
+    });
+
+    it("emits QR code to clients", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+
+      mockSocket.ev.emit("connection.update", {
+        qr: "test-qr-data-string",
+      });
+
+      expect(io.emit).toHaveBeenCalledWith("whatsapp:qr", {
+        qr: "test-qr-data-string",
+      });
+    });
+
+    it("unsubscribes from bus on stop", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+      await bridge.stop();
+      expect(bus.offBroadcast).toHaveBeenCalledOnce();
+    });
+
+    it("emits disconnected status on stop", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+      await bridge.stop();
+      expect(io.emit).toHaveBeenCalledWith("whatsapp:status", {
+        status: "disconnected",
+      });
+    });
+
+    it("nullifies the socket after stop", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+      await bridge.stop();
+      expect((bridge as any).socket).toBeNull();
+    });
+
+    it("can restart after stop", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+      await bridge.stop();
+      await bridge.start(join(tmpDir, "auth"));
+
+      expect((bridge as any).socket).not.toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // QR Code Pairing
+  // -------------------------------------------------------------------------
+
+  describe("QR code pairing", () => {
+    it("emits QR codes as they arrive", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+
+      mockSocket.ev.emit("connection.update", { qr: "qr-code-1" });
+      mockSocket.ev.emit("connection.update", { qr: "qr-code-2" });
+
+      expect(io.emit).toHaveBeenCalledWith("whatsapp:qr", { qr: "qr-code-1" });
+      expect(io.emit).toHaveBeenCalledWith("whatsapp:qr", { qr: "qr-code-2" });
+    });
+
+    it("stores phone number on connection open", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+      mockSocket.ev.emit("connection.update", { connection: "open" });
+
+      expect(configStore.get("whatsapp:phone_number")).toBe("1234567890");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Inbound Messages (WhatsApp → COO)
+  // -------------------------------------------------------------------------
+
+  describe("message handling", () => {
+    it("sends pairing code for unpaired users", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+
+      mockSocket.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: false },
+            message: { conversation: "Hello" },
+            pushName: "Alice",
+          },
+        ],
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should send pairing code message
+      expect(mockSocket.sentMessages).toHaveLength(1);
+      expect(mockSocket.sentMessages[0]!.jid).toBe("5551234567@s.whatsapp.net");
+      expect((mockSocket.sentMessages[0]!.content as any).text).toContain(
+        "I don't recognize you yet",
+      );
+
+      // Should emit pairing request
+      expect(io.emit).toHaveBeenCalledWith(
+        "whatsapp:pairing-request",
+        expect.objectContaining({
+          whatsappJid: "5551234567@s.whatsapp.net",
+          whatsappName: "Alice",
+        }),
+      );
+    });
+
+    it("routes messages from paired users to COO", async () => {
+      // Mark user as paired
+      configStore.set(
+        "whatsapp:paired:5551234567@s.whatsapp.net",
+        JSON.stringify({
+          whatsappJid: "5551234567@s.whatsapp.net",
+          whatsappName: "Alice",
+          pairedAt: new Date().toISOString(),
+        }),
+      );
+
+      await bridge.start(join(tmpDir, "auth"));
+
+      mockSocket.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: false },
+            message: { conversation: "Hello bot!" },
+            pushName: "Alice",
+          },
+        ],
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(bus.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromAgentId: null,
+          toAgentId: "coo",
+          type: MessageType.Chat,
+          content: "Hello bot!",
+          metadata: expect.objectContaining({
+            source: "whatsapp",
+            whatsappJid: "5551234567@s.whatsapp.net",
+          }),
+        }),
+      );
+    });
+
+    it("ignores messages from self", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+
+      mockSocket.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: true },
+            message: { conversation: "My own message" },
+            pushName: "Self",
+          },
+        ],
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(bus.send).not.toHaveBeenCalled();
+      expect(mockSocket.sentMessages).toHaveLength(0);
+    });
+
+    it("ignores non-text messages", async () => {
+      configStore.set(
+        "whatsapp:paired:5551234567@s.whatsapp.net",
+        JSON.stringify({
+          whatsappJid: "5551234567@s.whatsapp.net",
+          whatsappName: "Alice",
+          pairedAt: new Date().toISOString(),
+        }),
+      );
+
+      await bridge.start(join(tmpDir, "auth"));
+
+      mockSocket.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: false },
+            message: { imageMessage: { caption: "photo" } },
+            pushName: "Alice",
+          },
+        ],
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(bus.send).not.toHaveBeenCalled();
+    });
+
+    it("ignores non-notify message types", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+
+      mockSocket.ev.emit("messages.upsert", {
+        type: "append",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: false },
+            message: { conversation: "Hello" },
+            pushName: "Alice",
+          },
+        ],
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(bus.send).not.toHaveBeenCalled();
+      expect(mockSocket.sentMessages).toHaveLength(0);
+    });
+
+    it("creates a conversation for new messages", async () => {
+      configStore.set(
+        "whatsapp:paired:5551234567@s.whatsapp.net",
+        JSON.stringify({
+          whatsappJid: "5551234567@s.whatsapp.net",
+          whatsappName: "Alice",
+          pairedAt: new Date().toISOString(),
+        }),
+      );
+
+      await bridge.start(join(tmpDir, "auth"));
+
+      mockSocket.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: false },
+            message: { conversation: "hi" },
+            pushName: "Alice",
+          },
+        ],
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(coo.startNewConversation).toHaveBeenCalledOnce();
+      expect(io.emit).toHaveBeenCalledWith(
+        "conversation:created",
+        expect.objectContaining({
+          title: expect.stringContaining("WhatsApp: Alice"),
+        }),
+      );
+    });
+
+    it("reuses conversation for same JID", async () => {
+      configStore.set(
+        "whatsapp:paired:5551234567@s.whatsapp.net",
+        JSON.stringify({
+          whatsappJid: "5551234567@s.whatsapp.net",
+          whatsappName: "Alice",
+          pairedAt: new Date().toISOString(),
+        }),
+      );
+
+      await bridge.start(join(tmpDir, "auth"));
+
+      // First message
+      mockSocket.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: false },
+            message: { conversation: "first" },
+            pushName: "Alice",
+          },
+        ],
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Second message
+      mockSocket.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: false },
+            message: { conversation: "second" },
+            pushName: "Alice",
+          },
+        ],
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should only create one conversation
+      expect(coo.startNewConversation).toHaveBeenCalledOnce();
+      // But send two messages
+      expect(bus.send).toHaveBeenCalledTimes(2);
+    });
+
+    it("handles extendedTextMessage", async () => {
+      configStore.set(
+        "whatsapp:paired:5551234567@s.whatsapp.net",
+        JSON.stringify({
+          whatsappJid: "5551234567@s.whatsapp.net",
+          whatsappName: "Alice",
+          pairedAt: new Date().toISOString(),
+        }),
+      );
+
+      await bridge.start(join(tmpDir, "auth"));
+
+      mockSocket.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: false },
+            message: { extendedTextMessage: { text: "quoted reply text" } },
+            pushName: "Alice",
+          },
+        ],
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(bus.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: "quoted reply text",
+        }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Outbound Messages (COO → WhatsApp)
+  // -------------------------------------------------------------------------
+
+  describe("outbound messages", () => {
+    it("sends COO responses back to WhatsApp", async () => {
+      configStore.set(
+        "whatsapp:paired:5551234567@s.whatsapp.net",
+        JSON.stringify({
+          whatsappJid: "5551234567@s.whatsapp.net",
+          whatsappName: "Alice",
+          pairedAt: new Date().toISOString(),
+        }),
+      );
+
+      await bridge.start(join(tmpDir, "auth"));
+
+      // Simulate inbound message
+      mockSocket.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: false },
+            message: { conversation: "hello" },
+            pushName: "Alice",
+          },
+        ],
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const conversationId = bus.send.mock.calls[0]?.[0]?.conversationId;
+      expect(conversationId).toBeTruthy();
+
+      // Simulate COO response
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "resp-1",
+        fromAgentId: "coo",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "Hello from COO!",
+        metadata: {},
+        conversationId,
+        timestamp: new Date().toISOString(),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Find the COO reply (skip the pairing code message if any)
+      const cooReply = mockSocket.sentMessages.find(
+        (m) => (m.content as any).text === "Hello from COO!",
+      );
+      expect(cooReply).toBeTruthy();
+      expect(cooReply!.jid).toBe("5551234567@s.whatsapp.net");
+    });
+
+    it("ignores messages not from COO", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "msg-1",
+        fromAgentId: "some-agent",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "Not from COO",
+        metadata: {},
+        conversationId: "conv-1",
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(mockSocket.sentMessages).toHaveLength(0);
+    });
+
+    it("ignores COO messages addressed to another agent", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "msg-1",
+        fromAgentId: "coo",
+        toAgentId: "some-agent",
+        type: MessageType.Chat,
+        content: "For another agent",
+        metadata: {},
+        conversationId: "conv-1",
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(mockSocket.sentMessages).toHaveLength(0);
+    });
+
+    it("splits long messages", async () => {
+      configStore.set(
+        "whatsapp:paired:5551234567@s.whatsapp.net",
+        JSON.stringify({
+          whatsappJid: "5551234567@s.whatsapp.net",
+          whatsappName: "Alice",
+          pairedAt: new Date().toISOString(),
+        }),
+      );
+
+      await bridge.start(join(tmpDir, "auth"));
+
+      // Establish conversation
+      mockSocket.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: false },
+            message: { conversation: "hi" },
+            pushName: "Alice",
+          },
+        ],
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const conversationId = bus.send.mock.calls[0]?.[0]?.conversationId;
+
+      // Send a very long message
+      const longMessage = "x".repeat(10000);
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "resp-1",
+        fromAgentId: "coo",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: longMessage,
+        metadata: {},
+        conversationId,
+        timestamp: new Date().toISOString(),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Should have split the message into multiple parts
+      const replies = mockSocket.sentMessages.filter(
+        (m) => (m.content as any).text !== undefined && !(m.content as any).text.includes("don't recognize"),
+      );
+      expect(replies.length).toBeGreaterThan(1);
+
+      const totalContent = replies.map((m) => (m.content as any).text).join("");
+      expect(totalContent).toBe(longMessage);
+    });
+
+    it("does not send fallback when no paired users exist", async () => {
+      await bridge.start(join(tmpDir, "auth"));
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "resp-1",
+        fromAgentId: "coo",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "Unsolicited message",
+        metadata: {},
+        conversationId: "unknown-conv-id",
+        timestamp: new Date().toISOString(),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockSocket.sentMessages).toHaveLength(0);
+    });
+
+    it("sends to known jid for unsolicited message on existing conversation", async () => {
+      configStore.set(
+        "whatsapp:paired:5551234567@s.whatsapp.net",
+        JSON.stringify({
+          whatsappJid: "5551234567@s.whatsapp.net",
+          whatsappName: "Alice",
+          pairedAt: new Date().toISOString(),
+        }),
+      );
+
+      await bridge.start(join(tmpDir, "auth"));
+
+      // Establish a conversation first
+      mockSocket.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [
+          {
+            key: { remoteJid: "5551234567@s.whatsapp.net", fromMe: false },
+            message: { conversation: "hello" },
+            pushName: "Alice",
+          },
+        ],
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const conversationId = bus.send.mock.calls[0]?.[0]?.conversationId;
+
+      // Consume the pending response first
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "resp-1",
+        fromAgentId: "coo",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "First reply",
+        metadata: {},
+        conversationId,
+        timestamp: new Date().toISOString(),
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Now send an unsolicited message to the same conversation
+      broadcastHandler({
+        id: "resp-2",
+        fromAgentId: "coo",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "Follow-up message",
+        metadata: {},
+        conversationId,
+        timestamp: new Date().toISOString(),
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const followUp = mockSocket.sentMessages.find(
+        (m) => (m.content as any).text === "Follow-up message",
+      );
+      expect(followUp).toBeTruthy();
+      expect(followUp!.jid).toBe("5551234567@s.whatsapp.net");
+    });
+  });
+});

--- a/packages/server/src/whatsapp/pairing.ts
+++ b/packages/server/src/whatsapp/pairing.ts
@@ -1,0 +1,178 @@
+import { randomBytes } from "node:crypto";
+import { like } from "drizzle-orm";
+import { getDb, schema } from "../db/index.js";
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateCode(): string {
+  return randomBytes(3).toString("hex").toUpperCase(); // 6-char hex
+}
+
+const PAIRING_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export interface PendingPairing {
+  code: string;
+  whatsappJid: string;
+  whatsappName: string;
+  createdAt: string;
+}
+
+export interface PairedUser {
+  whatsappJid: string;
+  whatsappName: string;
+  pairedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Config-prefix query helper
+// ---------------------------------------------------------------------------
+
+function getConfigsByPrefix(prefix: string): Array<{ key: string; value: string }> {
+  const db = getDb();
+  return db
+    .select({ key: schema.config.key, value: schema.config.value })
+    .from(schema.config)
+    .where(like(schema.config.key, `${prefix}%`))
+    .all();
+}
+
+// ---------------------------------------------------------------------------
+// Pairing code management
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a pairing code for a WhatsApp user.
+ * Only one active code per user — generating a new one deletes the old.
+ */
+export function generatePairingCode(whatsappJid: string, whatsappName: string): string {
+  // Remove any existing code for this user
+  const existing = getConfigsByPrefix("whatsapp:pairing:");
+  for (const row of existing) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (data.whatsappJid === whatsappJid) {
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+
+  const code = generateCode();
+  const data: PendingPairing = {
+    code,
+    whatsappJid,
+    whatsappName,
+    createdAt: new Date().toISOString(),
+  };
+  setConfig(`whatsapp:pairing:${code}`, JSON.stringify(data));
+  return code;
+}
+
+/**
+ * Check whether a WhatsApp user is paired.
+ */
+export function isPaired(whatsappJid: string): boolean {
+  return !!getConfig(`whatsapp:paired:${whatsappJid}`);
+}
+
+/**
+ * Get paired user info.
+ */
+export function getPairedUser(whatsappJid: string): PairedUser | null {
+  const raw = getConfig(`whatsapp:paired:${whatsappJid}`);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as PairedUser;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Approve a pending pairing by code.
+ * Returns the paired user info, or null if the code is invalid/expired.
+ */
+export function approvePairing(code: string): PairedUser | null {
+  const raw = getConfig(`whatsapp:pairing:${code}`);
+  if (!raw) return null;
+
+  let pending: PendingPairing;
+  try {
+    pending = JSON.parse(raw) as PendingPairing;
+  } catch {
+    return null;
+  }
+
+  // Check expiry
+  if (Date.now() - new Date(pending.createdAt).getTime() > PAIRING_TTL_MS) {
+    deleteConfig(`whatsapp:pairing:${code}`);
+    return null;
+  }
+
+  const paired: PairedUser = {
+    whatsappJid: pending.whatsappJid,
+    whatsappName: pending.whatsappName,
+    pairedAt: new Date().toISOString(),
+  };
+
+  setConfig(`whatsapp:paired:${pending.whatsappJid}`, JSON.stringify(paired));
+  deleteConfig(`whatsapp:pairing:${code}`);
+  return paired;
+}
+
+/**
+ * Reject (delete) a pending pairing code.
+ */
+export function rejectPairing(code: string): boolean {
+  const raw = getConfig(`whatsapp:pairing:${code}`);
+  if (!raw) return false;
+  deleteConfig(`whatsapp:pairing:${code}`);
+  return true;
+}
+
+/**
+ * Revoke a paired user's access.
+ */
+export function revokePairing(whatsappJid: string): boolean {
+  const raw = getConfig(`whatsapp:paired:${whatsappJid}`);
+  if (!raw) return false;
+  deleteConfig(`whatsapp:paired:${whatsappJid}`);
+  return true;
+}
+
+/**
+ * List all paired users.
+ */
+export function listPairedUsers(): PairedUser[] {
+  const rows = getConfigsByPrefix("whatsapp:paired:");
+  const users: PairedUser[] = [];
+  for (const row of rows) {
+    try {
+      users.push(JSON.parse(row.value) as PairedUser);
+    } catch { /* ignore malformed */ }
+  }
+  return users;
+}
+
+/**
+ * List all pending (non-expired) pairing codes.
+ */
+export function listPendingPairings(): PendingPairing[] {
+  const rows = getConfigsByPrefix("whatsapp:pairing:");
+  const now = Date.now();
+  const pending: PendingPairing[] = [];
+  for (const row of rows) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (now - new Date(data.createdAt).getTime() <= PAIRING_TTL_MS) {
+        pending.push(data);
+      } else {
+        // Clean up expired
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+  return pending;
+}

--- a/packages/server/src/whatsapp/whatsapp-bridge.ts
+++ b/packages/server/src/whatsapp/whatsapp-bridge.ts
@@ -1,0 +1,336 @@
+import makeWASocket, {
+  useMultiFileAuthState,
+  DisconnectReason,
+  type WASocket,
+  type BaileysEventMap,
+} from "@whiskeysockets/baileys";
+import { Boom } from "@hapi/boom";
+import { nanoid } from "nanoid";
+import { eq } from "drizzle-orm";
+import { Server } from "socket.io";
+import type { ServerToClientEvents, ClientToServerEvents } from "@otterbot/shared";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage, Conversation } from "@otterbot/shared";
+import { MessageBus } from "../bus/message-bus.js";
+import { COO } from "../agents/coo.js";
+import { getDb, schema } from "../db/index.js";
+import { setConfig } from "../auth/auth.js";
+import { isPaired, generatePairingCode, listPairedUsers } from "./pairing.js";
+
+type TypedServer = Server<ClientToServerEvents, ServerToClientEvents>;
+
+// ---------------------------------------------------------------------------
+// WhatsApp Bridge
+// ---------------------------------------------------------------------------
+
+const WHATSAPP_MAX_LENGTH = 4096;
+
+interface PendingResponse {
+  jid: string;
+  conversationId: string;
+}
+
+export class WhatsAppBridge {
+  private socket: WASocket | null = null;
+  private bus: MessageBus;
+  private coo: COO;
+  private io: TypedServer;
+  private pendingResponses = new Map<string, PendingResponse>();
+  private broadcastHandler: ((message: BusMessage) => void) | null = null;
+  /** Map of `{jid}` → conversationId */
+  private conversationMap = new Map<string, string>();
+  /** Map of conversationId → jid (for sending outbound messages) */
+  private jidMap = new Map<string, string>();
+
+  constructor(deps: { bus: MessageBus; coo: COO; io: TypedServer }) {
+    this.bus = deps.bus;
+    this.coo = deps.coo;
+    this.io = deps.io;
+  }
+
+  async start(authStatePath: string): Promise<void> {
+    if (this.socket) {
+      await this.stop();
+    }
+
+    const { state, saveCreds } = await useMultiFileAuthState(authStatePath);
+
+    this.socket = makeWASocket({
+      auth: state,
+      printQRInTerminal: false,
+    });
+
+    // Save credentials on update
+    this.socket.ev.on("creds.update", saveCreds);
+
+    // Handle connection updates (QR, connected, disconnected)
+    this.socket.ev.on("connection.update", (update) => {
+      this.handleConnectionUpdate(update);
+    });
+
+    // Handle incoming messages
+    this.socket.ev.on("messages.upsert", (upsert) => {
+      this.handleMessagesUpsert(upsert).catch((err) => {
+        console.error("[WhatsApp] Error handling messages:", err);
+      });
+    });
+
+    // Subscribe to bus broadcasts to intercept COO responses
+    this.broadcastHandler = (message: BusMessage) => {
+      this.handleBusMessage(message);
+    };
+    this.bus.onBroadcast(this.broadcastHandler);
+  }
+
+  async stop(): Promise<void> {
+    // Clean up pending responses
+    this.pendingResponses.clear();
+
+    // Unsubscribe from bus
+    if (this.broadcastHandler) {
+      this.bus.offBroadcast(this.broadcastHandler);
+      this.broadcastHandler = null;
+    }
+
+    // Close socket
+    if (this.socket) {
+      this.socket.end(undefined);
+      this.socket = null;
+      this.io.emit("whatsapp:status", { status: "disconnected" });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Connection lifecycle
+  // -------------------------------------------------------------------------
+
+  private handleConnectionUpdate(update: Partial<BaileysEventMap["connection.update"]>): void {
+    const { connection, lastDisconnect, qr } = update;
+
+    if (qr) {
+      console.log("[WhatsApp] QR code received, emitting to clients");
+      this.io.emit("whatsapp:qr", { qr });
+    }
+
+    if (connection === "close") {
+      const statusCode = (lastDisconnect?.error as Boom)?.output?.statusCode;
+      const loggedOut = statusCode === DisconnectReason.loggedOut;
+
+      if (loggedOut) {
+        console.log("[WhatsApp] Logged out — not reconnecting");
+        this.io.emit("whatsapp:status", { status: "disconnected" });
+      } else {
+        console.log("[WhatsApp] Connection closed, status:", statusCode);
+        this.io.emit("whatsapp:status", { status: "error" });
+      }
+    } else if (connection === "open") {
+      const phoneNumber = this.socket?.user?.id?.split(":")[0] ?? undefined;
+      if (phoneNumber) {
+        setConfig("whatsapp:phone_number", phoneNumber);
+      }
+      console.log(`[WhatsApp] Connected as ${phoneNumber ?? "unknown"}`);
+      this.io.emit("whatsapp:status", {
+        status: "connected",
+        phoneNumber,
+      });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Inbound: WhatsApp → COO
+  // -------------------------------------------------------------------------
+
+  private async handleMessagesUpsert(
+    upsert: BaileysEventMap["messages.upsert"],
+  ): Promise<void> {
+    if (upsert.type !== "notify") return;
+
+    for (const msg of upsert.messages) {
+      // Ignore messages from self
+      if (msg.key.fromMe) continue;
+
+      // Only handle text messages
+      const text =
+        msg.message?.conversation ??
+        msg.message?.extendedTextMessage?.text;
+      if (!text) continue;
+
+      const jid = msg.key.remoteJid;
+      if (!jid) continue;
+
+      // Get sender name
+      const pushName = msg.pushName ?? jid.split("@")[0] ?? "Unknown";
+
+      // Check pairing
+      if (!isPaired(jid)) {
+        const code = generatePairingCode(jid, pushName);
+        await this.socket?.sendMessage(jid, {
+          text: `I don't recognize you yet. To pair with me, ask my owner to approve this code in the Otterbot dashboard:\n\n*${code}*\n\nThis code expires in 1 hour.`,
+        });
+        this.io.emit("whatsapp:pairing-request", {
+          code,
+          whatsappJid: jid,
+          whatsappName: pushName,
+        });
+        return;
+      }
+
+      // Route to COO
+      await this.routeToCOO(jid, pushName, text);
+    }
+  }
+
+  private async routeToCOO(
+    jid: string,
+    pushName: string,
+    content: string,
+  ): Promise<void> {
+    const db = getDb();
+    let conversationId = this.conversationMap.get(jid);
+
+    if (!conversationId) {
+      // Create a new conversation
+      conversationId = nanoid();
+      const now = new Date().toISOString();
+      const title = `WhatsApp: ${pushName} — ${content.slice(0, 60)}`;
+      const conversation: Conversation = {
+        id: conversationId,
+        title,
+        projectId: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      db.insert(schema.conversations).values(conversation).run();
+      this.coo.startNewConversation(conversationId, null, null);
+      this.io.emit("conversation:created", conversation);
+      this.conversationMap.set(jid, conversationId);
+      this.jidMap.set(conversationId, jid);
+    } else {
+      // Update timestamp
+      db.update(schema.conversations)
+        .set({ updatedAt: new Date().toISOString() })
+        .where(eq(schema.conversations.id, conversationId))
+        .run();
+    }
+
+    // Track pending response
+    this.pendingResponses.set(conversationId, {
+      jid,
+      conversationId,
+    });
+
+    // Send to COO via bus
+    this.bus.send({
+      fromAgentId: null,
+      toAgentId: "coo",
+      type: MessageType.Chat,
+      content,
+      conversationId,
+      metadata: {
+        source: "whatsapp",
+        whatsappJid: jid,
+        whatsappPushName: pushName,
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound: COO → WhatsApp
+  // -------------------------------------------------------------------------
+
+  private handleBusMessage(message: BusMessage): void {
+    // Only care about COO → CEO (null) responses
+    if (message.fromAgentId !== "coo" || message.toAgentId !== null) return;
+
+    const conversationId = message.conversationId;
+
+    if (conversationId) {
+      const pending = this.pendingResponses.get(conversationId);
+      if (pending) {
+        this.pendingResponses.delete(conversationId);
+        this.sendWhatsAppMessage(pending.jid, message.content).catch((err) => {
+          console.error("[WhatsApp] Error sending reply:", err);
+        });
+        return;
+      }
+
+      // Unsolicited message to a known conversation
+      const jid = this.jidMap.get(conversationId);
+      if (jid) {
+        this.sendWhatsAppMessage(jid, message.content).catch((err) => {
+          console.error("[WhatsApp] Error sending unsolicited message:", err);
+        });
+        return;
+      }
+    }
+
+    // Fallback: send to first paired user
+    const paired = listPairedUsers();
+    if (paired.length > 0) {
+      this.sendWhatsAppMessage(paired[0]!.whatsappJid, message.content).catch(
+        (err) => {
+          console.error("[WhatsApp] Error sending DM fallback:", err);
+        },
+      );
+    }
+  }
+
+  private async sendWhatsAppMessage(jid: string, content: string): Promise<void> {
+    if (!this.socket) return;
+    const chunks = splitMessage(content, WHATSAPP_MAX_LENGTH);
+    for (const chunk of chunks) {
+      await this.socket.sendMessage(jid, { text: chunk });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message splitting
+// ---------------------------------------------------------------------------
+
+function splitMessage(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLength) {
+    let splitIdx = -1;
+
+    // Try to split at paragraph boundary
+    const paragraphIdx = remaining.lastIndexOf("\n\n", maxLength);
+    if (paragraphIdx > maxLength * 0.3) {
+      splitIdx = paragraphIdx;
+    }
+
+    // Try sentence boundary
+    if (splitIdx === -1) {
+      const sentenceMatch = remaining.slice(0, maxLength).match(/.*[.!?]\s/s);
+      if (sentenceMatch) {
+        splitIdx = sentenceMatch[0].length;
+      }
+    }
+
+    // Hard cut at newline
+    if (splitIdx === -1) {
+      const newlineIdx = remaining.lastIndexOf("\n", maxLength);
+      if (newlineIdx > maxLength * 0.3) {
+        splitIdx = newlineIdx;
+      }
+    }
+
+    // Final fallback: hard cut
+    if (splitIdx === -1) {
+      splitIdx = maxLength;
+    }
+
+    chunks.push(remaining.slice(0, splitIdx).trimEnd());
+    remaining = remaining.slice(splitIdx).trimStart();
+  }
+
+  if (remaining) {
+    chunks.push(remaining);
+  }
+
+  return chunks;
+}

--- a/packages/server/src/whatsapp/whatsapp-settings.ts
+++ b/packages/server/src/whatsapp/whatsapp-settings.ts
@@ -1,0 +1,43 @@
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+import { listPairedUsers, listPendingPairings } from "./pairing.js";
+import type { PairedUser, PendingPairing } from "./pairing.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WhatsAppSettingsResponse {
+  enabled: boolean;
+  phoneNumber: string | null;
+  pairedUsers: PairedUser[];
+  pendingPairings: PendingPairing[];
+}
+
+// ---------------------------------------------------------------------------
+// Settings CRUD
+// ---------------------------------------------------------------------------
+
+export function getWhatsAppSettings(): WhatsAppSettingsResponse {
+  return {
+    enabled: getConfig("whatsapp:enabled") === "true",
+    phoneNumber: getConfig("whatsapp:phone_number") ?? null,
+    pairedUsers: listPairedUsers(),
+    pendingPairings: listPendingPairings(),
+  };
+}
+
+export function updateWhatsAppSettings(data: {
+  enabled?: boolean;
+}): void {
+  if (data.enabled !== undefined) {
+    setConfig("whatsapp:enabled", data.enabled ? "true" : "false");
+  }
+}
+
+/**
+ * Return the path where Baileys auth state should be stored.
+ * Defaults to a `whatsapp-auth` subdirectory under the configured data dir.
+ */
+export function getAuthStatePath(): string {
+  return getConfig("whatsapp:auth_state_path") ?? "whatsapp-auth";
+}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -63,6 +63,9 @@ export interface ServerToClientEvents {
   "mattermost:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
   "telegram:pairing-request": (data: { code: string; telegramUserId: string; telegramUsername: string }) => void;
   "telegram:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
+  "whatsapp:qr": (data: { qr: string }) => void;
+  "whatsapp:pairing-request": (data: { code: string; whatsappJid: string; whatsappName: string }) => void;
+  "whatsapp:status": (data: { status: "connected" | "disconnected" | "error"; phoneNumber?: string }) => void;
 }
 
 /** Events emitted from client to server */

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -39,7 +39,7 @@ export interface AgentModelOverride {
 }
 
 /** Supported messaging-platform chat provider types. */
-export type ChatProviderType = "discord" | "matrix" | "irc" | "teams" | "telegram" | "tlon";
+export type ChatProviderType = "discord" | "matrix" | "irc" | "teams" | "telegram" | "tlon" | "whatsapp";
 
 /** Settings common to all chat provider bridges. */
 export interface ChatProviderSettings {

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -25,6 +25,7 @@ import { TelegramSection } from "./TelegramSection";
 import { GoogleSection } from "./GoogleSection";
 import { SecuritySection } from "./SecuritySection";
 import { ModulesSection } from "./ModulesSection";
+import { WhatsAppSection } from "./WhatsAppSection";
 import type { SettingsSection } from "./settings-nav";
 
 interface SettingsPageProps {
@@ -60,6 +61,7 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
     if (activeSection === "telegram") return <TelegramSection />;
     if (activeSection === "slack") return <SlackSection />;
     if (activeSection === "mattermost") return <MattermostSection />;
+    if (activeSection === "whatsapp") return <WhatsAppSection />;
     if (activeSection === "security") return <SecuritySection />;
     if (activeSection === "soul") return <SoulTab />;
     if (activeSection === "memory") return <MemoryTab />;

--- a/packages/web/src/components/settings/WhatsAppSection.tsx
+++ b/packages/web/src/components/settings/WhatsAppSection.tsx
@@ -1,0 +1,230 @@
+import { useState, useEffect } from "react";
+import { cn } from "../../lib/utils";
+import { useSettingsStore } from "../../stores/settings-store";
+import { getSocket } from "../../lib/socket";
+
+export function WhatsAppSection() {
+  const enabled = useSettingsStore((s) => s.whatsappEnabled);
+  const phoneNumber = useSettingsStore((s) => s.whatsappPhoneNumber);
+  const pairedUsers = useSettingsStore((s) => s.whatsappPairedUsers);
+  const pendingPairings = useSettingsStore((s) => s.whatsappPendingPairings);
+  const loadWhatsAppSettings = useSettingsStore((s) => s.loadWhatsAppSettings);
+  const updateWhatsAppSettings = useSettingsStore((s) => s.updateWhatsAppSettings);
+  const approveWhatsAppPairing = useSettingsStore((s) => s.approveWhatsAppPairing);
+  const rejectWhatsAppPairing = useSettingsStore((s) => s.rejectWhatsAppPairing);
+  const revokeWhatsAppUser = useSettingsStore((s) => s.revokeWhatsAppUser);
+
+  const [qrCode, setQrCode] = useState<string | null>(null);
+  const [botStatus, setBotStatus] = useState<"connected" | "disconnected" | "error">("disconnected");
+
+  useEffect(() => {
+    loadWhatsAppSettings();
+  }, []);
+
+  // Listen for real-time WhatsApp events
+  useEffect(() => {
+    const socket = getSocket();
+
+    const handleStatus = (data: { status: "connected" | "disconnected" | "error"; phoneNumber?: string }) => {
+      setBotStatus(data.status);
+      if (data.status === "connected") {
+        setQrCode(null);
+        loadWhatsAppSettings();
+      }
+    };
+
+    const handleQr = (data: { qr: string }) => {
+      setQrCode(data.qr);
+    };
+
+    const handlePairingRequest = () => {
+      loadWhatsAppSettings();
+    };
+
+    socket.on("whatsapp:status", handleStatus);
+    socket.on("whatsapp:qr", handleQr);
+    socket.on("whatsapp:pairing-request", handlePairingRequest);
+
+    return () => {
+      socket.off("whatsapp:status", handleStatus);
+      socket.off("whatsapp:qr", handleQr);
+      socket.off("whatsapp:pairing-request", handlePairingRequest);
+    };
+  }, []);
+
+  const handleToggleEnabled = async () => {
+    await updateWhatsAppSettings({ enabled: !enabled });
+  };
+
+  return (
+    <div className="p-5 space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Connect Otterbot to WhatsApp via QR code pairing. Users must pair with
+        the bot before it responds to their messages.
+      </p>
+
+      {/* Enable toggle */}
+      <label className="flex items-center gap-3 cursor-pointer">
+        <button
+          onClick={handleToggleEnabled}
+          className={cn(
+            "relative w-9 h-5 rounded-full transition-colors",
+            enabled ? "bg-primary" : "bg-secondary",
+          )}
+        >
+          <span
+            className={cn(
+              "absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform",
+              enabled && "translate-x-4",
+            )}
+          />
+        </button>
+        <span className="text-sm">Enable WhatsApp integration</span>
+      </label>
+
+      {/* Connection status */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Connection
+        </label>
+
+        {phoneNumber && (
+          <div className="text-xs text-muted-foreground">
+            Phone: <span className="text-foreground font-medium">+{phoneNumber}</span>
+            {enabled && (
+              <span className={cn(
+                "ml-2 text-[10px] px-1.5 py-0.5 rounded",
+                botStatus === "connected"
+                  ? "text-green-500 bg-green-500/10"
+                  : botStatus === "error"
+                    ? "text-red-500 bg-red-500/10"
+                    : "text-muted-foreground bg-muted",
+              )}>
+                {botStatus === "connected" ? "Online" : botStatus === "error" ? "Error" : "Offline"}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* QR Code display */}
+        {enabled && qrCode && botStatus !== "connected" && (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground">
+              Scan this QR code with WhatsApp on your phone to connect:
+            </p>
+            <div className="bg-white p-4 rounded-lg inline-block">
+              <img
+                src={`https://api.qrserver.com/v1/create-qr-code/?size=256x256&data=${encodeURIComponent(qrCode)}`}
+                alt="WhatsApp QR Code"
+                className="w-64 h-64"
+              />
+            </div>
+          </div>
+        )}
+
+        {enabled && !qrCode && botStatus === "disconnected" && !phoneNumber && (
+          <p className="text-xs text-muted-foreground italic">
+            Waiting for QR code... Make sure the integration is enabled.
+          </p>
+        )}
+      </div>
+
+      {/* Paired Users section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Paired Users
+          <span className="ml-2 normal-case tracking-normal text-foreground">
+            {pairedUsers.length}
+          </span>
+        </label>
+
+        {pairedUsers.length === 0 ? (
+          <p className="text-[10px] text-muted-foreground">
+            No users have been paired yet. When someone messages the bot, they'll receive a pairing code to approve here.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {pairedUsers.map((user) => (
+              <div
+                key={user.whatsappJid}
+                className="flex items-center justify-between bg-secondary rounded-md px-3 py-2"
+              >
+                <div>
+                  <span className="text-xs font-medium">{user.whatsappName}</span>
+                  <span className="text-[10px] text-muted-foreground ml-2">
+                    Paired {new Date(user.pairedAt).toLocaleDateString()}
+                  </span>
+                </div>
+                <button
+                  onClick={() => revokeWhatsAppUser(user.whatsappJid)}
+                  className="text-[10px] text-red-500 hover:text-red-400 px-2 py-1"
+                >
+                  Revoke
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Pending Pairings section */}
+      {pendingPairings.length > 0 && (
+        <div className="border border-border rounded-lg p-4 space-y-3">
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Pending Pairings
+            <span className="ml-2 normal-case tracking-normal text-yellow-500">
+              {pendingPairings.length}
+            </span>
+          </label>
+
+          <div className="space-y-2">
+            {pendingPairings.map((pairing) => (
+              <div
+                key={pairing.code}
+                className="flex items-center justify-between bg-secondary rounded-md px-3 py-2"
+              >
+                <div>
+                  <span className="text-xs font-medium">{pairing.whatsappName}</span>
+                  <code className="text-[10px] bg-muted px-1.5 py-0.5 rounded ml-2 font-mono">
+                    {pairing.code}
+                  </code>
+                  <span className="text-[10px] text-muted-foreground ml-2">
+                    {new Date(pairing.createdAt).toLocaleTimeString()}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => approveWhatsAppPairing(pairing.code)}
+                    className="text-[10px] text-green-500 hover:text-green-400 bg-green-500/10 px-2 py-1 rounded"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => rejectWhatsAppPairing(pairing.code)}
+                    className="text-[10px] text-red-500 hover:text-red-400 px-2 py-1"
+                  >
+                    Reject
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Setup instructions */}
+      <div className="text-[10px] text-muted-foreground space-y-1">
+        <p>
+          <strong>How to set up WhatsApp:</strong>
+        </p>
+        <ol className="list-decimal list-inside space-y-0.5">
+          <li>Enable the WhatsApp integration above</li>
+          <li>A QR code will appear — scan it with WhatsApp on your phone</li>
+          <li>Go to WhatsApp &gt; Linked Devices &gt; Link a Device</li>
+          <li>Once connected, message the bot from any WhatsApp account</li>
+          <li>Approve the pairing code shown here to start chatting</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/settings-nav.ts
+++ b/packages/web/src/components/settings/settings-nav.ts
@@ -22,6 +22,7 @@ export type SettingsSection =
   | "telegram"
   | "slack"
   | "mattermost"
+  | "whatsapp"
   | "security";
 
 export interface NavItem {
@@ -81,6 +82,7 @@ export const SETTINGS_NAV: NavGroup[] = [
       { id: "telegram", label: "Telegram" },
       { id: "slack", label: "Slack" },
       { id: "mattermost", label: "Mattermost" },
+      { id: "whatsapp", label: "WhatsApp" },
     ],
   },
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@whiskeysockets/baileys':
+        specifier: 7.0.0-rc.9
+        version: 7.0.0-rc.9(sharp@0.34.5)
     devDependencies:
       '@playwright/test':
         specifier: ^1.58.2
@@ -78,6 +82,9 @@ importers:
       '@slack/bolt':
         specifier: ^4.6.0
         version: 4.6.0(@types/express@5.0.6)
+      '@whiskeysockets/baileys':
+        specifier: 7.0.0-rc.9
+        version: 7.0.0-rc.9(sharp@0.34.5)
       ai:
         specifier: ^4.1.61
         version: 4.3.19(react@19.2.4)(zod@3.25.76)
@@ -568,8 +575,21 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@borewit/text-codec@0.2.1':
+    resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
+
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@cacheable/memory@2.0.7':
+    resolution: {integrity: sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==}
+
+  '@cacheable/node-cache@1.7.6':
+    resolution: {integrity: sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A==}
+    engines: {node: '>=18'}
+
+  '@cacheable/utils@2.3.4':
+    resolution: {integrity: sha512-knwKUJEYgIfwShABS1BX6JyJJTglAFcEU7EXqzTdiGCXur4voqkiJkdgZIQtWNFhynzDWERcTYv/sETMu3uJWA==}
 
   '@chevrotain/cst-dts-gen@11.0.3':
     resolution: {integrity: sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==}
@@ -1287,6 +1307,12 @@ packages:
   '@fastify/static@8.3.0':
     resolution: {integrity: sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==}
 
+  '@hapi/boom@9.1.4':
+    resolution: {integrity: sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==}
+
+  '@hapi/hoek@9.3.0':
+    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
+
   '@huggingface/jinja@0.5.5':
     resolution: {integrity: sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ==}
     engines: {node: '>=18'}
@@ -1488,6 +1514,15 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
@@ -1856,6 +1891,13 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -2024,6 +2066,9 @@ packages:
   '@types/jsonwebtoken@9.0.6':
     resolution: {integrity: sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==}
 
+  '@types/long@4.0.2':
+    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -2032,6 +2077,9 @@ packages:
 
   '@types/node-telegram-bot-api@0.64.13':
     resolution: {integrity: sha512-/d3sYpZq4sDwKWAm9XsIsb8MclclJ1yPXZC7uAzZRrJIFY8yg/63oNrLf9CBTlaS/XGR1N66BwibfJQGiWVsqg==}
+
+  '@types/node@10.17.60':
+    resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
@@ -2210,6 +2258,26 @@ packages:
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
+  '@whiskeysockets/baileys@7.0.0-rc.9':
+    resolution: {integrity: sha512-YFm5gKXfDP9byCXCW3OPHKXLzrAKzolzgVUlRosHHgwbnf2YOO3XknkMm6J7+F0ns8OA0uuSBhgkRHTDtqkacw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      audio-decode: ^2.1.3
+      jimp: ^1.6.0
+      link-preview-js: ^3.0.0
+      sharp: '*'
+    peerDependenciesMeta:
+      audio-decode:
+        optional: true
+      jimp:
+        optional: true
+      link-preview-js:
+        optional: true
+
+  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
+    version: 2.0.1
+
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
@@ -2340,6 +2408,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -2554,6 +2625,9 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  cacheable@2.3.2:
+    resolution: {integrity: sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2759,6 +2833,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  curve25519-js@0.0.4:
+    resolution: {integrity: sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==}
 
   cytoscape-cose-bilkent@4.1.0:
     resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
@@ -3442,6 +3519,10 @@ packages:
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
+  file-type@21.3.0:
+    resolution: {integrity: sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==}
+    engines: {node: '>=20'}
+
   file-type@3.9.0:
     resolution: {integrity: sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==}
     engines: {node: '>=0.10.0'}
@@ -3705,6 +3786,10 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  hashery@1.5.0:
+    resolution: {integrity: sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==}
+    engines: {node: '>=20'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -3727,6 +3812,9 @@ packages:
 
   hls.js@1.6.15:
     resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
+
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -4117,6 +4205,9 @@ packages:
     resolution: {integrity: sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==}
     hasBin: true
 
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
@@ -4186,6 +4277,9 @@ packages:
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
+
+  long@4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -4478,6 +4572,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  music-metadata@11.12.1:
+    resolution: {integrity: sha512-j++ltLxHDb5VCXET9FzQ8bnueiLHwQKgCO7vcbkRH/3F7fRjPkv6qncGEJ47yFhmemcYtgvsOAlcQ1dRBTkDjg==}
+    engines: {node: '>=18'}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -4627,6 +4725,10 @@ packages:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
 
+  p-queue@9.1.0:
+    resolution: {integrity: sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==}
+    engines: {node: '>=20'}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
@@ -4634,6 +4736,10 @@ packages:
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
 
   pac-proxy-agent@7.2.0:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
@@ -4719,6 +4825,9 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
@@ -4727,6 +4836,10 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   pirates@4.0.7:
@@ -4837,6 +4950,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  protobufjs@6.8.8:
+    resolution: {integrity: sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==}
+    hasBin: true
+
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
@@ -4873,6 +4990,10 @@ packages:
     resolution: {integrity: sha512-AUGGWq0BhPM+IOS2U9A+ZREH3HDFkV1Y5HERYGDg5cbGXjoGsTCT7/A6VZRfNU0UJJdCclyEimZICkZW6pqJyw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  qified@0.6.0:
+    resolution: {integrity: sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==}
+    engines: {node: '>=20'}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -5376,6 +5497,10 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  strtok3@10.3.4:
+    resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
+    engines: {node: '>=18'}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -5442,6 +5567,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -5515,6 +5643,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
 
   tough-cookie@2.5.0:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
@@ -5615,6 +5747,10 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -5907,6 +6043,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  win-guid@0.2.1:
+    resolution: {integrity: sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -6379,7 +6518,27 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@borewit/text-codec@0.2.1': {}
+
   '@braintree/sanitize-url@7.1.2': {}
+
+  '@cacheable/memory@2.0.7':
+    dependencies:
+      '@cacheable/utils': 2.3.4
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/node-cache@1.7.6':
+    dependencies:
+      cacheable: 2.3.2
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.3.4':
+    dependencies:
+      hashery: 1.5.0
+      keyv: 5.6.0
 
   '@chevrotain/cst-dts-gen@11.0.3':
     dependencies:
@@ -6877,6 +7036,12 @@ snapshots:
       fastq: 1.20.1
       glob: 11.1.0
 
+  '@hapi/boom@9.1.4':
+    dependencies:
+      '@hapi/hoek': 9.3.0
+
+  '@hapi/hoek@9.3.0': {}
+
   '@huggingface/jinja@0.5.5': {}
 
   '@huggingface/transformers@3.8.1':
@@ -7029,6 +7194,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
 
   '@lukeed/ms@2.0.2': {}
 
@@ -7382,6 +7555,15 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.19(tsx@4.21.0)
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@tweenjs/tween.js@23.1.3': {}
@@ -7591,6 +7773,8 @@ snapshots:
     dependencies:
       '@types/node': 22.19.11
 
+  '@types/long@4.0.2': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -7601,6 +7785,8 @@ snapshots:
     dependencies:
       '@types/node': 22.19.11
       '@types/request': 2.48.13
+
+  '@types/node@10.17.60': {}
 
   '@types/node@22.19.11':
     dependencies:
@@ -7817,6 +8003,29 @@ snapshots:
 
   '@webgpu/types@0.1.69': {}
 
+  '@whiskeysockets/baileys@7.0.0-rc.9(sharp@0.34.5)':
+    dependencies:
+      '@cacheable/node-cache': 1.7.6
+      '@hapi/boom': 9.1.4
+      async-mutex: 0.5.0
+      libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
+      lru-cache: 11.2.6
+      music-metadata: 11.12.1
+      p-queue: 9.1.0
+      pino: 9.14.0
+      protobufjs: 7.5.4
+      sharp: 0.34.5
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+    dependencies:
+      curve25519-js: 0.0.4
+      protobufjs: 6.8.8
+
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/xterm@6.0.0': {}
@@ -7962,6 +8171,10 @@ snapshots:
       js-tokens: 10.0.0
 
   async-function@1.0.0: {}
+
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
 
   asynckit@0.4.0: {}
 
@@ -8245,6 +8458,14 @@ snapshots:
 
   cac@6.7.14: {}
 
+  cacheable@2.3.2:
+    dependencies:
+      '@cacheable/memory': 2.0.7
+      '@cacheable/utils': 2.3.4
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.6.0
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -8429,6 +8650,8 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  curve25519-js@0.0.4: {}
 
   cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.1):
     dependencies:
@@ -9238,6 +9461,15 @@ snapshots:
 
   fflate@0.8.2: {}
 
+  file-type@21.3.0:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.4
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   file-type@3.9.0: {}
 
   file-uri-to-path@1.0.0: {}
@@ -9548,6 +9780,10 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  hashery@1.5.0:
+    dependencies:
+      hookified: 1.15.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -9590,6 +9826,8 @@ snapshots:
   highlight.js@11.11.1: {}
 
   hls.js@1.6.15: {}
+
+  hookified@1.15.1: {}
 
   html-escaper@2.0.2: {}
 
@@ -9995,6 +10233,10 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
   khroma@2.1.0: {}
 
   kind-of@6.0.3: {}
@@ -10053,6 +10295,8 @@ snapshots:
   lodash@4.17.23: {}
 
   loglevel@1.9.2: {}
+
+  long@4.0.0: {}
 
   long@5.3.2: {}
 
@@ -10565,6 +10809,21 @@ snapshots:
 
   ms@2.1.3: {}
 
+  music-metadata@11.12.1:
+    dependencies:
+      '@borewit/text-codec': 0.2.1
+      '@tokenizer/token': 0.3.0
+      content-type: 1.0.5
+      debug: 4.4.3
+      file-type: 21.3.0
+      media-typer: 1.1.0
+      strtok3: 10.3.4
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+      win-guid: 0.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -10708,6 +10967,11 @@ snapshots:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
 
+  p-queue@9.1.0:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
@@ -10716,6 +10980,8 @@ snapshots:
   p-timeout@3.2.0:
     dependencies:
       p-finally: 1.0.0
+
+  p-timeout@7.0.1: {}
 
   pac-proxy-agent@7.2.0:
     dependencies:
@@ -10800,6 +11066,10 @@ snapshots:
 
   pify@2.3.0: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
@@ -10819,6 +11089,20 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
 
   pirates@4.0.7: {}
 
@@ -10922,6 +11206,22 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  protobufjs@6.8.8:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/long': 4.0.2
+      '@types/node': 10.17.60
+      long: 4.0.0
+
   protobufjs@7.5.4:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -11006,6 +11306,10 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
+
+  qified@0.6.0:
+    dependencies:
+      hookified: 1.15.1
 
   qs@6.14.2:
     dependencies:
@@ -11702,6 +12006,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strtok3@10.3.4:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -11826,6 +12134,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
+
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
@@ -11882,6 +12194,12 @@ snapshots:
   toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.1
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   tough-cookie@2.5.0:
     dependencies:
@@ -11996,6 +12314,8 @@ snapshots:
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
+
+  uint8array-extras@1.5.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -12332,6 +12652,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  win-guid@0.2.1: {}
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds WhatsApp as a fully integrated chat provider using the `@whiskeysockets/baileys` library for WhatsApp Web multi-device support
- Implements QR code pairing flow — the web UI displays a QR code for linking WhatsApp, and users are authorized via a 6-char hex pairing code system
- Follows the existing channel adapter pattern used by Discord, Slack, IRC, Mattermost, and Telegram

## Changes

### Shared (`packages/shared`)
- Add `"whatsapp"` to `ChatProviderType` union
- Add `whatsapp:qr`, `whatsapp:status`, and `whatsapp:pairing-request` socket events

### Server (`packages/server`)
- **`src/whatsapp/whatsapp-bridge.ts`** — Main bridge class: Baileys socket management, connection lifecycle (QR code emission, connect/disconnect/reconnect), inbound message routing to COO, outbound COO response delivery, message splitting (4096 char limit)
- **`src/whatsapp/pairing.ts`** — Pairing system: 6-char hex code generation, approval/rejection, TTL expiry (1 hour), paired user management
- **`src/whatsapp/whatsapp-settings.ts`** — Settings CRUD: enable/disable, phone number tracking, auth state path
- **`src/chat/whatsapp/WhatsAppProvider.ts`** — Registry provider stub
- **`src/index.ts`** — REST routes (GET/PUT settings, POST pair/approve, POST pair/reject, DELETE pair/:jid), bridge start/stop lifecycle, auto-start on server boot

### Web (`packages/web`)
- **`WhatsAppSection.tsx`** — Settings UI: enable toggle, real-time QR code display (rendered via QR API), connection status indicator, paired users list with revoke, pending pairing approvals with approve/reject, setup instructions
- **`settings-store.ts`** — Zustand state and actions for WhatsApp settings
- **`settings-nav.ts`** / **`SettingsPage.tsx`** — Navigation entry under Integrations

### Tests
- 22 unit tests covering connection lifecycle, QR code pairing, message handling (paired/unpaired users, self-messages, non-text messages), outbound COO responses, message splitting, and conversation reuse

## Test plan

- [x] All 707 tests pass (2 pre-existing web package failures unrelated to this PR)
- [ ] Manual: Enable WhatsApp in settings, scan QR code, verify connection
- [ ] Manual: Send message from unpaired user, verify pairing code flow
- [ ] Manual: Approve pairing, send message, verify COO response

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)