### PR TITLE
feat: add DeepSeek LLM provider support

### DIFF
--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -268,7 +268,7 @@ export const providers = sqliteTable("providers", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   type: text("type", {
-    enum: ["anthropic", "openai", "google", "ollama", "openai-compatible", "openrouter", "github-copilot", "huggingface", "nvidia", "xai", "zai", "perplexity", "deepgram", "bedrock", "lmstudio"],
+    enum: ["anthropic", "openai", "google", "ollama", "openai-compatible", "openrouter", "github-copilot", "huggingface", "nvidia", "xai", "zai", "perplexity", "deepgram", "bedrock", "lmstudio", "deepseek"],
   }).notNull(),
   apiKey: text("api_key"),
   baseUrl: text("base_url"),

--- a/packages/server/src/llm/__tests__/deepseek-provider.test.ts
+++ b/packages/server/src/llm/__tests__/deepseek-provider.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Unit tests for the DeepSeek LLM provider integration.
+ *
+ * These tests verify that:
+ * - resolveModel correctly creates a DeepSeek language model via OpenAI SDK
+ * - Provider credentials are resolved properly (Bearer token auth)
+ * - Configuration (provider type metadata, fallback models) is correct
+ * - Model selection passes through the correct model IDs
+ * - Model discovery and error handling work correctly
+ */
+
+// ---------------------------------------------------------------------------
+// Mock the DB and auth layers so we can test resolveModel in isolation
+// ---------------------------------------------------------------------------
+
+vi.mock("../../db/index.js", () => ({
+  getDb: vi.fn(() => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          get: () => undefined,
+        }),
+      }),
+    }),
+  })),
+  schema: {
+    providers: { id: "id" },
+  },
+}));
+
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn(() => null),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the AI SDK providers to avoid real API calls
+// ---------------------------------------------------------------------------
+
+const mockDeepSeekModel = { modelId: "deepseek-chat", provider: "deepseek" };
+const mockCreateOpenAI = vi.fn(() =>
+  vi.fn((model: string) => ({ ...mockDeepSeekModel, modelId: model })),
+);
+
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: mockCreateOpenAI,
+}));
+
+// Also mock other providers that are imported at module level
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => vi.fn()),
+}));
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: vi.fn(() => vi.fn()),
+}));
+vi.mock("@ai-sdk/openai-compatible", () => ({
+  createOpenAICompatible: vi.fn(() => vi.fn()),
+}));
+vi.mock("ollama-ai-provider", () => ({
+  createOllama: vi.fn(() => vi.fn()),
+}));
+vi.mock("@ai-sdk/amazon-bedrock", () => ({
+  createAmazonBedrock: vi.fn(() => vi.fn()),
+}));
+
+describe("DeepSeek provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("resolveModel", () => {
+    it("creates a DeepSeek model via OpenAI SDK with correct base URL", async () => {
+      const { resolveModel } = await import("../adapter.js");
+
+      const model = resolveModel({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        apiKey: "sk-deepseek-test-key",
+      });
+
+      expect(mockCreateOpenAI).toHaveBeenCalledWith({
+        baseURL: "https://api.deepseek.com",
+        apiKey: "sk-deepseek-test-key",
+      });
+      expect(model).toMatchObject({ modelId: "deepseek-chat" });
+    });
+
+    it("passes the correct model ID for deepseek-reasoner", async () => {
+      const { resolveModel } = await import("../adapter.js");
+
+      const model = resolveModel({
+        provider: "deepseek",
+        model: "deepseek-reasoner",
+        apiKey: "sk-key",
+      });
+
+      expect(model).toMatchObject({ modelId: "deepseek-reasoner" });
+    });
+
+    it("uses an empty string when no API key is provided", async () => {
+      const { resolveModel } = await import("../adapter.js");
+
+      resolveModel({
+        provider: "deepseek",
+        model: "deepseek-chat",
+      });
+
+      expect(mockCreateOpenAI).toHaveBeenCalledWith({
+        baseURL: "https://api.deepseek.com",
+        apiKey: "",
+      });
+    });
+
+    it("uses a custom base URL when provided", async () => {
+      const { resolveModel } = await import("../adapter.js");
+
+      resolveModel({
+        provider: "deepseek",
+        model: "deepseek-chat",
+        apiKey: "sk-key",
+        baseUrl: "https://custom-deepseek.example.com/v1",
+      });
+
+      expect(mockCreateOpenAI).toHaveBeenCalledWith({
+        baseURL: "https://custom-deepseek.example.com/v1",
+        apiKey: "sk-key",
+      });
+    });
+  });
+
+  describe("resolveProviderCredentials", () => {
+    it("falls back to legacy config when provider is not in DB", async () => {
+      const { resolveProviderCredentials } = await import("../adapter.js");
+
+      const creds = resolveProviderCredentials("deepseek");
+      expect(creds.type).toBe("deepseek");
+    });
+  });
+
+  describe("isThinkingModel", () => {
+    it("returns false for DeepSeek models", async () => {
+      const { isThinkingModel } = await import("../adapter.js");
+
+      expect(isThinkingModel({ provider: "deepseek", model: "deepseek-chat" })).toBe(false);
+      expect(isThinkingModel({ provider: "deepseek", model: "deepseek-reasoner" })).toBe(false);
+    });
+  });
+});
+
+describe("DeepSeek provider configuration", () => {
+  it("includes deepseek in PROVIDER_TYPE_META", async () => {
+    const { PROVIDER_TYPE_META } = await import("../../settings/settings.js");
+
+    const dsMeta = PROVIDER_TYPE_META.find((m) => m.type === "deepseek");
+    expect(dsMeta).toBeDefined();
+    expect(dsMeta!.label).toBe("DeepSeek");
+    expect(dsMeta!.needsApiKey).toBe(true);
+    expect(dsMeta!.needsBaseUrl).toBe(false);
+  });
+
+  it("has fallback models for deepseek provider", async () => {
+    const { fetchModelsWithCredentials } = await import("../../settings/settings.js");
+
+    // Without an API key, should return fallback models
+    const models = await fetchModelsWithCredentials("deepseek");
+    expect(models.length).toBeGreaterThan(0);
+    expect(models).toContain("deepseek-chat");
+    expect(models).toContain("deepseek-reasoner");
+  });
+});
+
+describe("DeepSeek model pricing", () => {
+  it("has pricing configured for deepseek-chat", async () => {
+    const { getModelPrice } = await import("../../settings/model-pricing.js");
+
+    const price = getModelPrice("deepseek-chat");
+    expect(price.inputPerMillion).toBeGreaterThan(0);
+    expect(price.outputPerMillion).toBeGreaterThan(0);
+  });
+
+  it("has pricing configured for deepseek-reasoner", async () => {
+    const { getModelPrice } = await import("../../settings/model-pricing.js");
+
+    const price = getModelPrice("deepseek-reasoner");
+    expect(price.inputPerMillion).toBeGreaterThan(0);
+    expect(price.outputPerMillion).toBeGreaterThan(0);
+  });
+});
+
+describe("DeepSeek error handling", () => {
+  it("throws for unknown provider type", async () => {
+    const { resolveModel } = await import("../adapter.js");
+
+    expect(() =>
+      resolveModel({
+        provider: "nonexistent-provider",
+        model: "some-model",
+      }),
+    ).toThrow(/Unknown LLM provider/);
+  });
+});

--- a/packages/server/src/llm/adapter.ts
+++ b/packages/server/src/llm/adapter.ts
@@ -210,6 +210,14 @@ export function resolveModel(config: LLMConfig): LanguageModel {
       return lmstudio(config.model);
     }
 
+    case "deepseek": {
+      const deepseek = createOpenAI({
+        baseURL: config.baseUrl ?? resolved.baseUrl ?? "https://api.deepseek.com",
+        apiKey: config.apiKey ?? resolved.apiKey ?? "",
+      });
+      return deepseek(config.model);
+    }
+
     default:
       throw new Error(`Unknown LLM provider: ${config.provider} (type: ${resolved.type})`);
   }

--- a/packages/server/src/settings/model-pricing.ts
+++ b/packages/server/src/settings/model-pricing.ts
@@ -34,6 +34,9 @@ const DEFAULT_MODEL_PRICES: Record<string, ModelPrice> = {
   "grok-3": { inputPerMillion: 3, outputPerMillion: 15 },
   "grok-3-mini": { inputPerMillion: 0.3, outputPerMillion: 0.5 },
   "grok-4": { inputPerMillion: 3, outputPerMillion: 15 },
+  // DeepSeek
+  "deepseek-chat": { inputPerMillion: 0.27, outputPerMillion: 1.10 },
+  "deepseek-reasoner": { inputPerMillion: 0.55, outputPerMillion: 2.19 },
   // Google
   "gemini-2.5-pro": { inputPerMillion: 1.25, outputPerMillion: 10 },
   "gemini-2.5-flash": { inputPerMillion: 0.15, outputPerMillion: 0.6 },

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -66,6 +66,7 @@ export const PROVIDER_TYPE_META: ProviderTypeMeta[] = [
   { type: "deepgram", label: "Deepgram", needsApiKey: true, needsBaseUrl: false },
   { type: "bedrock", label: "AWS Bedrock", needsApiKey: true, needsBaseUrl: true },
   { type: "lmstudio", label: "LM Studio", needsApiKey: false, needsBaseUrl: true },
+  { type: "deepseek", label: "DeepSeek", needsApiKey: true, needsBaseUrl: false },
 ];
 
 // Static fallback models per provider (used when API fetch fails)
@@ -134,6 +135,10 @@ const FALLBACK_MODELS: Record<string, string[]> = {
     "mistral-7b-instruct",
     "qwen2.5-coder-7b-instruct",
     "phi-3-mini-4k-instruct",
+  ],
+  deepseek: [
+    "deepseek-chat",
+    "deepseek-reasoner",
   ],
 };
 
@@ -670,6 +675,18 @@ export async function fetchModelsWithCredentials(
         if (!pplxRes.ok) return FALLBACK_MODELS.perplexity ?? [];
         const pplxData = (await pplxRes.json()) as { data?: Array<{ id: string }> };
         return pplxData.data?.map((m) => m.id).sort() ?? FALLBACK_MODELS.perplexity ?? [];
+      }
+
+      case "deepseek": {
+        if (!apiKey) return FALLBACK_MODELS.deepseek ?? [];
+        const deepseekBase = baseUrl ?? "https://api.deepseek.com";
+        const deepseekRes = await fetch(`${deepseekBase}/models`, {
+          headers: { Authorization: `Bearer ${apiKey}` },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!deepseekRes.ok) return FALLBACK_MODELS.deepseek ?? [];
+        const deepseekData = (await deepseekRes.json()) as { data?: Array<{ id: string }> };
+        return deepseekData.data?.map((m) => m.id).sort() ?? FALLBACK_MODELS.deepseek ?? [];
       }
 
       default:

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -1,4 +1,4 @@
-export type ProviderType = "anthropic" | "openai" | "google" | "ollama" | "openai-compatible" | "openrouter" | "github-copilot" | "huggingface" | "nvidia" | "xai" | "zai" | "perplexity" | "deepgram" | "bedrock" | "lmstudio";
+export type ProviderType = "anthropic" | "openai" | "google" | "ollama" | "openai-compatible" | "openrouter" | "github-copilot" | "huggingface" | "nvidia" | "xai" | "zai" | "perplexity" | "deepgram" | "bedrock" | "lmstudio" | "deepseek";
 
 export interface NamedProvider {
   id: string;

--- a/packages/web/src/components/settings/ProvidersTab.tsx
+++ b/packages/web/src/components/settings/ProvidersTab.tsx
@@ -11,6 +11,7 @@ const TYPE_LABELS: Record<string, string> = {
   huggingface: "Hugging Face",
   nvidia: "NVIDIA",
   lmstudio: "LM Studio",
+  deepseek: "DeepSeek",
 };
 
 export function ProvidersTab() {


### PR DESCRIPTION
## Summary
- Adds DeepSeek as a new LLM provider using the OpenAI-compatible API at `https://api.deepseek.com`
- Supports `deepseek-chat` (V3) and `deepseek-reasoner` (R1) models with fallback model list, model discovery, and pricing
- Includes full backend integration (adapter, settings, schema, pricing) and web UI label

Closes #240

## Changes
| File | Change |
|------|--------|
| `packages/shared/src/types/provider.ts` | Add `"deepseek"` to `ProviderType` union |
| `packages/server/src/db/schema.ts` | Add `"deepseek"` to providers table enum |
| `packages/server/src/settings/settings.ts` | Add metadata, fallback models, model discovery |
| `packages/server/src/llm/adapter.ts` | Add `resolveModel` case for DeepSeek |
| `packages/server/src/settings/model-pricing.ts` | Add pricing for deepseek-chat and deepseek-reasoner |
| `packages/web/src/components/settings/ProvidersTab.tsx` | Add "DeepSeek" UI label |
| `packages/server/src/llm/__tests__/deepseek-provider.test.ts` | 11 comprehensive unit tests |

## Test plan
- [x] All 816 tests pass (58 test files), including 11 new DeepSeek-specific tests
- [x] Tests cover: model resolution, credentials fallback, thinking model detection, provider metadata, fallback models, model pricing, and error handling
- [ ] Manual: configure a DeepSeek provider with API key and verify model discovery
- [ ] Manual: test chat completion with deepseek-chat model

🤖 Generated with [Claude Code](https://claude.com/claude-code)