### PR TITLE
feat: persist pipeline state across server restarts

### DIFF
--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -313,6 +313,27 @@ export async function migrateDb() {
     // Column already exists — ignore
   }
 
+  // Idempotent migration: add stage_reports to kanban_tasks
+  try {
+    db.run(sql`ALTER TABLE kanban_tasks ADD COLUMN stage_reports TEXT NOT NULL DEFAULT '{}'`);
+  } catch {
+    // Column already exists — ignore
+  }
+
+  // Idempotent migration: add last_kickback_source to kanban_tasks
+  try {
+    db.run(sql`ALTER TABLE kanban_tasks ADD COLUMN last_kickback_source TEXT`);
+  } catch {
+    // Column already exists — ignore
+  }
+
+  // Idempotent migration: add spawn_retry_count to kanban_tasks
+  try {
+    db.run(sql`ALTER TABLE kanban_tasks ADD COLUMN spawn_retry_count INTEGER NOT NULL DEFAULT 0`);
+  } catch {
+    // Column already exists — ignore
+  }
+
   // Backfill task_number for existing tasks that don't have one
   {
     const unnumbered = db

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -151,6 +151,12 @@ export const kanbanTasks = sqliteTable("kanban_tasks", {
     .default([]),
   taskNumber: integer("task_number"),
   pipelineAttempt: integer("pipeline_attempt").notNull().default(0),
+  stageReports: text("stage_reports", { mode: "json" })
+    .$type<Record<string, string>>()
+    .notNull()
+    .default({}),
+  lastKickbackSource: text("last_kickback_source"),
+  spawnRetryCount: integer("spawn_retry_count").notNull().default(0),
   createdAt: text("created_at")
     .notNull()
     .$defaultFn(() => new Date().toISOString()),


### PR DESCRIPTION
## Summary
- Adds three new columns to `kanban_tasks`: `stage_reports` (JSON), `last_kickback_source` (text), `spawn_retry_count` (integer)
- Adds idempotent migration blocks for the new columns
- Adds `persistPipelineState()` helper called at every mutation point (stage report storage, kickbacks, stage advance, spawn retries, PR feedback re-entry)
- Restores persisted state in both `recoverPipelines()` and `tryRecoverPipeline()` instead of using empty defaults

Previously, `stageReports`, `lastKickbackSource`, and `spawnRetryCount` lived only in the in-memory `pipelines` Map and were lost on server restart. This caused loss of kickback context, completion reports, and retry count resets (risking infinite retry loops).

## Test plan
- [x] All 842 tests pass (`npx pnpm test`)
- [x] No new type errors (`npx tsc --noEmit`)
- [ ] Manual: restart server mid-pipeline and verify stage reports, kickback source, and retry count are preserved