### PR TITLE
fix: git init branch naming for CI

### DIFF
--- a/packages/server/src/utils/git.ts
+++ b/packages/server/src/utils/git.ts
@@ -24,7 +24,7 @@ export function initGitRepo(cwd: string): void {
   }
 
   if (!isGitRepo(cwd)) {
-    execSync("git init", { cwd, stdio: "ignore" });
+    execSync("git init -b main", { cwd, stdio: "ignore" });
     // Set local config to ensure commits work even if global config is missing
     execSync("git config user.email 'otterbot@example.com'", { cwd, stdio: "ignore" });
     execSync("git config user.name 'OtterBot'", { cwd, stdio: "ignore" });


### PR DESCRIPTION
## Summary
- Fix git init to use `-b main` for consistent branch naming in CI environments
- Previous promotion failed because `git rev-parse main` didn't work in CI's shallow checkout

## Test plan
- CI runs tests + build automatically on merge