### PR TITLE
feat: add Nextcloud Talk chat channel support

### DIFF
--- a/packages/server/src/nextcloud-talk/__tests__/nextcloud-talk-bridge.test.ts
+++ b/packages/server/src/nextcloud-talk/__tests__/nextcloud-talk-bridge.test.ts
@@ -1,0 +1,679 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { migrateDb, resetDb } from "../../db/index.js";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage } from "@otterbot/shared";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Mock fetch (global)
+// ---------------------------------------------------------------------------
+
+const mockFetchResponses = new Map<string, { ok: boolean; status: number; body: unknown }>();
+
+function setFetchResponse(urlPattern: string, response: { ok?: boolean; status?: number; body: unknown }) {
+  mockFetchResponses.set(urlPattern, {
+    ok: response.ok ?? true,
+    status: response.status ?? 200,
+    body: response.body,
+  });
+}
+
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
+  const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+  for (const [pattern, response] of mockFetchResponses) {
+    if (url.includes(pattern)) {
+      return {
+        ok: response.ok,
+        status: response.status,
+        json: async () => response.body,
+        text: async () => JSON.stringify(response.body),
+      } as Response;
+    }
+  }
+
+  return { ok: false, status: 404, json: async () => ({}), text: async () => "Not found" } as Response;
+}) as typeof fetch;
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+const { NextcloudTalkBridge } = await import("../nextcloud-talk-bridge.js");
+
+interface SendParams {
+  fromAgentId: string | null;
+  toAgentId: string | null;
+  type: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  conversationId?: string;
+}
+
+function createMockBus() {
+  const broadcastHandlers: ((message: BusMessage) => void)[] = [];
+  const sent: SendParams[] = [];
+
+  const bus = {
+    send: vi.fn((params: SendParams) => {
+      sent.push(params);
+      const message: BusMessage = {
+        id: "test-msg-id",
+        fromAgentId: params.fromAgentId,
+        toAgentId: params.toAgentId,
+        type: params.type as BusMessage["type"],
+        content: params.content,
+        metadata: params.metadata ?? {},
+        conversationId: params.conversationId,
+        timestamp: new Date().toISOString(),
+      };
+      return message;
+    }),
+    onBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      broadcastHandlers.push(handler);
+    }),
+    offBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      const idx = broadcastHandlers.indexOf(handler);
+      if (idx >= 0) broadcastHandlers.splice(idx, 1);
+    }),
+    _broadcastHandlers: broadcastHandlers,
+    _sent: sent,
+  };
+
+  return bus;
+}
+
+function createMockCoo() {
+  return {
+    startNewConversation: vi.fn(),
+  };
+}
+
+function createMockIo() {
+  return {
+    emit: vi.fn(),
+  };
+}
+
+const testConfig = {
+  serverUrl: "https://nextcloud.example.com",
+  username: "otterbot",
+  appPassword: "test-app-password",
+};
+
+describe("NextcloudTalkBridge", () => {
+  let tmpDir: string;
+  let bus: ReturnType<typeof createMockBus>;
+  let coo: ReturnType<typeof createMockCoo>;
+  let io: ReturnType<typeof createMockIo>;
+  let bridge: InstanceType<typeof NextcloudTalkBridge>;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-nctalk-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+
+    bus = createMockBus();
+    coo = createMockCoo();
+    io = createMockIo();
+    mockFetchResponses.clear();
+
+    // Default: /ocs/v2.php/cloud/user returns the bot user
+    setFetchResponse("/ocs/v2.php/cloud/user", {
+      body: { ocs: { data: { id: "otterbot", displayname: "Otterbot" } } },
+    });
+
+    bridge = new NextcloudTalkBridge({
+      bus: bus as any,
+      coo: coo as any,
+      io: io as any,
+    });
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+    mockFetchResponses.clear();
+  });
+
+  // -------------------------------------------------------------------------
+  // Connection & Lifecycle
+  // -------------------------------------------------------------------------
+
+  describe("connection initialization", () => {
+    it("authenticates with Nextcloud", async () => {
+      await bridge.start(testConfig);
+
+      const fetchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const authCalls = fetchCalls.filter(
+        (c: unknown[]) => typeof c[0] === "string" && c[0].includes("/ocs/v2.php/cloud/user"),
+      );
+      expect(authCalls.length).toBeGreaterThanOrEqual(1);
+
+      // Check auth header
+      const headers = (authCalls[0]![1] as RequestInit).headers as Record<string, string>;
+      expect(headers.Authorization).toMatch(/^Basic /);
+      expect(headers["OCS-APIRequest"]).toBe("true");
+    });
+
+    it("emits connected status on successful start", async () => {
+      await bridge.start(testConfig);
+
+      expect(io.emit).toHaveBeenCalledWith("nextcloud-talk:status", {
+        status: "connected",
+        botUsername: "Otterbot",
+      });
+    });
+
+    it("subscribes to bus broadcasts", async () => {
+      await bridge.start(testConfig);
+
+      expect(bus.onBroadcast).toHaveBeenCalledOnce();
+    });
+
+    it("throws on auth failure", async () => {
+      setFetchResponse("/ocs/v2.php/cloud/user", {
+        ok: false,
+        status: 401,
+        body: { message: "Unauthorized" },
+      });
+
+      await expect(bridge.start(testConfig)).rejects.toThrow("Nextcloud Talk auth failed");
+    });
+  });
+
+  describe("cleanup on stop", () => {
+    it("unsubscribes from bus broadcasts", async () => {
+      await bridge.start(testConfig);
+      await bridge.stop();
+
+      expect(bus.offBroadcast).toHaveBeenCalledOnce();
+    });
+
+    it("emits disconnected status", async () => {
+      await bridge.start(testConfig);
+      await bridge.stop();
+
+      expect(io.emit).toHaveBeenCalledWith("nextcloud-talk:status", {
+        status: "disconnected",
+      });
+    });
+
+    it("can restart after stop", async () => {
+      await bridge.start(testConfig);
+      await bridge.stop();
+
+      await bridge.start(testConfig);
+
+      expect(io.emit).toHaveBeenCalledWith("nextcloud-talk:status", {
+        status: "connected",
+        botUsername: "Otterbot",
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Message sending
+  // -------------------------------------------------------------------------
+
+  describe("sendMessage", () => {
+    it("sends messages via the OCS API", async () => {
+      await bridge.start(testConfig);
+
+      setFetchResponse("/api/v1/chat/room-token-1", {
+        body: { ocs: { data: {} } },
+      });
+
+      await bridge.sendMessage("room-token-1", "Hello from Otterbot!");
+
+      const fetchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const chatCalls = fetchCalls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          c[0].includes("/api/v1/chat/room-token-1") &&
+          (c[1] as RequestInit)?.method === "POST",
+      );
+      expect(chatCalls.length).toBe(1);
+
+      const body = JSON.parse((chatCalls[0]![1] as RequestInit).body as string);
+      expect(body.message).toBe("Hello from Otterbot!");
+    });
+
+    it("throws on send failure", async () => {
+      await bridge.start(testConfig);
+
+      setFetchResponse("/api/v1/chat/room-token-1", {
+        ok: false,
+        status: 403,
+        body: { message: "Forbidden" },
+      });
+
+      await expect(bridge.sendMessage("room-token-1", "test")).rejects.toThrow(
+        "Failed to send message: HTTP 403",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Outbound Messages (COO → Nextcloud Talk)
+  // -------------------------------------------------------------------------
+
+  describe("outbound messages", () => {
+    it("ignores messages not from COO", async () => {
+      await bridge.start(testConfig);
+
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockClear();
+      setFetchResponse("/ocs/v2.php/cloud/user", {
+        body: { ocs: { data: { id: "otterbot", displayname: "Otterbot" } } },
+      });
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "msg-1",
+        fromAgentId: "some-agent",
+        toAgentId: null,
+        type: MessageType.Chat,
+        content: "Not from COO",
+        metadata: {},
+        conversationId: "conv-1",
+        timestamp: new Date().toISOString(),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const fetchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const chatCalls = fetchCalls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          c[0].includes("/api/v1/chat/"),
+      );
+      expect(chatCalls.length).toBe(0);
+    });
+
+    it("ignores COO messages addressed to another agent", async () => {
+      await bridge.start(testConfig);
+
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockClear();
+      setFetchResponse("/ocs/v2.php/cloud/user", {
+        body: { ocs: { data: { id: "otterbot", displayname: "Otterbot" } } },
+      });
+
+      const broadcastHandler = bus._broadcastHandlers[0]!;
+      broadcastHandler({
+        id: "msg-1",
+        fromAgentId: "coo",
+        toAgentId: "some-agent",
+        type: MessageType.Chat,
+        content: "For another agent",
+        metadata: {},
+        conversationId: "conv-1",
+        timestamp: new Date().toISOString(),
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      const fetchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const chatCalls = fetchCalls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          c[0].includes("/api/v1/chat/"),
+      );
+      expect(chatCalls.length).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getJoinedRooms
+  // -------------------------------------------------------------------------
+
+  describe("getJoinedRooms", () => {
+    it("returns empty array when not started", async () => {
+      const rooms = await bridge.getJoinedRooms();
+      expect(rooms).toEqual([]);
+    });
+
+    it("returns rooms from the API", async () => {
+      await bridge.start(testConfig);
+
+      setFetchResponse("/ocs/v2.php/apps/spreed/api/v4/room", {
+        body: {
+          ocs: {
+            data: [
+              { token: "room1", name: "general", displayName: "General", type: 2 },
+              { token: "room2", name: "random", displayName: "Random", type: 3 },
+            ],
+          },
+        },
+      });
+
+      const rooms = await bridge.getJoinedRooms();
+      expect(rooms).toEqual([
+        { token: "room1", name: "general", displayName: "General", type: 2 },
+        { token: "room2", name: "random", displayName: "Random", type: 3 },
+      ]);
+    });
+
+    it("returns empty array on API error", async () => {
+      await bridge.start(testConfig);
+
+      setFetchResponse("/ocs/v2.php/apps/spreed/api/v4/room", {
+        ok: false,
+        status: 500,
+        body: { message: "Server error" },
+      });
+
+      const rooms = await bridge.getJoinedRooms();
+      expect(rooms).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  describe("error handling", () => {
+    it("does not throw when sendMessage is called after stop", async () => {
+      await bridge.start(testConfig);
+      await bridge.stop();
+
+      // sendMessage should not throw, it should simply return (no config)
+      await expect(bridge.sendMessage("room-token", "hello")).resolves.toBeUndefined();
+    });
+
+    it("handles auth header generation correctly", async () => {
+      await bridge.start(testConfig);
+
+      const fetchCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const authCall = fetchCalls.find(
+        (c: unknown[]) => typeof c[0] === "string" && c[0].includes("/ocs/v2.php/cloud/user"),
+      );
+      const headers = (authCall![1] as RequestInit).headers as Record<string, string>;
+      const expectedAuth = "Basic " + Buffer.from("otterbot:test-app-password").toString("base64");
+      expect(headers.Authorization).toBe(expectedAuth);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Settings tests
+// ---------------------------------------------------------------------------
+
+describe("NextcloudTalkSettings", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-nctalk-settings-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+    mockFetchResponses.clear();
+  });
+
+  afterEach(() => {
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+    mockFetchResponses.clear();
+  });
+
+  it("returns default settings when nothing is configured", async () => {
+    const { getNextcloudTalkSettings } = await import("../nextcloud-talk-settings.js");
+    const settings = getNextcloudTalkSettings();
+
+    expect(settings.enabled).toBe(false);
+    expect(settings.serverUrl).toBeNull();
+    expect(settings.serverUrlSet).toBe(false);
+    expect(settings.usernameSet).toBe(false);
+    expect(settings.appPasswordSet).toBe(false);
+    expect(settings.botUsername).toBeNull();
+    expect(settings.requireMention).toBe(true);
+    expect(settings.allowedConversations).toEqual([]);
+    expect(settings.pairedUsers).toEqual([]);
+    expect(settings.pendingPairings).toEqual([]);
+  });
+
+  it("updates and retrieves settings", async () => {
+    const { getNextcloudTalkSettings, updateNextcloudTalkSettings } = await import(
+      "../nextcloud-talk-settings.js"
+    );
+
+    updateNextcloudTalkSettings({
+      enabled: true,
+      serverUrl: "https://nextcloud.example.com/",
+      username: "otterbot",
+      appPassword: "secret123",
+      requireMention: false,
+      allowedConversations: ["room1", "room2"],
+    });
+
+    const settings = getNextcloudTalkSettings();
+    expect(settings.enabled).toBe(true);
+    expect(settings.serverUrl).toBe("https://nextcloud.example.com"); // trailing slash stripped
+    expect(settings.serverUrlSet).toBe(true);
+    expect(settings.usernameSet).toBe(true);
+    expect(settings.appPasswordSet).toBe(true);
+    expect(settings.botUsername).toBe("otterbot");
+    expect(settings.requireMention).toBe(false);
+    expect(settings.allowedConversations).toEqual(["room1", "room2"]);
+  });
+
+  it("clears settings when empty strings are provided", async () => {
+    const { getNextcloudTalkSettings, updateNextcloudTalkSettings } = await import(
+      "../nextcloud-talk-settings.js"
+    );
+
+    updateNextcloudTalkSettings({
+      serverUrl: "https://nextcloud.example.com",
+      username: "otterbot",
+      appPassword: "secret123",
+    });
+
+    updateNextcloudTalkSettings({
+      serverUrl: "",
+      username: "",
+      appPassword: "",
+    });
+
+    const settings = getNextcloudTalkSettings();
+    expect(settings.serverUrlSet).toBe(false);
+    expect(settings.usernameSet).toBe(false);
+    expect(settings.appPasswordSet).toBe(false);
+  });
+
+  it("tests connection successfully", async () => {
+    const { updateNextcloudTalkSettings, testNextcloudTalkConnection } = await import(
+      "../nextcloud-talk-settings.js"
+    );
+
+    updateNextcloudTalkSettings({
+      serverUrl: "https://nextcloud.example.com",
+      username: "otterbot",
+      appPassword: "secret123",
+    });
+
+    setFetchResponse("/ocs/v2.php/cloud/user", {
+      body: { ocs: { data: { id: "otterbot", displayname: "Otterbot" } } },
+    });
+
+    const result = await testNextcloudTalkConnection();
+    expect(result.ok).toBe(true);
+    expect(result.botUsername).toBe("Otterbot");
+    expect(result.latencyMs).toBeDefined();
+  });
+
+  it("returns error when server URL is not configured", async () => {
+    const { testNextcloudTalkConnection } = await import("../nextcloud-talk-settings.js");
+
+    const result = await testNextcloudTalkConnection();
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Nextcloud server URL not configured.");
+  });
+
+  it("returns error when username is not configured", async () => {
+    const { updateNextcloudTalkSettings, testNextcloudTalkConnection } = await import(
+      "../nextcloud-talk-settings.js"
+    );
+
+    updateNextcloudTalkSettings({ serverUrl: "https://nextcloud.example.com" });
+
+    const result = await testNextcloudTalkConnection();
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Nextcloud username not configured.");
+  });
+
+  it("returns error when app password is not configured", async () => {
+    const { updateNextcloudTalkSettings, testNextcloudTalkConnection } = await import(
+      "../nextcloud-talk-settings.js"
+    );
+
+    updateNextcloudTalkSettings({
+      serverUrl: "https://nextcloud.example.com",
+      username: "otterbot",
+    });
+
+    const result = await testNextcloudTalkConnection();
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Nextcloud app password not configured.");
+  });
+
+  it("returns error on connection failure", async () => {
+    const { updateNextcloudTalkSettings, testNextcloudTalkConnection } = await import(
+      "../nextcloud-talk-settings.js"
+    );
+
+    updateNextcloudTalkSettings({
+      serverUrl: "https://nextcloud.example.com",
+      username: "otterbot",
+      appPassword: "secret123",
+    });
+
+    setFetchResponse("/ocs/v2.php/cloud/user", {
+      ok: false,
+      status: 401,
+      body: "Unauthorized",
+    });
+
+    const result = await testNextcloudTalkConnection();
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("401");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pairing tests
+// ---------------------------------------------------------------------------
+
+describe("NextcloudTalkPairing", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-nctalk-pairing-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+  });
+
+  afterEach(() => {
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("generates and approves pairing codes", async () => {
+    const {
+      generatePairingCode,
+      isPaired,
+      approvePairing,
+      listPairedUsers,
+      listPendingPairings,
+    } = await import("../pairing.js");
+
+    expect(isPaired("user1")).toBe(false);
+
+    const code = generatePairingCode("user1", "Alice");
+    expect(code).toMatch(/^[0-9A-F]{6}$/);
+
+    expect(listPendingPairings().length).toBe(1);
+    expect(listPendingPairings()[0]!.nextcloudUserId).toBe("user1");
+
+    const result = approvePairing(code);
+    expect(result).not.toBeNull();
+    expect(result!.nextcloudUserId).toBe("user1");
+    expect(result!.nextcloudDisplayName).toBe("Alice");
+
+    expect(isPaired("user1")).toBe(true);
+    expect(listPairedUsers().length).toBe(1);
+    expect(listPendingPairings().length).toBe(0);
+  });
+
+  it("rejects pairing codes", async () => {
+    const { generatePairingCode, rejectPairing, isPaired, listPendingPairings } =
+      await import("../pairing.js");
+
+    const code = generatePairingCode("user1", "Alice");
+    expect(listPendingPairings().length).toBe(1);
+
+    const result = rejectPairing(code);
+    expect(result).toBe(true);
+
+    expect(isPaired("user1")).toBe(false);
+    expect(listPendingPairings().length).toBe(0);
+  });
+
+  it("revokes paired users", async () => {
+    const { generatePairingCode, approvePairing, revokePairing, isPaired } =
+      await import("../pairing.js");
+
+    const code = generatePairingCode("user1", "Alice");
+    approvePairing(code);
+    expect(isPaired("user1")).toBe(true);
+
+    const result = revokePairing("user1");
+    expect(result).toBe(true);
+    expect(isPaired("user1")).toBe(false);
+  });
+
+  it("returns false for invalid pairing code", async () => {
+    const { approvePairing, rejectPairing } = await import("../pairing.js");
+
+    expect(approvePairing("INVALID")).toBeNull();
+    expect(rejectPairing("INVALID")).toBe(false);
+  });
+
+  it("returns false when revoking non-existent user", async () => {
+    const { revokePairing } = await import("../pairing.js");
+
+    expect(revokePairing("nonexistent")).toBe(false);
+  });
+
+  it("replaces old pairing code when generating new one", async () => {
+    const { generatePairingCode, listPendingPairings, approvePairing } =
+      await import("../pairing.js");
+
+    const code1 = generatePairingCode("user1", "Alice");
+    const code2 = generatePairingCode("user1", "Alice");
+
+    expect(code1).not.toBe(code2);
+    expect(listPendingPairings().length).toBe(1);
+
+    // Old code should be invalid
+    expect(approvePairing(code1)).toBeNull();
+
+    // New code should work
+    const result = approvePairing(code2);
+    expect(result).not.toBeNull();
+  });
+});

--- a/packages/server/src/nextcloud-talk/nextcloud-talk-bridge.ts
+++ b/packages/server/src/nextcloud-talk/nextcloud-talk-bridge.ts
@@ -1,0 +1,489 @@
+import { nanoid } from "nanoid";
+import { eq } from "drizzle-orm";
+import { Server } from "socket.io";
+import type { ServerToClientEvents, ClientToServerEvents } from "@otterbot/shared";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage, Conversation } from "@otterbot/shared";
+import { MessageBus } from "../bus/message-bus.js";
+import { COO } from "../agents/coo.js";
+import { getDb, schema } from "../db/index.js";
+import { getConfig } from "../auth/auth.js";
+import { isPaired, generatePairingCode, listPairedUsers } from "./pairing.js";
+
+type TypedServer = Server<ClientToServerEvents, ServerToClientEvents>;
+
+// ---------------------------------------------------------------------------
+// Nextcloud Talk Bridge
+// ---------------------------------------------------------------------------
+
+const NC_TALK_MAX_LENGTH = 32000;
+const POLL_INTERVAL_MS = 3000;
+
+export interface NextcloudTalkConfig {
+  serverUrl: string;
+  username: string;
+  appPassword: string;
+}
+
+interface PendingResponse {
+  conversationToken: string;
+  conversationId: string;
+}
+
+interface NcTalkMessage {
+  id: number;
+  actorType: string;
+  actorId: string;
+  actorDisplayName: string;
+  message: string;
+  timestamp: number;
+  token: string;
+  messageType: string;
+  systemMessage: string;
+}
+
+interface NcTalkRoom {
+  token: string;
+  name: string;
+  displayName: string;
+  type: number; // 1=one-to-one, 2=group, 3=public, 4=changelog
+  lastMessage?: NcTalkMessage;
+}
+
+export class NextcloudTalkBridge {
+  private bus: MessageBus;
+  private coo: COO;
+  private io: TypedServer;
+  private config: NextcloudTalkConfig | null = null;
+  private broadcastHandler: ((message: BusMessage) => void) | null = null;
+  /** Map of `{nextcloudUserId}:{roomToken}` → conversationId */
+  private conversationMap = new Map<string, string>();
+  /** Map of conversationId → roomToken for sending responses */
+  private channelMap = new Map<string, string>();
+  private pendingResponses = new Map<string, PendingResponse>();
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private polling = false;
+  /** Track last known message ID per room to only fetch new messages */
+  private lastKnownMessageId = new Map<string, number>();
+
+  constructor(deps: { bus: MessageBus; coo: COO; io: TypedServer }) {
+    this.bus = deps.bus;
+    this.coo = deps.coo;
+    this.io = deps.io;
+  }
+
+  async start(config: NextcloudTalkConfig): Promise<void> {
+    if (this.polling) {
+      await this.stop();
+    }
+
+    this.config = config;
+
+    // Validate credentials by fetching current user
+    const authHeader = this.getAuthHeader();
+    const res = await fetch(`${config.serverUrl}/ocs/v2.php/cloud/user`, {
+      headers: {
+        Authorization: authHeader,
+        "OCS-APIRequest": "true",
+        Accept: "application/json",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Nextcloud Talk auth failed: HTTP ${res.status}`);
+    }
+
+    const userData = (await res.json()) as {
+      ocs?: { data?: { id?: string; displayname?: string } };
+    };
+    const displayName = userData.ocs?.data?.displayname ?? config.username;
+
+    this.polling = true;
+    console.log(`[Nextcloud Talk] Connected as ${displayName}`);
+    this.io.emit("nextcloud-talk:status", {
+      status: "connected",
+      botUsername: displayName,
+    });
+
+    // Subscribe to bus broadcasts to intercept COO responses
+    this.broadcastHandler = (message: BusMessage) => {
+      this.handleBusMessage(message);
+    };
+    this.bus.onBroadcast(this.broadcastHandler);
+
+    // Start polling for new messages
+    this.schedulePoll();
+  }
+
+  async stop(): Promise<void> {
+    this.polling = false;
+
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+
+    this.pendingResponses.clear();
+
+    if (this.broadcastHandler) {
+      this.bus.offBroadcast(this.broadcastHandler);
+      this.broadcastHandler = null;
+    }
+
+    if (this.config) {
+      this.io.emit("nextcloud-talk:status", { status: "disconnected" });
+    }
+
+    this.config = null;
+  }
+
+  async getJoinedRooms(): Promise<NcTalkRoom[]> {
+    if (!this.config) return [];
+
+    try {
+      const res = await fetch(
+        `${this.config.serverUrl}/ocs/v2.php/apps/spreed/api/v4/room`,
+        {
+          headers: {
+            Authorization: this.getAuthHeader(),
+            "OCS-APIRequest": "true",
+            Accept: "application/json",
+          },
+        },
+      );
+      if (!res.ok) return [];
+      const data = (await res.json()) as { ocs?: { data?: NcTalkRoom[] } };
+      return data.ocs?.data ?? [];
+    } catch (err) {
+      console.error("[Nextcloud Talk] Error fetching rooms:", err);
+      return [];
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Polling
+  // -------------------------------------------------------------------------
+
+  private schedulePoll(): void {
+    if (!this.polling || this.pollTimer) return;
+    this.pollTimer = setTimeout(async () => {
+      this.pollTimer = null;
+      await this.pollMessages();
+      if (this.polling) {
+        this.schedulePoll();
+      }
+    }, POLL_INTERVAL_MS);
+  }
+
+  private async pollMessages(): Promise<void> {
+    if (!this.config) return;
+
+    try {
+      const rooms = await this.getJoinedRooms();
+
+      // Check allowed conversations filter
+      const raw = getConfig("nextcloud-talk:allowed_conversations");
+      let allowedConversations: string[] = [];
+      if (raw) {
+        try { allowedConversations = JSON.parse(raw); } catch { /* ignore */ }
+      }
+
+      for (const room of rooms) {
+        // Skip changelog rooms
+        if (room.type === 4) continue;
+
+        // If allowed conversations list is set and non-empty, filter
+        if (allowedConversations.length > 0 && !allowedConversations.includes(room.token)) {
+          // Always allow 1-to-1 conversations (DMs)
+          if (room.type !== 1) continue;
+        }
+
+        await this.pollRoomMessages(room);
+      }
+    } catch (err) {
+      console.error("[Nextcloud Talk] Poll error:", err);
+      this.io.emit("nextcloud-talk:status", { status: "error" });
+    }
+  }
+
+  private async pollRoomMessages(room: NcTalkRoom): Promise<void> {
+    if (!this.config) return;
+
+    const lastKnown = this.lastKnownMessageId.get(room.token) ?? 0;
+
+    try {
+      // Use lookIntoFuture=1 with lastKnownMessageId to get only new messages
+      let url = `${this.config.serverUrl}/ocs/v2.php/apps/spreed/api/v1/chat/${room.token}?limit=100&setReadMarker=0`;
+      if (lastKnown > 0) {
+        url += `&lookIntoFuture=1&lastKnownMessageId=${lastKnown}`;
+      } else {
+        // First poll: get last few messages to establish baseline
+        url += `&lookIntoFuture=0`;
+      }
+
+      const res = await fetch(url, {
+        headers: {
+          Authorization: this.getAuthHeader(),
+          "OCS-APIRequest": "true",
+          Accept: "application/json",
+        },
+      });
+
+      // 304 = no new messages
+      if (res.status === 304) return;
+      if (!res.ok) return;
+
+      const data = (await res.json()) as {
+        ocs?: { data?: NcTalkMessage[] };
+      };
+      const messages = data.ocs?.data ?? [];
+
+      if (messages.length === 0) return;
+
+      // Update last known message ID
+      const maxId = Math.max(...messages.map((m) => m.id));
+      this.lastKnownMessageId.set(room.token, maxId);
+
+      // On first poll, just record the baseline — don't process old messages
+      if (lastKnown === 0) return;
+
+      // Process new messages
+      for (const msg of messages) {
+        await this.handleMessage(msg, room);
+      }
+    } catch (err) {
+      console.error(`[Nextcloud Talk] Error polling room ${room.token}:`, err);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Inbound: Nextcloud Talk → COO
+  // -------------------------------------------------------------------------
+
+  private async handleMessage(msg: NcTalkMessage, room: NcTalkRoom): Promise<void> {
+    // Ignore system messages
+    if (msg.systemMessage) return;
+
+    // Ignore own messages
+    if (msg.actorId === this.config?.username) return;
+
+    // Ignore non-user messages (bots, guests, etc. unless actorType is "users")
+    if (msg.actorType !== "users") return;
+
+    const isDM = room.type === 1;
+    const requireMention = getConfig("nextcloud-talk:require_mention") !== "false";
+    const botUsername = this.config?.username;
+
+    // In group/public rooms, only respond to @mentions (unless require_mention is off)
+    if (!isDM && requireMention) {
+      if (!botUsername || !msg.message.includes(`@${botUsername}`)) {
+        return;
+      }
+    }
+
+    const nextcloudUserId = msg.actorId;
+    const nextcloudDisplayName = msg.actorDisplayName || msg.actorId;
+
+    // Check pairing
+    if (!isPaired(nextcloudUserId)) {
+      const code = generatePairingCode(nextcloudUserId, nextcloudDisplayName);
+      await this.sendMessage(
+        room.token,
+        `I don't recognize you yet. To pair with me, ask my owner to approve this code in the Otterbot dashboard:\n\n**\`${code}\`**\n\nThis code expires in 1 hour.`,
+      );
+      this.io.emit("nextcloud-talk:pairing-request", {
+        code,
+        nextcloudUserId,
+        nextcloudDisplayName,
+      });
+      return;
+    }
+
+    // Extract content — strip bot mention if present
+    let content = msg.message;
+    if (botUsername) {
+      content = content.replace(new RegExp(`@${botUsername}\\b`, "g"), "").trim();
+    }
+    if (!content) return;
+
+    // Route to COO
+    await this.routeToCOO(room.token, nextcloudUserId, nextcloudDisplayName, content);
+  }
+
+  private async routeToCOO(
+    roomToken: string,
+    nextcloudUserId: string,
+    nextcloudDisplayName: string,
+    content: string,
+  ): Promise<void> {
+    const convKey = `${nextcloudUserId}:${roomToken}`;
+
+    const db = getDb();
+    let conversationId = this.conversationMap.get(convKey);
+
+    if (!conversationId) {
+      conversationId = nanoid();
+      const now = new Date().toISOString();
+      const title = `Nextcloud Talk: ${nextcloudDisplayName} — ${content.slice(0, 60)}`;
+      const conversation: Conversation = {
+        id: conversationId,
+        title,
+        projectId: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      db.insert(schema.conversations).values(conversation).run();
+      this.coo.startNewConversation(conversationId, null, null);
+      this.io.emit("conversation:created", conversation);
+      this.conversationMap.set(convKey, conversationId);
+    } else {
+      db.update(schema.conversations)
+        .set({ updatedAt: new Date().toISOString() })
+        .where(eq(schema.conversations.id, conversationId))
+        .run();
+    }
+
+    this.channelMap.set(conversationId, roomToken);
+
+    // Track pending response
+    this.pendingResponses.set(conversationId, {
+      conversationToken: roomToken,
+      conversationId,
+    });
+
+    // Send to COO via bus
+    this.bus.send({
+      fromAgentId: null,
+      toAgentId: "coo",
+      type: MessageType.Chat,
+      content,
+      conversationId,
+      metadata: {
+        source: "nextcloud-talk",
+        nextcloudUserId,
+        nextcloudRoomToken: roomToken,
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound: COO → Nextcloud Talk
+  // -------------------------------------------------------------------------
+
+  private handleBusMessage(message: BusMessage): void {
+    // Only care about COO → CEO (null) responses
+    if (message.fromAgentId !== "coo" || message.toAgentId !== null) return;
+
+    const conversationId = message.conversationId;
+
+    if (conversationId) {
+      const pending = this.pendingResponses.get(conversationId);
+      if (pending) {
+        this.pendingResponses.delete(conversationId);
+        this.sendReply(pending.conversationToken, message.content).catch((err) => {
+          console.error("[Nextcloud Talk] Error sending reply:", err);
+        });
+        return;
+      }
+
+      // Unsolicited message to a known Nextcloud Talk room
+      const roomToken = this.channelMap.get(conversationId);
+      if (roomToken) {
+        this.sendReply(roomToken, message.content).catch((err) => {
+          console.error("[Nextcloud Talk] Error sending unsolicited message:", err);
+        });
+        return;
+      }
+    }
+  }
+
+  private async sendReply(roomToken: string, content: string): Promise<void> {
+    const chunks = splitMessage(content, NC_TALK_MAX_LENGTH);
+    for (const chunk of chunks) {
+      await this.sendMessage(roomToken, chunk);
+    }
+  }
+
+  async sendMessage(roomToken: string, message: string): Promise<void> {
+    if (!this.config) return;
+
+    const res = await fetch(
+      `${this.config.serverUrl}/ocs/v2.php/apps/spreed/api/v1/chat/${roomToken}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: this.getAuthHeader(),
+          "OCS-APIRequest": "true",
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ message }),
+      },
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Failed to send message: HTTP ${res.status} — ${text.slice(0, 200)}`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private getAuthHeader(): string {
+    if (!this.config) return "";
+    return "Basic " + Buffer.from(`${this.config.username}:${this.config.appPassword}`).toString("base64");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message splitting
+// ---------------------------------------------------------------------------
+
+function splitMessage(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLength) {
+    let splitIdx = -1;
+
+    // Try to split at paragraph boundary
+    const paragraphIdx = remaining.lastIndexOf("\n\n", maxLength);
+    if (paragraphIdx > maxLength * 0.3) {
+      splitIdx = paragraphIdx;
+    }
+
+    // Try sentence boundary
+    if (splitIdx === -1) {
+      const sentenceMatch = remaining.slice(0, maxLength).match(/.*[.!?]\s/s);
+      if (sentenceMatch) {
+        splitIdx = sentenceMatch[0].length;
+      }
+    }
+
+    // Hard cut at newline
+    if (splitIdx === -1) {
+      const newlineIdx = remaining.lastIndexOf("\n", maxLength);
+      if (newlineIdx > maxLength * 0.3) {
+        splitIdx = newlineIdx;
+      }
+    }
+
+    // Final fallback: hard cut
+    if (splitIdx === -1) {
+      splitIdx = maxLength;
+    }
+
+    chunks.push(remaining.slice(0, splitIdx).trimEnd());
+    remaining = remaining.slice(splitIdx).trimStart();
+  }
+
+  if (remaining) {
+    chunks.push(remaining);
+  }
+
+  return chunks;
+}

--- a/packages/server/src/nextcloud-talk/nextcloud-talk-settings.ts
+++ b/packages/server/src/nextcloud-talk/nextcloud-talk-settings.ts
@@ -1,0 +1,140 @@
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+import { listPairedUsers, listPendingPairings } from "./pairing.js";
+import type { PairedUser, PendingPairing } from "./pairing.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NextcloudTalkSettingsResponse {
+  enabled: boolean;
+  serverUrl: string | null;
+  serverUrlSet: boolean;
+  usernameSet: boolean;
+  appPasswordSet: boolean;
+  botUsername: string | null;
+  requireMention: boolean;
+  allowedConversations: string[];
+  pairedUsers: PairedUser[];
+  pendingPairings: PendingPairing[];
+}
+
+export interface NextcloudTalkTestResult {
+  ok: boolean;
+  error?: string;
+  latencyMs?: number;
+  botUsername?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Settings CRUD
+// ---------------------------------------------------------------------------
+
+export function getNextcloudTalkSettings(): NextcloudTalkSettingsResponse {
+  const raw = getConfig("nextcloud-talk:allowed_conversations");
+  let allowedConversations: string[] = [];
+  if (raw) {
+    try { allowedConversations = JSON.parse(raw); } catch { /* ignore */ }
+  }
+
+  return {
+    enabled: getConfig("nextcloud-talk:enabled") === "true",
+    serverUrl: getConfig("nextcloud-talk:server_url") ?? null,
+    serverUrlSet: !!getConfig("nextcloud-talk:server_url"),
+    usernameSet: !!getConfig("nextcloud-talk:username"),
+    appPasswordSet: !!getConfig("nextcloud-talk:app_password"),
+    botUsername: getConfig("nextcloud-talk:username") ?? null,
+    requireMention: getConfig("nextcloud-talk:require_mention") !== "false", // default true
+    allowedConversations,
+    pairedUsers: listPairedUsers(),
+    pendingPairings: listPendingPairings(),
+  };
+}
+
+export function updateNextcloudTalkSettings(data: {
+  enabled?: boolean;
+  serverUrl?: string;
+  username?: string;
+  appPassword?: string;
+  requireMention?: boolean;
+  allowedConversations?: string[];
+}): void {
+  if (data.enabled !== undefined) {
+    setConfig("nextcloud-talk:enabled", data.enabled ? "true" : "false");
+  }
+  if (data.serverUrl !== undefined) {
+    if (data.serverUrl === "") {
+      deleteConfig("nextcloud-talk:server_url");
+    } else {
+      // Normalize: strip trailing slash
+      setConfig("nextcloud-talk:server_url", data.serverUrl.replace(/\/+$/, ""));
+    }
+  }
+  if (data.username !== undefined) {
+    if (data.username === "") {
+      deleteConfig("nextcloud-talk:username");
+    } else {
+      setConfig("nextcloud-talk:username", data.username);
+    }
+  }
+  if (data.appPassword !== undefined) {
+    if (data.appPassword === "") {
+      deleteConfig("nextcloud-talk:app_password");
+    } else {
+      setConfig("nextcloud-talk:app_password", data.appPassword);
+    }
+  }
+  if (data.requireMention !== undefined) {
+    setConfig("nextcloud-talk:require_mention", data.requireMention ? "true" : "false");
+  }
+  if (data.allowedConversations !== undefined) {
+    setConfig("nextcloud-talk:allowed_conversations", JSON.stringify(data.allowedConversations));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connection test
+// ---------------------------------------------------------------------------
+
+export async function testNextcloudTalkConnection(): Promise<NextcloudTalkTestResult> {
+  const serverUrl = getConfig("nextcloud-talk:server_url");
+  const username = getConfig("nextcloud-talk:username");
+  const appPassword = getConfig("nextcloud-talk:app_password");
+  if (!serverUrl) return { ok: false, error: "Nextcloud server URL not configured." };
+  if (!username) return { ok: false, error: "Nextcloud username not configured." };
+  if (!appPassword) return { ok: false, error: "Nextcloud app password not configured." };
+
+  const start = Date.now();
+  const authHeader = "Basic " + Buffer.from(`${username}:${appPassword}`).toString("base64");
+
+  try {
+    const res = await fetch(`${serverUrl}/ocs/v2.php/cloud/user`, {
+      headers: {
+        Authorization: authHeader,
+        "OCS-APIRequest": "true",
+        Accept: "application/json",
+      },
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      return { ok: false, error: `HTTP ${res.status}: ${body.slice(0, 200)}` };
+    }
+
+    const data = (await res.json()) as {
+      ocs?: { data?: { id?: string; displayname?: string } };
+    };
+    const displayName = data.ocs?.data?.displayname ?? data.ocs?.data?.id ?? username;
+
+    return {
+      ok: true,
+      latencyMs: Date.now() - start,
+      botUsername: displayName,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/packages/server/src/nextcloud-talk/pairing.ts
+++ b/packages/server/src/nextcloud-talk/pairing.ts
@@ -1,0 +1,165 @@
+import { randomBytes } from "node:crypto";
+import { like } from "drizzle-orm";
+import { getDb, schema } from "../db/index.js";
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateCode(): string {
+  return randomBytes(3).toString("hex").toUpperCase(); // 6-char hex
+}
+
+const PAIRING_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export interface PendingPairing {
+  code: string;
+  nextcloudUserId: string;
+  nextcloudDisplayName: string;
+  createdAt: string;
+}
+
+export interface PairedUser {
+  nextcloudUserId: string;
+  nextcloudDisplayName: string;
+  pairedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Config-prefix query helper
+// ---------------------------------------------------------------------------
+
+function getConfigsByPrefix(prefix: string): Array<{ key: string; value: string }> {
+  const db = getDb();
+  return db
+    .select({ key: schema.config.key, value: schema.config.value })
+    .from(schema.config)
+    .where(like(schema.config.key, `${prefix}%`))
+    .all();
+}
+
+// ---------------------------------------------------------------------------
+// Pairing code management
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a pairing code for a Nextcloud Talk user.
+ * Only one active code per user — generating a new one deletes the old.
+ */
+export function generatePairingCode(nextcloudUserId: string, nextcloudDisplayName: string): string {
+  // Remove any existing code for this user
+  const existing = getConfigsByPrefix("nextcloud-talk:pairing:");
+  for (const row of existing) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (data.nextcloudUserId === nextcloudUserId) {
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+
+  const code = generateCode();
+  const data: PendingPairing = {
+    code,
+    nextcloudUserId,
+    nextcloudDisplayName,
+    createdAt: new Date().toISOString(),
+  };
+  setConfig(`nextcloud-talk:pairing:${code}`, JSON.stringify(data));
+  return code;
+}
+
+/**
+ * Check whether a Nextcloud Talk user is paired.
+ */
+export function isPaired(nextcloudUserId: string): boolean {
+  return !!getConfig(`nextcloud-talk:paired:${nextcloudUserId}`);
+}
+
+/**
+ * Approve a pending pairing by code.
+ * Returns the paired user info, or null if the code is invalid/expired.
+ */
+export function approvePairing(code: string): PairedUser | null {
+  const raw = getConfig(`nextcloud-talk:pairing:${code}`);
+  if (!raw) return null;
+
+  let pending: PendingPairing;
+  try {
+    pending = JSON.parse(raw) as PendingPairing;
+  } catch {
+    return null;
+  }
+
+  // Check expiry
+  if (Date.now() - new Date(pending.createdAt).getTime() > PAIRING_TTL_MS) {
+    deleteConfig(`nextcloud-talk:pairing:${code}`);
+    return null;
+  }
+
+  const paired: PairedUser = {
+    nextcloudUserId: pending.nextcloudUserId,
+    nextcloudDisplayName: pending.nextcloudDisplayName,
+    pairedAt: new Date().toISOString(),
+  };
+
+  setConfig(`nextcloud-talk:paired:${pending.nextcloudUserId}`, JSON.stringify(paired));
+  deleteConfig(`nextcloud-talk:pairing:${code}`);
+  return paired;
+}
+
+/**
+ * Reject (delete) a pending pairing code.
+ */
+export function rejectPairing(code: string): boolean {
+  const raw = getConfig(`nextcloud-talk:pairing:${code}`);
+  if (!raw) return false;
+  deleteConfig(`nextcloud-talk:pairing:${code}`);
+  return true;
+}
+
+/**
+ * Revoke a paired user's access.
+ */
+export function revokePairing(nextcloudUserId: string): boolean {
+  const raw = getConfig(`nextcloud-talk:paired:${nextcloudUserId}`);
+  if (!raw) return false;
+  deleteConfig(`nextcloud-talk:paired:${nextcloudUserId}`);
+  return true;
+}
+
+/**
+ * List all paired users.
+ */
+export function listPairedUsers(): PairedUser[] {
+  const rows = getConfigsByPrefix("nextcloud-talk:paired:");
+  const users: PairedUser[] = [];
+  for (const row of rows) {
+    try {
+      users.push(JSON.parse(row.value) as PairedUser);
+    } catch { /* ignore malformed */ }
+  }
+  return users;
+}
+
+/**
+ * List all pending (non-expired) pairing codes.
+ */
+export function listPendingPairings(): PendingPairing[] {
+  const rows = getConfigsByPrefix("nextcloud-talk:pairing:");
+  const now = Date.now();
+  const pending: PendingPairing[] = [];
+  for (const row of rows) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (now - new Date(data.createdAt).getTime() <= PAIRING_TTL_MS) {
+        pending.push(data);
+      } else {
+        // Clean up expired
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+  return pending;
+}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -67,6 +67,8 @@ export interface ServerToClientEvents {
   "whatsapp:status": (data: { status: "connected" | "disconnected" | "qr" | "authenticated" | "auth_failure"; qr?: string }) => void;
   "signal:pairing-request": (data: { code: string; signalNumber: string }) => void;
   "signal:status": (data: { status: "connected" | "disconnected" | "error"; phoneNumber?: string }) => void;
+  "nextcloud-talk:pairing-request": (data: { code: string; nextcloudUserId: string; nextcloudDisplayName: string }) => void;
+  "nextcloud-talk:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
   "merge-queue:updated": (data: { entries: MergeQueueEntry[] }) => void;
   "merge-queue:entry-updated": (entry: MergeQueueEntry) => void;
 }

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -39,7 +39,7 @@ export interface AgentModelOverride {
 }
 
 /** Supported messaging-platform chat provider types. */
-export type ChatProviderType = "discord" | "matrix" | "irc" | "teams" | "telegram" | "tlon" | "whatsapp" | "signal";
+export type ChatProviderType = "discord" | "matrix" | "irc" | "teams" | "telegram" | "tlon" | "whatsapp" | "signal" | "nextcloud-talk";
 
 /** Settings common to all chat provider bridges. */
 export interface ChatProviderSettings {
@@ -61,4 +61,13 @@ export interface TeamsChatProviderSettings extends ChatProviderSettings {
   appIdSet: boolean;
   appPasswordSet: boolean;
   tenantId: string | null;
+}
+
+/** Nextcloud Talk-specific chat provider settings exposed to the client. */
+export interface NextcloudTalkChatProviderSettings extends ChatProviderSettings {
+  type: "nextcloud-talk";
+  serverUrl: string | null;
+  usernameSet: boolean;
+  appPasswordSet: boolean;
+  botUsername: string | null;
 }

--- a/packages/web/src/components/settings/NextcloudTalkSection.tsx
+++ b/packages/web/src/components/settings/NextcloudTalkSection.tsx
@@ -1,0 +1,365 @@
+import { useState, useEffect } from "react";
+import { cn } from "../../lib/utils";
+import { useSettingsStore } from "../../stores/settings-store";
+import { getSocket } from "../../lib/socket";
+
+export function NextcloudTalkSection() {
+  const enabled = useSettingsStore((s) => s.nextcloudTalkEnabled);
+  const serverUrlSet = useSettingsStore((s) => s.nextcloudTalkServerUrlSet);
+  const usernameSet = useSettingsStore((s) => s.nextcloudTalkUsernameSet);
+  const appPasswordSet = useSettingsStore((s) => s.nextcloudTalkAppPasswordSet);
+  const botUsername = useSettingsStore((s) => s.nextcloudTalkBotUsername);
+  const requireMention = useSettingsStore((s) => s.nextcloudTalkRequireMention);
+  const testResult = useSettingsStore((s) => s.nextcloudTalkTestResult);
+  const pairedUsers = useSettingsStore((s) => s.nextcloudTalkPairedUsers);
+  const pendingPairings = useSettingsStore((s) => s.nextcloudTalkPendingPairings);
+  const loadNextcloudTalkSettings = useSettingsStore((s) => s.loadNextcloudTalkSettings);
+  const updateNextcloudTalkSettings = useSettingsStore((s) => s.updateNextcloudTalkSettings);
+  const testNextcloudTalkConnection = useSettingsStore((s) => s.testNextcloudTalkConnection);
+  const approveNextcloudTalkPairing = useSettingsStore((s) => s.approveNextcloudTalkPairing);
+  const rejectNextcloudTalkPairing = useSettingsStore((s) => s.rejectNextcloudTalkPairing);
+  const revokeNextcloudTalkUser = useSettingsStore((s) => s.revokeNextcloudTalkUser);
+
+  const [localServerUrl, setLocalServerUrl] = useState("");
+  const [localUsername, setLocalUsername] = useState("");
+  const [localAppPassword, setLocalAppPassword] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [botStatus, setBotStatus] = useState<"connected" | "disconnected" | "error">("disconnected");
+
+  useEffect(() => {
+    loadNextcloudTalkSettings();
+  }, []);
+
+  // Listen for real-time Nextcloud Talk events
+  useEffect(() => {
+    const socket = getSocket();
+
+    const handleStatus = (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => {
+      setBotStatus(data.status);
+      if (data.status === "connected") {
+        loadNextcloudTalkSettings();
+      }
+    };
+
+    const handlePairingRequest = () => {
+      loadNextcloudTalkSettings();
+    };
+
+    socket.on("nextcloud-talk:status", handleStatus);
+    socket.on("nextcloud-talk:pairing-request", handlePairingRequest);
+
+    return () => {
+      socket.off("nextcloud-talk:status", handleStatus);
+      socket.off("nextcloud-talk:pairing-request", handlePairingRequest);
+    };
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    const data: { serverUrl?: string; username?: string; appPassword?: string } = {};
+    if (localServerUrl) data.serverUrl = localServerUrl;
+    if (localUsername) data.username = localUsername;
+    if (localAppPassword) data.appPassword = localAppPassword;
+    await updateNextcloudTalkSettings(data);
+    setLocalServerUrl("");
+    setLocalUsername("");
+    setLocalAppPassword("");
+    setSaving(false);
+  };
+
+  const handleToggleEnabled = async () => {
+    await updateNextcloudTalkSettings({ enabled: !enabled });
+  };
+
+  const handleToggleMention = async () => {
+    await updateNextcloudTalkSettings({ requireMention: !requireMention });
+  };
+
+  const handleTest = () => {
+    testNextcloudTalkConnection();
+  };
+
+  const handleClearCredentials = async () => {
+    setSaving(true);
+    await updateNextcloudTalkSettings({ username: "", appPassword: "" });
+    setLocalUsername("");
+    setLocalAppPassword("");
+    setSaving(false);
+  };
+
+  return (
+    <div className="p-5 space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Connect Otterbot to Nextcloud Talk. Users must pair with the bot before it
+        responds to their messages.
+      </p>
+
+      {/* Enable toggle */}
+      <label className="flex items-center gap-3 cursor-pointer">
+        <button
+          onClick={handleToggleEnabled}
+          className={cn(
+            "relative w-9 h-5 rounded-full transition-colors",
+            enabled ? "bg-primary" : "bg-secondary",
+          )}
+        >
+          <span
+            className={cn(
+              "absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform",
+              enabled && "translate-x-4",
+            )}
+          />
+        </button>
+        <span className="text-sm">Enable Nextcloud Talk integration</span>
+      </label>
+
+      {/* Connection section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <div>
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Server URL
+            {serverUrlSet && (
+              <span className="ml-2 text-green-500 normal-case tracking-normal">
+                Set
+              </span>
+            )}
+          </label>
+          <input
+            type="text"
+            value={localServerUrl}
+            onChange={(e) => setLocalServerUrl(e.target.value)}
+            placeholder="https://your-nextcloud-server.com"
+            className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+          />
+        </div>
+
+        <div>
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Username
+            {usernameSet && (
+              <span className="ml-2 text-green-500 normal-case tracking-normal">
+                Set
+              </span>
+            )}
+          </label>
+          <input
+            type="text"
+            value={localUsername}
+            onChange={(e) => setLocalUsername(e.target.value)}
+            placeholder={
+              usernameSet ? "Enter new username to change" : "Nextcloud username"
+            }
+            className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+          />
+        </div>
+
+        <div>
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            App Password
+            {appPasswordSet && (
+              <span className="ml-2 text-green-500 normal-case tracking-normal">
+                Set
+              </span>
+            )}
+          </label>
+          <input
+            type="password"
+            value={localAppPassword}
+            onChange={(e) => setLocalAppPassword(e.target.value)}
+            placeholder={
+              appPasswordSet ? "Enter new password to change" : "Paste your app password"
+            }
+            className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary font-mono"
+          />
+          <p className="text-[10px] text-muted-foreground mt-1">
+            Generate an app password in Nextcloud under Settings &gt; Security &gt; Devices &amp; sessions.
+          </p>
+        </div>
+
+        {botUsername && (
+          <div className="text-xs text-muted-foreground">
+            Bot: <span className="text-foreground font-medium">{botUsername}</span>
+            {enabled && usernameSet && appPasswordSet && serverUrlSet && (
+              <span className={cn(
+                "ml-2 text-[10px] px-1.5 py-0.5 rounded",
+                botStatus === "connected"
+                  ? "text-green-500 bg-green-500/10"
+                  : botStatus === "error"
+                    ? "text-red-500 bg-red-500/10"
+                    : "text-muted-foreground bg-muted",
+              )}>
+                {botStatus === "connected" ? "Online" : botStatus === "error" ? "Error" : "Offline"}
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 pt-1">
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="text-xs bg-primary text-primary-foreground px-3 py-1.5 rounded-md hover:bg-primary/90 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+          <button
+            onClick={handleTest}
+            disabled={testResult?.testing || !usernameSet || !appPasswordSet || !serverUrlSet}
+            className="text-xs bg-secondary text-foreground px-3 py-1.5 rounded-md hover:bg-secondary/80 disabled:opacity-50"
+          >
+            {testResult?.testing ? "Testing..." : "Test Connection"}
+          </button>
+          {(usernameSet || appPasswordSet) && (
+            <button
+              onClick={handleClearCredentials}
+              disabled={saving}
+              className="text-xs text-red-500 hover:text-red-400 px-2 py-1.5"
+            >
+              Clear Credentials
+            </button>
+          )}
+
+          {testResult && !testResult.testing && (
+            <span
+              className={cn(
+                "text-xs",
+                testResult.ok ? "text-green-500" : "text-red-500",
+              )}
+            >
+              {testResult.ok
+                ? "\u2713 Connected"
+                : `\u2717 ${testResult.error ?? "Failed"}`}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Behavior section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Behavior
+        </label>
+        <label className="flex items-center gap-3 cursor-pointer">
+          <button
+            onClick={handleToggleMention}
+            className={cn(
+              "relative w-9 h-5 rounded-full transition-colors",
+              requireMention ? "bg-primary" : "bg-secondary",
+            )}
+          >
+            <span
+              className={cn(
+                "absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform",
+                requireMention && "translate-x-4",
+              )}
+            />
+          </button>
+          <div>
+            <span className="text-sm">Require @mention in group conversations</span>
+            <p className="text-[10px] text-muted-foreground">
+              When enabled, the bot only responds to messages that @mention it in group conversations. One-to-one chats always work.
+            </p>
+          </div>
+        </label>
+      </div>
+
+      {/* Paired Users section */}
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+          Paired Users
+          <span className="ml-2 normal-case tracking-normal text-foreground">
+            {pairedUsers.length}
+          </span>
+        </label>
+
+        {pairedUsers.length === 0 ? (
+          <p className="text-[10px] text-muted-foreground">
+            No users have been paired yet. When someone messages the bot, they'll receive a pairing code to approve here.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {pairedUsers.map((user) => (
+              <div
+                key={user.nextcloudUserId}
+                className="flex items-center justify-between bg-secondary rounded-md px-3 py-2"
+              >
+                <div>
+                  <span className="text-xs font-medium">{user.nextcloudDisplayName}</span>
+                  <span className="text-[10px] text-muted-foreground ml-2">
+                    Paired {new Date(user.pairedAt).toLocaleDateString()}
+                  </span>
+                </div>
+                <button
+                  onClick={() => revokeNextcloudTalkUser(user.nextcloudUserId)}
+                  className="text-[10px] text-red-500 hover:text-red-400 px-2 py-1"
+                >
+                  Revoke
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Pending Pairings section */}
+      {pendingPairings.length > 0 && (
+        <div className="border border-border rounded-lg p-4 space-y-3">
+          <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
+            Pending Pairings
+            <span className="ml-2 normal-case tracking-normal text-yellow-500">
+              {pendingPairings.length}
+            </span>
+          </label>
+
+          <div className="space-y-2">
+            {pendingPairings.map((pairing) => (
+              <div
+                key={pairing.code}
+                className="flex items-center justify-between bg-secondary rounded-md px-3 py-2"
+              >
+                <div>
+                  <span className="text-xs font-medium">{pairing.nextcloudDisplayName}</span>
+                  <code className="text-[10px] bg-muted px-1.5 py-0.5 rounded ml-2 font-mono">
+                    {pairing.code}
+                  </code>
+                  <span className="text-[10px] text-muted-foreground ml-2">
+                    {new Date(pairing.createdAt).toLocaleTimeString()}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => approveNextcloudTalkPairing(pairing.code)}
+                    className="text-[10px] text-green-500 hover:text-green-400 bg-green-500/10 px-2 py-1 rounded"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => rejectNextcloudTalkPairing(pairing.code)}
+                    className="text-[10px] text-red-500 hover:text-red-400 px-2 py-1"
+                  >
+                    Reject
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Setup instructions */}
+      <div className="text-[10px] text-muted-foreground space-y-1">
+        <p>
+          <strong>How to set up Nextcloud Talk:</strong>
+        </p>
+        <ol className="list-decimal list-inside space-y-0.5">
+          <li>Create a dedicated Nextcloud user account for the bot (or use an existing one)</li>
+          <li>Log in as that user and go to Settings &gt; Security &gt; Devices &amp; sessions</li>
+          <li>Create a new app password and copy it</li>
+          <li>Enter the Nextcloud server URL, username, and app password above</li>
+          <li>Add the bot user to the Talk conversations you want it to participate in</li>
+          <li>Users who message the bot will receive a pairing code to approve here</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -21,6 +21,7 @@ import { GitHubTab } from "./GitHubTab";
 import { DiscordSection } from "./DiscordSection";
 import { SlackSection } from "./SlackSection";
 import { MattermostSection } from "./MattermostSection";
+import { NextcloudTalkSection } from "./NextcloudTalkSection";
 import { TelegramSection } from "./TelegramSection";
 import { GoogleSection } from "./GoogleSection";
 import { SecuritySection } from "./SecuritySection";
@@ -61,6 +62,7 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
     if (activeSection === "telegram") return <TelegramSection />;
     if (activeSection === "slack") return <SlackSection />;
     if (activeSection === "mattermost") return <MattermostSection />;
+    if (activeSection === "nextcloud-talk") return <NextcloudTalkSection />;
     if (activeSection === "worker-names") return <WorkerNamesSection />;
     if (activeSection === "security") return <SecuritySection />;
     if (activeSection === "soul") return <SoulTab />;

--- a/packages/web/src/components/settings/settings-nav.ts
+++ b/packages/web/src/components/settings/settings-nav.ts
@@ -22,6 +22,7 @@ export type SettingsSection =
   | "telegram"
   | "slack"
   | "mattermost"
+  | "nextcloud-talk"
   | "worker-names"
   | "security";
 
@@ -83,6 +84,7 @@ export const SETTINGS_NAV: NavGroup[] = [
       { id: "telegram", label: "Telegram" },
       { id: "slack", label: "Slack" },
       { id: "mattermost", label: "Mattermost" },
+      { id: "nextcloud-talk", label: "Nextcloud Talk" },
     ],
   },
   {

--- a/packages/web/src/stores/settings-store.ts
+++ b/packages/web/src/stores/settings-store.ts
@@ -212,6 +212,17 @@ interface SettingsState {
   mattermostPendingPairings: Array<{ code: string; mattermostUserId: string; mattermostUsername: string; createdAt: string }>;
   mattermostTestResult: TestResult | null;
 
+  // Nextcloud Talk
+  nextcloudTalkEnabled: boolean;
+  nextcloudTalkServerUrlSet: boolean;
+  nextcloudTalkUsernameSet: boolean;
+  nextcloudTalkAppPasswordSet: boolean;
+  nextcloudTalkBotUsername: string | null;
+  nextcloudTalkRequireMention: boolean;
+  nextcloudTalkPairedUsers: Array<{ nextcloudUserId: string; nextcloudDisplayName: string; pairedAt: string }>;
+  nextcloudTalkPendingPairings: Array<{ code: string; nextcloudUserId: string; nextcloudDisplayName: string; createdAt: string }>;
+  nextcloudTalkTestResult: TestResult | null;
+
   // Google
   googleConnected: boolean;
   googleConnectedEmail: string | null;
@@ -418,6 +429,21 @@ interface SettingsState {
   rejectMattermostPairing: (code: string) => Promise<void>;
   revokeMattermostUser: (userId: string) => Promise<void>;
 
+  // Nextcloud Talk actions
+  loadNextcloudTalkSettings: () => Promise<void>;
+  updateNextcloudTalkSettings: (data: {
+    enabled?: boolean;
+    serverUrl?: string;
+    username?: string;
+    appPassword?: string;
+    requireMention?: boolean;
+    allowedConversations?: string[];
+  }) => Promise<void>;
+  testNextcloudTalkConnection: () => Promise<void>;
+  approveNextcloudTalkPairing: (code: string) => Promise<void>;
+  rejectNextcloudTalkPairing: (code: string) => Promise<void>;
+  revokeNextcloudTalkUser: (userId: string) => Promise<void>;
+
   // Google actions
   loadGoogleSettings: () => Promise<void>;
   updateGoogleCredentials: (data: {
@@ -550,6 +576,15 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   mattermostPairedUsers: [],
   mattermostPendingPairings: [],
   mattermostTestResult: null,
+  nextcloudTalkEnabled: false,
+  nextcloudTalkServerUrlSet: false,
+  nextcloudTalkUsernameSet: false,
+  nextcloudTalkAppPasswordSet: false,
+  nextcloudTalkBotUsername: null,
+  nextcloudTalkRequireMention: true,
+  nextcloudTalkPairedUsers: [],
+  nextcloudTalkPendingPairings: [],
+  nextcloudTalkTestResult: null,
   googleConnected: false,
   googleConnectedEmail: null,
   googleClientIdSet: false,
@@ -2039,6 +2074,112 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       });
       if (!res.ok) throw new Error("Failed to revoke user");
       await get().loadMattermostSettings();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+    }
+  },
+
+  // Nextcloud Talk actions
+
+  loadNextcloudTalkSettings: async () => {
+    try {
+      const res = await fetch("/api/settings/nextcloud-talk");
+      if (!res.ok) return;
+      const data = await res.json();
+      set({
+        nextcloudTalkEnabled: data.enabled,
+        nextcloudTalkServerUrlSet: data.serverUrlSet,
+        nextcloudTalkUsernameSet: data.usernameSet,
+        nextcloudTalkAppPasswordSet: data.appPasswordSet,
+        nextcloudTalkBotUsername: data.botUsername,
+        nextcloudTalkRequireMention: data.requireMention,
+        nextcloudTalkPairedUsers: data.pairedUsers,
+        nextcloudTalkPendingPairings: data.pendingPairings,
+      });
+    } catch {
+      // Silently fail
+    }
+  },
+
+  updateNextcloudTalkSettings: async (data) => {
+    set({ error: null });
+    try {
+      const res = await fetch("/api/settings/nextcloud-talk", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) throw new Error("Failed to update Nextcloud Talk settings");
+      await get().loadNextcloudTalkSettings();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+    }
+  },
+
+  testNextcloudTalkConnection: async () => {
+    set({ nextcloudTalkTestResult: { ok: false, testing: true } });
+    try {
+      const res = await fetch("/api/settings/nextcloud-talk/test", {
+        method: "POST",
+      });
+      const data = await res.json();
+      set({
+        nextcloudTalkTestResult: {
+          ok: data.ok,
+          error: data.error,
+          testing: false,
+        },
+        nextcloudTalkBotUsername: data.ok ? data.botUsername : get().nextcloudTalkBotUsername,
+      });
+    } catch {
+      set({
+        nextcloudTalkTestResult: {
+          ok: false,
+          error: "Network error",
+          testing: false,
+        },
+      });
+    }
+  },
+
+  approveNextcloudTalkPairing: async (code) => {
+    set({ error: null });
+    try {
+      const res = await fetch("/api/settings/nextcloud-talk/pair/approve", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      });
+      if (!res.ok) throw new Error("Failed to approve pairing");
+      await get().loadNextcloudTalkSettings();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+    }
+  },
+
+  rejectNextcloudTalkPairing: async (code) => {
+    set({ error: null });
+    try {
+      const res = await fetch("/api/settings/nextcloud-talk/pair/reject", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      });
+      if (!res.ok) throw new Error("Failed to reject pairing");
+      await get().loadNextcloudTalkSettings();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+    }
+  },
+
+  revokeNextcloudTalkUser: async (userId) => {
+    set({ error: null });
+    try {
+      const res = await fetch(`/api/settings/nextcloud-talk/pair/${userId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to revoke user");
+      await get().loadNextcloudTalkSettings();
     } catch (err) {
       set({ error: err instanceof Error ? err.message : "Unknown error" });
     }


### PR DESCRIPTION
## Summary
- Adds a new `nextcloud-talk` chat provider type to Otterbot, enabling connection to Nextcloud Talk via the OCS API
- Implements full bridge (polling-based message handling), settings module, pairing system, API routes, and web UI settings panel
- Includes comprehensive unit tests covering bridge lifecycle, authentication, message sending, room listing, error handling, settings CRUD, connection testing, and pairing flow

## Changes
- **`packages/shared`**: Added `"nextcloud-talk"` to `ChatProviderType` union, `NextcloudTalkChatProviderSettings` interface, and socket event types for `nextcloud-talk:status` and `nextcloud-talk:pairing-request`
- **`packages/server/src/nextcloud-talk/`**: New directory with `nextcloud-talk-bridge.ts` (polling-based bridge using OCS API), `nextcloud-talk-settings.ts` (CRUD + connection test), `pairing.ts` (code gen/approve/reject/revoke)
- **`packages/server/src/index.ts`**: Imports, bridge lifecycle functions (`startNextcloudTalkBridge`/`stopNextcloudTalkBridge`), startup hooks, graceful shutdown, and REST API routes for settings/pairing
- **`packages/web/src/components/settings/NextcloudTalkSection.tsx`**: Full settings UI with enable toggle, server URL/username/app password inputs, connection test, mention behavior toggle, paired users, and pending pairings
- **`packages/web/src/stores/settings-store.ts`**: State and actions for the new provider
- **`packages/web/src/components/settings/settings-nav.ts`**: Added `"nextcloud-talk"` section under Integrations
- **`packages/web/src/components/settings/SettingsPage.tsx`**: Routes to `NextcloudTalkSection`

## Test plan
- [x] All 872 existing tests pass
- [x] New Nextcloud Talk tests pass (bridge lifecycle, auth, send, rooms, errors, settings, pairing)
- [x] Full project build succeeds (`pnpm build`)
- [ ] Manual test with a real Nextcloud Talk instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)