### PR TITLE
fix: use project githubBranch for pipeline + auto-enqueue completed tasks

### DIFF
--- a/packages/server/src/pipeline/pipeline-manager.ts
+++ b/packages/server/src/pipeline/pipeline-manager.ts
@@ -110,7 +110,10 @@ export class PipelineManager {
   /** Sweep interval in milliseconds (10 minutes) */
   private static readonly SWEEP_INTERVAL_MS = 10 * 60 * 1000;
   /** Merge queue reference (injected to avoid circular deps) */
-  private mergeQueue: { onReReviewComplete(taskId: string, passed: boolean): Promise<void> } | null = null;
+  private mergeQueue: {
+    onReReviewComplete(taskId: string, passed: boolean): Promise<void>;
+    approveForMerge(taskId: string): unknown;
+  } | null = null;
 
   constructor(coo: COO, io: TypedServer) {
     this.coo = coo;
@@ -118,7 +121,10 @@ export class PipelineManager {
   }
 
   /** Inject the merge queue (avoids circular dependency) */
-  setMergeQueue(mq: { onReReviewComplete(taskId: string, passed: boolean): Promise<void> }): void {
+  setMergeQueue(mq: {
+    onReReviewComplete(taskId: string, passed: boolean): Promise<void>;
+    approveForMerge(taskId: string): unknown;
+  }): void {
     this.mergeQueue = mq;
   }
 


### PR DESCRIPTION
## Summary
- Pipeline was resolving `targetBranch` from the `config` table with a hardcoded `"main"` fallback, ignoring the project's `githubBranch` column — now checks `project.githubBranch` first, matching the merge-queue pattern
- Applied across all 5 locations in `pipeline-manager.ts`, plus `team-lead.ts` and `coo.ts`
- **Fixed pipeline tasks stuck in "In Review"**: After the pipeline completes all stages (reviewer PASS), the task moved to `in_review` but was never enqueued in the merge queue. The only path into the merge queue was via PR Monitor detecting an external `APPROVED` GitHub review — which never comes for bot-created PRs. Now auto-enqueues the task after pipeline completion.

## Test plan
- [x] All existing tests pass (8 pre-existing failures in LLM provider tests unrelated)
- [x] TypeScript type-check passes for affected files
- [ ] After deploy, verify pipeline-completed tasks auto-enqueue in merge queue instead of sitting in "In Review"
- [ ] Verify `[PipelineManager]` logs show correct target branch (e.g. `dev` not `main`)