### PR TITLE
fix: capture worktree branch before cleanup to fix pipeline stage handoff

### DIFF
--- a/packages/server/src/utils/git.ts
+++ b/packages/server/src/utils/git.ts
@@ -83,7 +83,7 @@ export function createWorktree(repoPath: string, worktreePath: string, branchNam
   if (existsSync(worktreePath)) {
     try {
         // Try git removal first
-        execSync(`git worktree remove --force ${worktreePath}`, { cwd: repoPath, stdio: "ignore" });
+        execSync(`git worktree remove --force "${worktreePath}"`, { cwd: repoPath, stdio: "ignore" });
     } catch {
         // Fallback to manual removal
         rmSync(worktreePath, { recursive: true, force: true });
@@ -94,7 +94,7 @@ export function createWorktree(repoPath: string, worktreePath: string, branchNam
   // If a source branch is specified, fetch it first so the ref exists locally
   if (sourceBranch) {
     try {
-      execSync(`git fetch origin ${sourceBranch}`, { cwd: repoPath, stdio: "ignore" });
+      execSync(`git fetch origin "${sourceBranch}"`, { cwd: repoPath, stdio: "ignore" });
     } catch { /* best effort — branch may be local-only */ }
   }
 
@@ -107,11 +107,11 @@ export function createWorktree(repoPath: string, worktreePath: string, branchNam
   // -f: force creation
   // -B: create/reset branch
   try {
-    execSync(`git worktree add -f -B ${branchName} ${worktreePath} ${startPoint}`, { cwd: repoPath, stdio: "ignore" });
+    execSync(`git worktree add -f -B "${branchName}" "${worktreePath}" "${startPoint}"`, { cwd: repoPath, stdio: "ignore" });
   } catch (error) {
     // Prune and retry — also fall back to local ref if remote ref failed
     execSync("git worktree prune", { cwd: repoPath, stdio: "ignore" });
-    execSync(`git worktree add -f -B ${branchName} ${worktreePath} ${startPointFallback}`, { cwd: repoPath, stdio: "ignore" });
+    execSync(`git worktree add -f -B "${branchName}" "${worktreePath}" "${startPointFallback}"`, { cwd: repoPath, stdio: "ignore" });
   }
 }
 
@@ -124,7 +124,7 @@ export function removeWorktree(repoPath: string, worktreePath: string): void {
   try {
     if (existsSync(worktreePath)) {
         // Force remove even if there are uncommitted changes (agent is done/destroyed)
-        execSync(`git worktree remove --force ${worktreePath}`, { cwd: repoPath, stdio: "ignore" });
+        execSync(`git worktree remove --force "${worktreePath}"`, { cwd: repoPath, stdio: "ignore" });
     }
   } catch (error) {
     // If it fails, maybe it's already gone or not a worktree.

--- a/packages/server/src/workspace/workspace.ts
+++ b/packages/server/src/workspace/workspace.ts
@@ -155,6 +155,11 @@ export class WorkspaceManager {
     return resolve(this.root, "projects", projectId, "worktrees");
   }
 
+  /** Get the worktree path for an agent (without creating it) */
+  agentWorktreePath(projectId: string, agentId: string): string {
+    return resolve(this.worktreesPath(projectId), agentId);
+  }
+
   private isUnder(child: string, parent: string): boolean {
     const normalizedChild = resolve(child);
     const normalizedParent = resolve(parent);


### PR DESCRIPTION
## Summary

- **Capture worktree branch before cleanup**: In `TeamLead.handleWorkerReport()`, detect the feature branch the coder pushed by inspecting the worktree's remote branches before the worktree is destroyed
- **Pass detected branch as fallback**: `PipelineManager.advancePipeline()` now accepts an optional `detectedBranch` param, used when regex extraction from the text report fails
- **Fix `#` handling**: Updated `extractBranchName` regex to include `#` in the character class, and quoted all branch/path params in `git.ts` shell commands to prevent `#` from being interpreted as a shell comment

## Context

Pipeline workers (coder → security → tester → reviewer) all reported "Files changed: 0" because `state.prBranch` stayed null when the coder's text report didn't mention the branch in a recognizable pattern. Subsequent workers got fresh worktrees from HEAD with no changes.

## Files Changed

- `packages/server/src/agents/team-lead.ts` — capture worktree branch before cleanup, pass to PipelineManager
- `packages/server/src/workspace/workspace.ts` — add `agentWorktreePath()` helper
- `packages/server/src/pipeline/pipeline-manager.ts` — accept `detectedBranch` param, fix regex `#` support
- `packages/server/src/utils/git.ts` — quote all branch/path params in shell commands

## Test plan

- [x] `npx pnpm build` passes
- [x] `npx pnpm test` — all 805 tests pass
- [ ] Deploy and verify pipeline workers pick up the coder's branch correctly