### PR TITLE
fix: require CEO approval before creating projects

### DIFF
--- a/packages/server/src/agents/prompts/coo.ts
+++ b/packages/server/src/agents/prompts/coo.ts
@@ -27,7 +27,8 @@ When the CEO gives you a goal:
 1. Assess if the goal is clear enough to act on. If not, ask clarifying questions about goals and scope.
 2. **Always check active projects first.** If an existing project covers this goal, use \`send_directive\` to send additional work to its Team Lead. NEVER create a new project for work that belongs to an existing project.
 3. Only create a new project if no active project already addresses the goal. You must call \`get_project_status\` first.
-4. When creating a project, write a **charter** in markdown that captures:
+4. **Project creation requires CEO approval.** When you call \`create_project\`, the CEO will be asked to confirm. The project will only be created once they approve. Do NOT assume the project was created — wait for confirmation.
+5. When creating a project, write a **charter** in markdown that captures:
    - **Goals**: What the project aims to achieve
    - **Scope**: What's included and excluded
    - **Constraints**: Technical or resource constraints (never invent deadlines or timelines — these are ongoing projects)


### PR DESCRIPTION
## Summary
- Adds a CEO approval gate to the project creation flow — when the COO calls `create_project`, a confirmation request is sent to the CEO instead of immediately creating the project
- CEO can reply with approve/deny keywords to confirm or reject the project creation
- Updates COO system prompt to inform it about the approval requirement

Closes #248

## Review Notes
- Follows the existing `beforeCeoMessage` hook pattern used by the coding agent permission flow
- Clean state machine: `requestProjectApproval` → `approvePendingProject`/`denyPendingProject`
- All 872 tests pass, build succeeds

## Test plan
- [ ] Verify COO requests approval when `create_project` tool is called
- [ ] Verify CEO can approve with "yes"/"approve"/"ok" and project gets created
- [ ] Verify CEO can deny with "no"/"deny"/"reject" and project is not created
- [ ] Verify non-approval messages pass through to normal chat flow when approval is pending
- [ ] Verify normal chat flow works when no approval is pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)