### PR TITLE
feat: add merge queue for auto-rebase and sequential PR merging

### DIFF
--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -573,6 +573,24 @@ export async function migrateDb() {
     created_at TEXT NOT NULL
   )`);
 
+  // Merge queue table
+  db.run(sql`CREATE TABLE IF NOT EXISTS merge_queue (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    pr_branch TEXT NOT NULL,
+    base_branch TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'queued',
+    position INTEGER NOT NULL,
+    rebase_attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    approved_at TEXT NOT NULL,
+    merged_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`);
+
   // Custom scheduled tasks
   db.run(sql`CREATE TABLE IF NOT EXISTS custom_scheduled_tasks (
     id TEXT PRIMARY KEY,

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -446,6 +446,29 @@ export const customScheduledTasks = sqliteTable("custom_scheduled_tasks", {
   updatedAt: text("updated_at").notNull().$defaultFn(() => new Date().toISOString()),
 });
 
+export const mergeQueue = sqliteTable("merge_queue", {
+  id: text("id").primaryKey(),
+  taskId: text("task_id").notNull(),
+  projectId: text("project_id").notNull(),
+  prNumber: integer("pr_number").notNull(),
+  prBranch: text("pr_branch").notNull(),
+  baseBranch: text("base_branch").notNull(),
+  status: text("status", {
+    enum: ["queued", "rebasing", "re_review", "merging", "merged", "conflict", "failed"],
+  }).notNull().default("queued"),
+  position: integer("position").notNull(),
+  rebaseAttempts: integer("rebase_attempts").notNull().default(0),
+  lastError: text("last_error"),
+  approvedAt: text("approved_at").notNull(),
+  mergedAt: text("merged_at"),
+  createdAt: text("created_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+  updatedAt: text("updated_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+});
+
 export const memoryEpisodes = sqliteTable("memory_episodes", {
   id: text("id").primaryKey(),
   date: text("date").notNull(), // YYYY-MM-DD

--- a/packages/server/src/merge-queue/merge-queue.ts
+++ b/packages/server/src/merge-queue/merge-queue.ts
@@ -1,0 +1,563 @@
+import { nanoid } from "nanoid";
+import { eq, and } from "drizzle-orm";
+import type { Server } from "socket.io";
+import type {
+  ServerToClientEvents,
+  ClientToServerEvents,
+  KanbanTask,
+  MergeQueueEntry,
+  MergeQueueStatus,
+} from "@otterbot/shared";
+import { getDb, schema } from "../db/index.js";
+import { getConfig } from "../auth/auth.js";
+import {
+  fetchPullRequest,
+  mergePullRequest,
+  createIssueComment,
+  gitEnvWithPAT,
+  gitCredentialArgs,
+} from "../github/github-service.js";
+import { rebaseBranch, forcePushBranch } from "../utils/git.js";
+import { formatBotComment } from "../utils/github-comments.js";
+import type { Scheduler } from "../schedulers/scheduler-registry.js";
+import type { PipelineManager } from "../pipeline/pipeline-manager.js";
+import type { WorkspaceManager } from "../workspace/workspace.js";
+
+type TypedServer = Server<ClientToServerEvents, ServerToClientEvents>;
+
+export class MergeQueue implements Scheduler {
+  private io: TypedServer;
+  private workspace: WorkspaceManager;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private pipelineManager: PipelineManager | null = null;
+  private processing = false;
+
+  constructor(io: TypedServer, workspace: WorkspaceManager) {
+    this.io = io;
+    this.workspace = workspace;
+  }
+
+  setPipelineManager(pm: PipelineManager): void {
+    this.pipelineManager = pm;
+  }
+
+  // ─── Scheduler interface ──────────────────────────────────────────
+
+  start(intervalMs = 30_000): void {
+    if (this.intervalId) return;
+    this.recover();
+    this.intervalId = setInterval(() => {
+      this.poll().catch((err) => {
+        console.error("[MergeQueue] Poll error:", err);
+      });
+    }, intervalMs);
+    console.log(`[MergeQueue] Started polling every ${intervalMs / 1000}s`);
+  }
+
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  // ─── Public API ───────────────────────────────────────────────────
+
+  /**
+   * Enqueue a task for merge. Creates a queued entry from an in_review task.
+   */
+  approveForMerge(taskId: string): MergeQueueEntry | null {
+    const db = getDb();
+    const task = db.select().from(schema.kanbanTasks).where(eq(schema.kanbanTasks.id, taskId)).get();
+    if (!task) return null;
+    if (!task.prNumber || !task.prBranch) return null;
+
+    // Check if already in queue
+    const existing = db
+      .select()
+      .from(schema.mergeQueue)
+      .where(eq(schema.mergeQueue.taskId, taskId))
+      .get();
+    if (existing) return existing as unknown as MergeQueueEntry;
+
+    // Get project info for base branch
+    const project = db.select().from(schema.projects).where(eq(schema.projects.id, task.projectId)).get();
+    const baseBranch = project?.githubBranch
+      ?? getConfig(`project:${task.projectId}:github:branch`)
+      ?? "main";
+
+    // Determine position (append to end)
+    const allEntries = db.select().from(schema.mergeQueue).all();
+    const maxPosition = allEntries.reduce((max, e) => Math.max(max, e.position), 0);
+
+    const now = new Date().toISOString();
+    const entry = {
+      id: nanoid(),
+      taskId,
+      projectId: task.projectId,
+      prNumber: task.prNumber,
+      prBranch: task.prBranch,
+      baseBranch,
+      status: "queued" as const,
+      position: maxPosition + 1,
+      rebaseAttempts: 0,
+      lastError: null,
+      approvedAt: now,
+      mergedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    db.insert(schema.mergeQueue).values(entry).run();
+
+    const result = entry as unknown as MergeQueueEntry;
+    this.emitEntryUpdated(result);
+    this.emitQueueUpdated();
+
+    console.log(`[MergeQueue] Task ${taskId} (PR #${task.prNumber}) enqueued at position ${entry.position}`);
+    return result;
+  }
+
+  /**
+   * Remove a task from the merge queue. Task stays in in_review.
+   */
+  removeFromQueue(taskId: string): boolean {
+    const db = getDb();
+    const entry = db
+      .select()
+      .from(schema.mergeQueue)
+      .where(eq(schema.mergeQueue.taskId, taskId))
+      .get();
+    if (!entry) return false;
+
+    db.delete(schema.mergeQueue).where(eq(schema.mergeQueue.id, entry.id)).run();
+    this.emitQueueUpdated();
+
+    console.log(`[MergeQueue] Removed task ${taskId} from queue`);
+    return true;
+  }
+
+  /**
+   * Get all queue entries, ordered by position.
+   */
+  getQueue(projectId?: string): MergeQueueEntry[] {
+    const db = getDb();
+    let entries;
+    if (projectId) {
+      entries = db
+        .select()
+        .from(schema.mergeQueue)
+        .where(eq(schema.mergeQueue.projectId, projectId))
+        .all();
+    } else {
+      entries = db.select().from(schema.mergeQueue).all();
+    }
+    return (entries as unknown as MergeQueueEntry[]).sort((a, b) => a.position - b.position);
+  }
+
+  /**
+   * Check if a task is in the merge queue.
+   */
+  isInQueue(taskId: string): boolean {
+    const db = getDb();
+    const entry = db
+      .select()
+      .from(schema.mergeQueue)
+      .where(eq(schema.mergeQueue.taskId, taskId))
+      .get();
+    return !!entry;
+  }
+
+  /**
+   * Reorder an entry to a new position.
+   */
+  reorderEntry(entryId: string, newPosition: number): boolean {
+    const db = getDb();
+    const entry = db.select().from(schema.mergeQueue).where(eq(schema.mergeQueue.id, entryId)).get();
+    if (!entry) return false;
+
+    const now = new Date().toISOString();
+    db.update(schema.mergeQueue)
+      .set({ position: newPosition, updatedAt: now })
+      .where(eq(schema.mergeQueue.id, entryId))
+      .run();
+
+    this.emitQueueUpdated();
+    return true;
+  }
+
+  /**
+   * Called by PipelineManager when re-review completes.
+   */
+  async onReReviewComplete(taskId: string, passed: boolean): Promise<void> {
+    const db = getDb();
+    const entry = db
+      .select()
+      .from(schema.mergeQueue)
+      .where(eq(schema.mergeQueue.taskId, taskId))
+      .get();
+    if (!entry) return;
+
+    if (passed) {
+      // Re-review passed — proceed to merge
+      await this.updateEntryStatus(entry.id, "merging");
+      await this.doMerge(entry.id);
+    } else {
+      // Re-review failed — mark as failed
+      await this.updateEntryStatus(entry.id, "failed", "Re-review failed after rebase");
+
+      // Move task back to in_review
+      const now = new Date().toISOString();
+      db.update(schema.kanbanTasks)
+        .set({ column: "in_review", updatedAt: now })
+        .where(eq(schema.kanbanTasks.id, taskId))
+        .run();
+      const updated = db.select().from(schema.kanbanTasks).where(eq(schema.kanbanTasks.id, taskId)).get();
+      if (updated) {
+        this.io.emit("kanban:task-updated", updated as unknown as KanbanTask);
+      }
+    }
+  }
+
+  // ─── Internal ─────────────────────────────────────────────────────
+
+  /**
+   * Recovery on server restart: reset transient states.
+   */
+  private recover(): void {
+    const db = getDb();
+    const now = new Date().toISOString();
+
+    // Reset rebasing → queued (rebase state is lost)
+    db.update(schema.mergeQueue)
+      .set({ status: "queued", updatedAt: now })
+      .where(eq(schema.mergeQueue.status, "rebasing"))
+      .run();
+
+    // Reset re_review → queued (pipeline state is in-memory)
+    db.update(schema.mergeQueue)
+      .set({ status: "queued", updatedAt: now })
+      .where(eq(schema.mergeQueue.status, "re_review"))
+      .run();
+
+    // For merging entries, we'll check PR status in the next poll
+
+    const recovered = db.select().from(schema.mergeQueue).all();
+    if (recovered.length > 0) {
+      console.log(`[MergeQueue] Recovered ${recovered.length} queue entries`);
+    }
+  }
+
+  /**
+   * Main poll loop: sync state and process next entry.
+   */
+  private async poll(): Promise<void> {
+    if (this.processing) return;
+    this.processing = true;
+
+    try {
+      await this.syncExternalState();
+      await this.processNext();
+    } finally {
+      this.processing = false;
+    }
+  }
+
+  /**
+   * Check GitHub for PRs that were merged/closed externally.
+   */
+  private async syncExternalState(): Promise<void> {
+    const token = getConfig("github:token");
+    if (!token) return;
+
+    const db = getDb();
+    const activeEntries = db
+      .select()
+      .from(schema.mergeQueue)
+      .all()
+      .filter((e) => !["merged", "failed"].includes(e.status));
+
+    for (const entry of activeEntries) {
+      try {
+        const project = db.select().from(schema.projects).where(eq(schema.projects.id, entry.projectId)).get();
+        if (!project?.githubRepo) continue;
+
+        const pr = await fetchPullRequest(project.githubRepo, token, entry.prNumber);
+
+        if (pr.merged) {
+          // Merged externally — mark as merged, move task to done
+          await this.updateEntryStatus(entry.id, "merged");
+          const now = new Date().toISOString();
+          db.update(schema.mergeQueue)
+            .set({ mergedAt: now, updatedAt: now })
+            .where(eq(schema.mergeQueue.id, entry.id))
+            .run();
+
+          db.update(schema.kanbanTasks)
+            .set({
+              column: "done",
+              completionReport: `PR #${entry.prNumber} merged (detected by merge queue).`,
+              updatedAt: now,
+            })
+            .where(eq(schema.kanbanTasks.id, entry.taskId))
+            .run();
+
+          const updated = db.select().from(schema.kanbanTasks).where(eq(schema.kanbanTasks.id, entry.taskId)).get();
+          if (updated) {
+            this.io.emit("kanban:task-updated", updated as unknown as KanbanTask);
+          }
+
+          console.log(`[MergeQueue] PR #${entry.prNumber} merged externally — task ${entry.taskId} → done`);
+        } else if (pr.state === "closed") {
+          // Closed without merge — remove from queue, task → backlog
+          db.delete(schema.mergeQueue).where(eq(schema.mergeQueue.id, entry.id)).run();
+
+          const now = new Date().toISOString();
+          db.update(schema.kanbanTasks)
+            .set({ column: "backlog", assigneeAgentId: null, updatedAt: now })
+            .where(eq(schema.kanbanTasks.id, entry.taskId))
+            .run();
+
+          const updated = db.select().from(schema.kanbanTasks).where(eq(schema.kanbanTasks.id, entry.taskId)).get();
+          if (updated) {
+            this.io.emit("kanban:task-updated", updated as unknown as KanbanTask);
+          }
+
+          this.emitQueueUpdated();
+          console.log(`[MergeQueue] PR #${entry.prNumber} closed — task ${entry.taskId} → backlog`);
+        }
+      } catch (err) {
+        console.error(`[MergeQueue] Error syncing PR #${entry.prNumber}:`, err);
+      }
+    }
+  }
+
+  /**
+   * Process the next queued entry if nothing is currently being processed.
+   */
+  private async processNext(): Promise<void> {
+    const db = getDb();
+    const activeEntries = db
+      .select()
+      .from(schema.mergeQueue)
+      .all()
+      .filter((e) => ["rebasing", "re_review", "merging"].includes(e.status));
+
+    // Don't process if something is actively being worked on
+    if (activeEntries.length > 0) return;
+
+    // Find next queued entry
+    const queued = db
+      .select()
+      .from(schema.mergeQueue)
+      .where(eq(schema.mergeQueue.status, "queued"))
+      .all()
+      .sort((a, b) => a.position - b.position);
+
+    if (queued.length === 0) return;
+
+    const next = queued[0];
+    await this.processEntry(next.id);
+  }
+
+  /**
+   * Process a single queue entry: rebase → re-review → merge.
+   */
+  private async processEntry(entryId: string): Promise<void> {
+    const db = getDb();
+    const entry = db.select().from(schema.mergeQueue).where(eq(schema.mergeQueue.id, entryId)).get();
+    if (!entry) return;
+
+    const project = db.select().from(schema.projects).where(eq(schema.projects.id, entry.projectId)).get();
+    if (!project?.githubRepo) return;
+
+    const token = getConfig("github:token");
+    if (!token) return;
+
+    // Step 1: Rebase
+    await this.updateEntryStatus(entryId, "rebasing");
+
+    const repoPath = this.workspace.repoPath(entry.projectId);
+    const gitEnv = gitEnvWithPAT(token);
+    const credArgs = gitCredentialArgs();
+
+    const rebaseSuccess = rebaseBranch(
+      repoPath,
+      entry.prBranch,
+      entry.baseBranch,
+      gitEnv,
+      credArgs,
+    );
+
+    if (!rebaseSuccess) {
+      // Rebase conflict
+      await this.updateEntryStatus(entryId, "conflict", "Rebase conflict with base branch");
+
+      // Post comment on PR
+      try {
+        await createIssueComment(
+          project.githubRepo,
+          token,
+          entry.prNumber,
+          formatBotComment(
+            "Merge Queue: Rebase Conflict",
+            `Could not automatically rebase \`${entry.prBranch}\` onto \`${entry.baseBranch}\`. ` +
+            `Please resolve the conflicts manually and re-approve for merge.`,
+          ),
+        );
+      } catch { /* best effort */ }
+
+      // Move task to backlog for attention
+      const now = new Date().toISOString();
+      db.update(schema.kanbanTasks)
+        .set({ column: "backlog", assigneeAgentId: null, updatedAt: now })
+        .where(eq(schema.kanbanTasks.id, entry.taskId))
+        .run();
+      const updated = db.select().from(schema.kanbanTasks).where(eq(schema.kanbanTasks.id, entry.taskId)).get();
+      if (updated) {
+        this.io.emit("kanban:task-updated", updated as unknown as KanbanTask);
+      }
+
+      console.log(`[MergeQueue] Rebase conflict for PR #${entry.prNumber}`);
+      return;
+    }
+
+    // Force push the rebased branch
+    try {
+      forcePushBranch(repoPath, entry.prBranch, gitEnv, credArgs);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await this.updateEntryStatus(entryId, "failed", `Force push failed: ${msg}`);
+      console.error(`[MergeQueue] Force push failed for PR #${entry.prNumber}:`, err);
+      return;
+    }
+
+    // Step 2: Re-review via pipeline (if pipeline is enabled)
+    if (this.pipelineManager?.isEnabled(entry.projectId)) {
+      await this.updateEntryStatus(entryId, "re_review");
+      try {
+        await this.pipelineManager.startReReview(entry.taskId, entry.prBranch, entry.prNumber);
+        // Pipeline will call onReReviewComplete when done
+        console.log(`[MergeQueue] Started re-review for PR #${entry.prNumber}`);
+        return;
+      } catch (err) {
+        console.error(`[MergeQueue] Failed to start re-review for PR #${entry.prNumber}:`, err);
+        // Fall through to merge without re-review
+      }
+    }
+
+    // Step 3: Merge (if no pipeline, or pipeline start failed)
+    await this.updateEntryStatus(entryId, "merging");
+    await this.doMerge(entryId);
+  }
+
+  /**
+   * Perform the actual merge via GitHub API.
+   */
+  private async doMerge(entryId: string): Promise<void> {
+    const db = getDb();
+    const entry = db.select().from(schema.mergeQueue).where(eq(schema.mergeQueue.id, entryId)).get();
+    if (!entry) return;
+
+    const project = db.select().from(schema.projects).where(eq(schema.projects.id, entry.projectId)).get();
+    if (!project?.githubRepo) return;
+
+    const token = getConfig("github:token");
+    if (!token) return;
+
+    const task = db.select().from(schema.kanbanTasks).where(eq(schema.kanbanTasks.id, entry.taskId)).get();
+
+    try {
+      const commitTitle = task
+        ? `${task.title} (#${entry.prNumber})`
+        : `PR #${entry.prNumber}`;
+
+      await mergePullRequest(
+        project.githubRepo,
+        token,
+        entry.prNumber,
+        "squash",
+        commitTitle,
+      );
+
+      // Mark as merged
+      const now = new Date().toISOString();
+      db.update(schema.mergeQueue)
+        .set({ status: "merged", mergedAt: now, updatedAt: now })
+        .where(eq(schema.mergeQueue.id, entryId))
+        .run();
+
+      // Move task to done
+      db.update(schema.kanbanTasks)
+        .set({
+          column: "done",
+          completionReport: `PR #${entry.prNumber} merged via merge queue.`,
+          updatedAt: now,
+        })
+        .where(eq(schema.kanbanTasks.id, entry.taskId))
+        .run();
+
+      const updated = db.select().from(schema.kanbanTasks).where(eq(schema.kanbanTasks.id, entry.taskId)).get();
+      if (updated) {
+        this.io.emit("kanban:task-updated", updated as unknown as KanbanTask);
+      }
+
+      this.emitEntryUpdated(this.getEntry(entryId)!);
+      this.emitQueueUpdated();
+
+      console.log(`[MergeQueue] PR #${entry.prNumber} merged successfully`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+
+      // Check if it's a rate limit or temporary error — keep in merging for retry
+      if (msg.includes("405") || msg.includes("409")) {
+        // 405 = not mergeable, 409 = conflict
+        await this.updateEntryStatus(entryId, "failed", `Merge failed: ${msg}`);
+      } else {
+        // Retry on next poll cycle
+        console.error(`[MergeQueue] Merge API error for PR #${entry.prNumber}: ${msg}`);
+      }
+    }
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────────────
+
+  private async updateEntryStatus(
+    entryId: string,
+    status: MergeQueueStatus,
+    error?: string,
+  ): Promise<void> {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const updates: Record<string, unknown> = { status, updatedAt: now };
+    if (error !== undefined) updates.lastError = error;
+    if (status === "rebasing") {
+      // Increment rebase attempts
+      const entry = db.select().from(schema.mergeQueue).where(eq(schema.mergeQueue.id, entryId)).get();
+      if (entry) updates.rebaseAttempts = entry.rebaseAttempts + 1;
+    }
+
+    db.update(schema.mergeQueue)
+      .set(updates)
+      .where(eq(schema.mergeQueue.id, entryId))
+      .run();
+
+    const updated = this.getEntry(entryId);
+    if (updated) this.emitEntryUpdated(updated);
+  }
+
+  private getEntry(entryId: string): MergeQueueEntry | null {
+    const db = getDb();
+    const entry = db.select().from(schema.mergeQueue).where(eq(schema.mergeQueue.id, entryId)).get();
+    return (entry as unknown as MergeQueueEntry) ?? null;
+  }
+
+  private emitEntryUpdated(entry: MergeQueueEntry): void {
+    this.io.emit("merge-queue:entry-updated", entry);
+  }
+
+  private emitQueueUpdated(): void {
+    const entries = this.getQueue();
+    this.io.emit("merge-queue:updated", { entries });
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,3 +17,4 @@ export * from "./types/coding-agent.js";
 export * from "./types/opencode.js";
 export * from "./types/memory.js";
 export * from "./types/module.js";
+export * from "./types/merge-queue.js";

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -6,6 +6,7 @@ import type { SceneZone } from "./environment.js";
 import type { CodingAgentSession, CodingAgentMessage, CodingAgentFileDiff, CodingAgentPermission } from "./coding-agent.js";
 import type { SoulDocument, Memory, MemoryEpisode, SoulSuggestion } from "./memory.js";
 import type { Todo } from "./todo.js";
+import type { MergeQueueEntry } from "./merge-queue.js";
 
 /** Events emitted from server to client */
 export interface ServerToClientEvents {
@@ -64,6 +65,8 @@ export interface ServerToClientEvents {
   "telegram:pairing-request": (data: { code: string; telegramUserId: string; telegramUsername: string }) => void;
   "telegram:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
   "whatsapp:status": (data: { status: "connected" | "disconnected" | "qr" | "authenticated" | "auth_failure"; qr?: string }) => void;
+  "merge-queue:updated": (data: { entries: MergeQueueEntry[] }) => void;
+  "merge-queue:entry-updated": (entry: MergeQueueEntry) => void;
 }
 
 /** Events emitted from client to server */
@@ -216,5 +219,23 @@ export interface ClientToServerEvents {
   // Soul advisor
   "soul:suggest": (
     callback: (ack: { ok: boolean; suggestions?: SoulSuggestion[]; error?: string }) => void,
+  ) => void;
+
+  // Merge queue
+  "merge-queue:approve": (
+    data: { taskId: string },
+    callback?: (ack: { ok: boolean; entry?: MergeQueueEntry; error?: string }) => void,
+  ) => void;
+  "merge-queue:remove": (
+    data: { taskId: string },
+    callback?: (ack: { ok: boolean; error?: string }) => void,
+  ) => void;
+  "merge-queue:list": (
+    data?: { projectId?: string },
+    callback?: (entries: MergeQueueEntry[]) => void,
+  ) => void;
+  "merge-queue:reorder": (
+    data: { entryId: string; newPosition: number },
+    callback?: (ack: { ok: boolean; error?: string }) => void,
   ) => void;
 }

--- a/packages/shared/src/types/merge-queue.ts
+++ b/packages/shared/src/types/merge-queue.ts
@@ -1,0 +1,25 @@
+export type MergeQueueStatus =
+  | "queued"
+  | "rebasing"
+  | "re_review"
+  | "merging"
+  | "merged"
+  | "conflict"
+  | "failed";
+
+export interface MergeQueueEntry {
+  id: string;
+  taskId: string;
+  projectId: string;
+  prNumber: number;
+  prBranch: string;
+  baseBranch: string;
+  status: MergeQueueStatus;
+  position: number;
+  rebaseAttempts: number;
+  lastError: string | null;
+  approvedAt: string;
+  mergedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/web/src/components/kanban/KanbanBoard.tsx
+++ b/packages/web/src/components/kanban/KanbanBoard.tsx
@@ -17,6 +17,7 @@ import { useProjectStore } from "../../stores/project-store";
 import { KanbanCard } from "./KanbanCard";
 import { KanbanTaskDetail } from "./KanbanTaskDetail";
 import { KanbanDroppableColumn } from "./KanbanDroppableColumn";
+import { MergeQueuePanel } from "./MergeQueuePanel";
 import { KanbanColumn, type KanbanTask } from "@otterbot/shared";
 
 const COLUMNS: { key: KanbanColumn; label: string }[] = [
@@ -172,6 +173,10 @@ export function KanbanBoard({ projectId }: { projectId: string }) {
             onClose={() => setSelectedTaskId(null)}
           />
         )}
+      </div>
+
+      <div className="px-4 pb-2">
+        <MergeQueuePanel projectId={projectId} />
       </div>
 
       <DragOverlay>

--- a/packages/web/src/components/kanban/MergeQueuePanel.tsx
+++ b/packages/web/src/components/kanban/MergeQueuePanel.tsx
@@ -1,0 +1,69 @@
+import { useEffect } from "react";
+import type { MergeQueueStatus } from "@otterbot/shared";
+import { useMergeQueueStore } from "../../stores/merge-queue-store";
+import { getSocket } from "../../lib/socket";
+
+const STATUS_CONFIG: Record<MergeQueueStatus, { label: string; color: string }> = {
+  queued: { label: "Queued", color: "text-blue-400" },
+  rebasing: { label: "Rebasing...", color: "text-purple-400" },
+  re_review: { label: "Re-Review...", color: "text-indigo-400" },
+  merging: { label: "Merging...", color: "text-emerald-400" },
+  merged: { label: "Merged", color: "text-emerald-400" },
+  conflict: { label: "Conflict", color: "text-red-400" },
+  failed: { label: "Failed", color: "text-red-400" },
+};
+
+export function MergeQueuePanel({ projectId }: { projectId: string }) {
+  const entries = useMergeQueueStore((s) => s.entries);
+  const setEntries = useMergeQueueStore((s) => s.setEntries);
+
+  useEffect(() => {
+    const socket = getSocket();
+    socket.emit("merge-queue:list", { projectId }, (result) => {
+      if (result) setEntries(result);
+    });
+  }, [projectId, setEntries]);
+
+  const projectEntries = entries
+    .filter((e) => e.projectId === projectId && e.status !== "merged")
+    .sort((a, b) => a.position - b.position);
+
+  if (projectEntries.length === 0) return null;
+
+  const handleRemove = (taskId: string) => {
+    const socket = getSocket();
+    socket.emit("merge-queue:remove", { taskId });
+  };
+
+  return (
+    <div className="bg-card border border-border rounded-lg p-3">
+      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+        Merge Queue ({projectEntries.length})
+      </h3>
+      <div className="space-y-2">
+        {projectEntries.map((entry, i) => {
+          const config = STATUS_CONFIG[entry.status];
+          return (
+            <div
+              key={entry.id}
+              className="flex items-center gap-2 text-xs bg-muted/30 rounded px-2 py-1.5"
+            >
+              <span className="text-muted-foreground font-mono w-4">{i + 1}.</span>
+              <span className="truncate flex-1">PR #{entry.prNumber}</span>
+              <span className={`font-medium ${config.color}`}>{config.label}</span>
+              {entry.status === "queued" && (
+                <button
+                  className="text-muted-foreground hover:text-red-400 transition-colors"
+                  onClick={() => handleRemove(entry.taskId)}
+                  title="Remove from queue"
+                >
+                  &times;
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/hooks/use-socket.ts
+++ b/packages/web/src/hooks/use-socket.ts
@@ -7,6 +7,7 @@ import { useAgentActivityStore } from "../stores/agent-activity-store";
 import { useEnvironmentStore } from "../stores/environment-store";
 import { useCodingAgentStore } from "../stores/coding-agent-store";
 import { useTodoStore } from "../stores/todo-store";
+import { useMergeQueueStore } from "../stores/merge-queue-store";
 
 export function useSocket() {
   const initialized = useRef(false);
@@ -44,6 +45,8 @@ export function useSocket() {
   const addTodo = useTodoStore((s) => s.addTodo);
   const patchTodo = useTodoStore((s) => s.patchTodo);
   const removeTodo = useTodoStore((s) => s.removeTodo);
+  const setMergeQueueEntries = useMergeQueueStore((s) => s.setEntries);
+  const updateMergeQueueEntry = useMergeQueueStore((s) => s.updateEntry);
 
   useEffect(() => {
     if (initialized.current) return;
@@ -134,6 +137,14 @@ export function useSocket() {
 
     socket.on("kanban:task-deleted", ({ taskId }) => {
       removeTask(taskId);
+    });
+
+    socket.on("merge-queue:updated", ({ entries }) => {
+      setMergeQueueEntries(entries);
+    });
+
+    socket.on("merge-queue:entry-updated", (entry) => {
+      updateMergeQueueEntry(entry);
     });
 
     socket.on("todo:created", (todo) => {
@@ -229,6 +240,8 @@ export function useSocket() {
       socket.off("kanban:task-created");
       socket.off("kanban:task-updated");
       socket.off("kanban:task-deleted");
+      socket.off("merge-queue:updated");
+      socket.off("merge-queue:entry-updated");
       socket.off("todo:created");
       socket.off("todo:updated");
       socket.off("todo:deleted");

--- a/packages/web/src/stores/merge-queue-store.ts
+++ b/packages/web/src/stores/merge-queue-store.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+import type { MergeQueueEntry } from "@otterbot/shared";
+
+interface MergeQueueState {
+  entries: MergeQueueEntry[];
+  setEntries: (entries: MergeQueueEntry[]) => void;
+  updateEntry: (entry: MergeQueueEntry) => void;
+}
+
+export const useMergeQueueStore = create<MergeQueueState>((set) => ({
+  entries: [],
+
+  setEntries: (entries) => set({ entries }),
+
+  updateEntry: (entry) =>
+    set((state) => {
+      const exists = state.entries.some((e) => e.id === entry.id);
+      if (exists) {
+        return {
+          entries: state.entries.map((e) => (e.id === entry.id ? entry : e)),
+        };
+      }
+      return { entries: [...state.entries, entry] };
+    }),
+}));


### PR DESCRIPTION
## Summary

- Adds a **merge queue** that processes approved PRs sequentially: rebase onto latest base branch, re-run pipeline review stages, then auto-merge via GitHub API
- Entry triggers: GitHub PR approval (detected by PR Monitor) or UI "Approve for Merge" button on kanban task cards
- State machine per entry: `queued → rebasing → re_review → merging → merged` (with `conflict`/`failed` error states)

### Changes

- **Merge Queue Service** (`packages/server/src/merge-queue/merge-queue.ts`): Core service with poll loop, state machine, recovery on restart
- **Git utilities** (`packages/server/src/utils/git.ts`): `rebaseBranch()` and `forcePushBranch()` with PAT auth
- **GitHub API** (`packages/server/src/github/github-service.ts`): `mergePullRequest()` and `updatePullRequest()` methods
- **Pipeline re-review** (`packages/server/src/pipeline/pipeline-manager.ts`): `startReReview()` runs security/tester/reviewer stages, skipping triage/coder
- **PR Monitor** (`packages/server/src/github/pr-monitor.ts`): Auto-enqueues PRs on GitHub APPROVED reviews
- **Database** (`packages/server/src/db/schema.ts`, `index.ts`): `merge_queue` table with migration
- **Shared types** (`packages/shared/src/types/merge-queue.ts`, `events.ts`): `MergeQueueEntry`, `MergeQueueStatus`, socket events
- **Web UI**: Approve button on in_review cards, status badges, merge queue panel below kanban board, real-time updates via socket

## Test plan

- [ ] Verify all existing tests pass (`npx pnpm test`)
- [ ] Type-check server and shared packages
- [ ] Create a project with pipeline enabled, spawn 2 workers on tasks touching same file
- [ ] Wait for both PRs to reach `in_review`, approve both via UI button
- [ ] Verify first PR rebases and merges, second PR rebases onto updated base and merges
- [ ] Test manually merging a PR on GitHub — queue should detect and adapt
- [ ] Test rebase conflict scenario — entry should go to `conflict` status