### PR TITLE
feat: add MCP server support

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,6 +23,7 @@
     "@fastify/multipart": "^9.0.3",
     "@fastify/static": "^8.1.0",
     "@huggingface/transformers": "^3.4.1",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@opencode-ai/sdk": "^1.2.6",
     "@otterbot/shared": "workspace:*",
     "@slack/bolt": "^4.6.0",

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -626,6 +626,25 @@ export async function migrateDb() {
     updated_at TEXT NOT NULL
   )`);
 
+  // MCP servers table
+  db.run(sql`CREATE TABLE IF NOT EXISTS mcp_servers (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 0,
+    transport TEXT NOT NULL,
+    command TEXT,
+    args TEXT NOT NULL DEFAULT '[]',
+    env TEXT NOT NULL DEFAULT '{}',
+    url TEXT,
+    headers TEXT NOT NULL DEFAULT '{}',
+    auto_start INTEGER NOT NULL DEFAULT 0,
+    timeout INTEGER NOT NULL DEFAULT 30000,
+    allowed_tools TEXT,
+    discovered_tools TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`);
+
   // FTS5 full-text search index for memories
   try {
     db.run(sql`CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { sqliteTable, text, integer, primaryKey, unique } from "drizzle-orm/sqlite-core";
-import type { ScanFinding, SkillScanStatus, CodingAgentPart, CodingAgentType, MemoryCategory, MemorySource } from "@otterbot/shared";
+import type { ScanFinding, SkillScanStatus, CodingAgentPart, CodingAgentType, MemoryCategory, MemorySource, McpToolMeta } from "@otterbot/shared";
 
 export const agents = sqliteTable("agents", {
   id: text("id").primaryKey(),
@@ -467,6 +467,41 @@ export const mergeQueue = sqliteTable("merge_queue", {
   lastError: text("last_error"),
   approvedAt: text("approved_at").notNull(),
   mergedAt: text("merged_at"),
+  createdAt: text("created_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+  updatedAt: text("updated_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+});
+
+export const mcpServers = sqliteTable("mcp_servers", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  enabled: integer("enabled", { mode: "boolean" }).notNull().default(false),
+  transport: text("transport", { enum: ["stdio", "sse"] }).notNull(),
+  command: text("command"),
+  args: text("args", { mode: "json" })
+    .$type<string[]>()
+    .notNull()
+    .default([]),
+  env: text("env", { mode: "json" })
+    .$type<Record<string, string>>()
+    .notNull()
+    .default({}),
+  url: text("url"),
+  headers: text("headers", { mode: "json" })
+    .$type<Record<string, string>>()
+    .notNull()
+    .default({}),
+  autoStart: integer("auto_start", { mode: "boolean" }).notNull().default(false),
+  timeout: integer("timeout").notNull().default(30000),
+  allowedTools: text("allowed_tools", { mode: "json" })
+    .$type<string[] | null>()
+    .default(null),
+  discoveredTools: text("discovered_tools", { mode: "json" })
+    .$type<McpToolMeta[] | null>()
+    .default(null),
   createdAt: text("created_at")
     .notNull()
     .$defaultFn(() => new Date().toISOString()),

--- a/packages/server/src/mcp/mcp-client-manager.ts
+++ b/packages/server/src/mcp/mcp-client-manager.ts
@@ -1,0 +1,313 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { mkdirSync } from "node:fs";
+import type { McpServerConfig, McpServerRuntime, McpServerStatus, McpToolMeta } from "@otterbot/shared";
+import { McpServerService } from "./mcp-service.js";
+import { filterEnvVars, getIsolatedWorkDir } from "./mcp-security.js";
+
+interface ManagedClient {
+  client: Client;
+  transport: StdioClientTransport | SSEClientTransport;
+  status: McpServerStatus;
+  error?: string;
+  pid?: number;
+  connectedAt?: string;
+  toolCount: number;
+}
+
+type StatusListener = (runtime: McpServerRuntime) => void;
+
+class McpClientManagerSingleton {
+  private clients = new Map<string, ManagedClient>();
+  private statusListeners: StatusListener[] = [];
+
+  onStatusChange(listener: StatusListener): () => void {
+    this.statusListeners.push(listener);
+    return () => {
+      this.statusListeners = this.statusListeners.filter((l) => l !== listener);
+    };
+  }
+
+  private emitStatus(id: string) {
+    const runtime = this.getStatus(id);
+    for (const listener of this.statusListeners) {
+      listener(runtime);
+    }
+  }
+
+  async start(serverId: string): Promise<void> {
+    // Stop if already running
+    if (this.clients.has(serverId)) {
+      await this.stop(serverId);
+    }
+
+    const service = new McpServerService();
+    const config = service.get(serverId);
+    if (!config) throw new Error(`MCP server "${serverId}" not found`);
+
+    this.setClientState(serverId, { status: "connecting", toolCount: 0 });
+    this.emitStatus(serverId);
+
+    try {
+      const transport = this.createTransport(config);
+      const client = new Client(
+        { name: "otterbot", version: "0.1.0" },
+        { capabilities: {} },
+      );
+
+      await client.connect(transport);
+
+      // Get PID for stdio transports
+      let pid: number | undefined;
+      if (transport instanceof StdioClientTransport) {
+        pid = transport.pid ?? undefined;
+      }
+
+      // Discover tools
+      const toolCount = await this.discoverAndSaveTools(serverId, client, service);
+
+      this.clients.set(serverId, {
+        client,
+        transport,
+        status: "connected",
+        pid,
+        connectedAt: new Date().toISOString(),
+        toolCount,
+      });
+
+      // Set up disconnect handler
+      transport.onclose = () => {
+        const managed = this.clients.get(serverId);
+        if (managed) {
+          managed.status = "disconnected";
+          this.emitStatus(serverId);
+        }
+      };
+
+      transport.onerror = (err: Error) => {
+        const managed = this.clients.get(serverId);
+        if (managed) {
+          managed.status = "error";
+          managed.error = err.message;
+          this.emitStatus(serverId);
+        }
+      };
+
+      this.emitStatus(serverId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.setClientState(serverId, { status: "error", error: message, toolCount: 0 });
+      this.emitStatus(serverId);
+      throw err;
+    }
+  }
+
+  async stop(serverId: string): Promise<void> {
+    const managed = this.clients.get(serverId);
+    if (!managed) return;
+
+    try {
+      await managed.transport.close();
+    } catch {
+      // Ignore close errors
+    }
+
+    this.clients.delete(serverId);
+    this.emitStatus(serverId);
+  }
+
+  async restart(serverId: string): Promise<void> {
+    await this.stop(serverId);
+    await this.start(serverId);
+  }
+
+  async stopAll(): Promise<void> {
+    const ids = [...this.clients.keys()];
+    await Promise.allSettled(ids.map((id) => this.stop(id)));
+  }
+
+  async autoStartAll(): Promise<void> {
+    const service = new McpServerService();
+    const servers = service.list().filter((s) => s.enabled && s.autoStart);
+    for (const server of servers) {
+      try {
+        await this.start(server.id);
+        console.log(`[MCP] Auto-started server "${server.name}"`);
+      } catch (err) {
+        console.error(`[MCP] Failed to auto-start server "${server.name}":`, err);
+      }
+    }
+  }
+
+  async discoverTools(serverId: string): Promise<McpToolMeta[]> {
+    const managed = this.clients.get(serverId);
+    if (!managed || managed.status !== "connected") {
+      throw new Error("MCP server is not connected");
+    }
+    const service = new McpServerService();
+    const toolCount = await this.discoverAndSaveTools(serverId, managed.client, service);
+    managed.toolCount = toolCount;
+    return service.get(serverId)?.discoveredTools ?? [];
+  }
+
+  async callTool(serverId: string, toolName: string, args: Record<string, unknown>): Promise<unknown> {
+    const managed = this.clients.get(serverId);
+    if (!managed || managed.status !== "connected") {
+      throw new Error("MCP server is not connected");
+    }
+
+    // Check allowed tools gate
+    const service = new McpServerService();
+    const config = service.get(serverId);
+    if (config?.allowedTools !== null) {
+      if (!config?.allowedTools?.includes(toolName)) {
+        throw new Error(`Tool "${toolName}" is not in the allowed tools list for server "${config?.name}"`);
+      }
+    }
+
+    const result = await managed.client.callTool({ name: toolName, arguments: args });
+    return result;
+  }
+
+  /**
+   * Search connected servers for a tool by name.
+   * Returns the server ID and tool metadata if found.
+   */
+  findTool(toolName: string): { serverId: string; tool: McpToolMeta } | null {
+    const service = new McpServerService();
+    const servers = service.list().filter((s) => s.enabled);
+
+    for (const server of servers) {
+      const managed = this.clients.get(server.id);
+      if (!managed || managed.status !== "connected") continue;
+
+      const tools = server.discoveredTools ?? [];
+      // Check allowed tools gate
+      if (server.allowedTools !== null && !server.allowedTools?.includes(toolName)) {
+        continue;
+      }
+      const tool = tools.find((t) => t.name === toolName);
+      if (tool) return { serverId: server.id, tool };
+    }
+    return null;
+  }
+
+  /**
+   * Get all enabled tool names from connected MCP servers, filtered by allowedTools.
+   */
+  getAllEnabledToolNames(): string[] {
+    const service = new McpServerService();
+    const servers = service.list().filter((s) => s.enabled);
+    const names: string[] = [];
+
+    for (const server of servers) {
+      const managed = this.clients.get(server.id);
+      if (!managed || managed.status !== "connected") continue;
+
+      const tools = server.discoveredTools ?? [];
+      for (const tool of tools) {
+        if (server.allowedTools === null || server.allowedTools.includes(tool.name)) {
+          names.push(`mcp_${this.sanitizeName(server.name)}_${tool.name}`);
+        }
+      }
+    }
+
+    return names;
+  }
+
+  getStatus(serverId: string): McpServerRuntime {
+    const managed = this.clients.get(serverId);
+    if (!managed) {
+      return { id: serverId, status: "disconnected", toolCount: 0 };
+    }
+    return {
+      id: serverId,
+      status: managed.status,
+      error: managed.error,
+      pid: managed.pid,
+      connectedAt: managed.connectedAt,
+      toolCount: managed.toolCount,
+    };
+  }
+
+  getAllStatuses(): Map<string, McpServerRuntime> {
+    const statuses = new Map<string, McpServerRuntime>();
+    for (const id of this.clients.keys()) {
+      statuses.set(id, this.getStatus(id));
+    }
+    return statuses;
+  }
+
+  isConnected(serverId: string): boolean {
+    const managed = this.clients.get(serverId);
+    return managed?.status === "connected";
+  }
+
+  /** Convert server name to safe identifier */
+  sanitizeName(name: string): string {
+    return name.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
+  }
+
+  private createTransport(config: McpServerConfig): StdioClientTransport | SSEClientTransport {
+    if (config.transport === "stdio") {
+      const workDir = getIsolatedWorkDir(config.id);
+      mkdirSync(workDir, { recursive: true });
+
+      return new StdioClientTransport({
+        command: config.command!,
+        args: config.args,
+        env: filterEnvVars(config.env),
+        cwd: workDir,
+        stderr: "pipe",
+      });
+    }
+
+    return new SSEClientTransport(new URL(config.url!), {
+      requestInit: {
+        headers: config.headers,
+      },
+    });
+  }
+
+  private async discoverAndSaveTools(
+    serverId: string,
+    client: Client,
+    service: McpServerService,
+  ): Promise<number> {
+    try {
+      const result = await client.listTools();
+      const tools: McpToolMeta[] = (result.tools ?? []).map((t) => ({
+        name: t.name,
+        description: t.description ?? "",
+        inputSchema: t.inputSchema as Record<string, unknown>,
+      }));
+      service.updateDiscoveredTools(serverId, tools);
+      return tools.length;
+    } catch (err) {
+      console.warn(`[MCP] Failed to discover tools for "${serverId}":`, err);
+      return 0;
+    }
+  }
+
+  private setClientState(
+    serverId: string,
+    state: Partial<ManagedClient>,
+  ) {
+    const existing = this.clients.get(serverId);
+    if (existing) {
+      Object.assign(existing, state);
+    } else {
+      this.clients.set(serverId, {
+        client: null as any,
+        transport: null as any,
+        status: "disconnected",
+        toolCount: 0,
+        ...state,
+      });
+    }
+  }
+}
+
+/** Singleton MCP client manager */
+export const McpClientManager = new McpClientManagerSingleton();

--- a/packages/server/src/mcp/mcp-security.ts
+++ b/packages/server/src/mcp/mcp-security.ts
@@ -1,0 +1,246 @@
+import { basename } from "node:path";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Commands allowed for stdio MCP servers */
+const ALLOWED_COMMANDS = new Set([
+  "npx",
+  "node",
+  "python",
+  "python3",
+  "uvx",
+  "docker",
+  "deno",
+]);
+
+/** Patterns blocked in command arguments */
+const BLOCKED_ARG_PATTERNS = [
+  /\brm\b/,
+  /\bdd\b/,
+  /\bmkfs\b/,
+  /\bshutdown\b/,
+  /\bcurl\b/,
+  /\bwget\b/,
+  /\bnc\b/,
+  /\bssh\b/,
+  /\bchmod\b/,
+  /\bchown\b/,
+];
+
+/** Environment variables that must never be passed to MCP processes */
+const BLOCKED_ENV_VARS = new Set([
+  "OTTERBOT_DB_KEY",
+  "DATABASE_URL",
+  "OTTERBOT_PASSPHRASE",
+  "SESSION_SECRET",
+]);
+
+/** Environment variables safe to inherit from host */
+const SAFE_INHERITED_VARS = new Set([
+  "PATH",
+  "HOME",
+  "USER",
+  "LANG",
+  "TZ",
+  "TERM",
+  "NODE_ENV",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+]);
+
+/** RFC 1918 and other internal network patterns */
+const INTERNAL_NETWORK_PATTERNS = [
+  /^10\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+  /^127\./,
+  /^169\.254\./,
+  /^0\./,
+  /^\[::1\]/,
+  /^\[fc/i,
+  /^\[fd/i,
+  /^\[fe80:/i,
+];
+
+export interface SecurityWarning {
+  type: "no-version-pin" | "non-https" | "secret-env" | "broad-tools";
+  message: string;
+}
+
+export interface CommandValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Validate a command for stdio transport.
+ * Only allows commands from the allowlist.
+ */
+export function validateCommand(command: string): CommandValidationResult {
+  const base = basename(command);
+  if (!ALLOWED_COMMANDS.has(base)) {
+    return {
+      valid: false,
+      error: `Command "${base}" is not allowed. Allowed commands: ${[...ALLOWED_COMMANDS].join(", ")}`,
+    };
+  }
+  return { valid: true };
+}
+
+/**
+ * Validate command arguments for dangerous patterns.
+ */
+export function validateArgs(args: string[]): CommandValidationResult {
+  for (const arg of args) {
+    for (const pattern of BLOCKED_ARG_PATTERNS) {
+      if (pattern.test(arg)) {
+        return {
+          valid: false,
+          error: `Argument "${arg}" contains blocked pattern "${pattern.source}"`,
+        };
+      }
+    }
+  }
+  return { valid: true };
+}
+
+/**
+ * Filter environment variables for MCP process.
+ * Removes blocked vars, adds safe inherited vars, then applies user-defined vars.
+ */
+export function filterEnvVars(userEnv: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  // Add safe inherited vars from host
+  for (const key of SAFE_INHERITED_VARS) {
+    if (process.env[key]) {
+      result[key] = process.env[key]!;
+    }
+  }
+
+  // Add user-defined vars, filtering out blocked ones
+  for (const [key, value] of Object.entries(userEnv)) {
+    if (!BLOCKED_ENV_VARS.has(key)) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get the isolated working directory for an MCP server process.
+ */
+export function getIsolatedWorkDir(serverId: string): string {
+  return join(tmpdir(), "otterbot-mcp", serverId);
+}
+
+/**
+ * Validate an SSE URL for security.
+ * Requires HTTPS for non-localhost URLs.
+ * Blocks internal network addresses.
+ */
+export function validateSseUrl(url: string): CommandValidationResult {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { valid: false, error: "Invalid URL" };
+  }
+
+  const hostname = parsed.hostname;
+  const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+
+  // Require HTTPS for non-localhost
+  if (!isLocalhost && parsed.protocol !== "https:") {
+    return {
+      valid: false,
+      error: "HTTPS is required for non-localhost MCP server URLs",
+    };
+  }
+
+  // Block internal network addresses (except localhost)
+  if (!isLocalhost) {
+    for (const pattern of INTERNAL_NETWORK_PATTERNS) {
+      if (pattern.test(hostname)) {
+        return {
+          valid: false,
+          error: `Internal network addresses are not allowed: ${hostname}`,
+        };
+      }
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Generate security warnings for a server configuration.
+ * Warnings are advisory, not blocking.
+ */
+export function getSecurityWarnings(config: {
+  transport: "stdio" | "sse";
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  allowedTools?: string[] | null;
+}): SecurityWarning[] {
+  const warnings: SecurityWarning[] = [];
+
+  if (config.transport === "stdio") {
+    // Check for npx without version pin
+    if (config.command && basename(config.command) === "npx") {
+      const args = config.args ?? [];
+      const packageArg = args.find((a) => !a.startsWith("-"));
+      if (packageArg && !packageArg.includes("@")) {
+        warnings.push({
+          type: "no-version-pin",
+          message: `Package "${packageArg}" has no version pin. Consider using "${packageArg}@latest" or a specific version.`,
+        });
+      }
+    }
+  }
+
+  if (config.transport === "sse" && config.url) {
+    try {
+      const parsed = new URL(config.url);
+      const isLocalhost = parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+      if (isLocalhost && parsed.protocol !== "https:") {
+        warnings.push({
+          type: "non-https",
+          message: "Using HTTP for localhost connection. HTTPS is recommended for production use.",
+        });
+      }
+    } catch {
+      // URL validation handled separately
+    }
+  }
+
+  // Check for secret-looking env vars
+  const secretPattern = /passw|secret|token|key|auth/i;
+  if (config.env) {
+    for (const key of Object.keys(config.env)) {
+      if (secretPattern.test(key)) {
+        warnings.push({
+          type: "secret-env",
+          message: `Environment variable "${key}" appears to contain a secret. It will be stored encrypted in the database.`,
+        });
+      }
+    }
+  }
+
+  // Check for broad tool permissions
+  if (config.allowedTools === null) {
+    warnings.push({
+      type: "broad-tools",
+      message: "All tools from this server are allowed. Consider restricting to specific tools.",
+    });
+  }
+
+  return warnings;
+}

--- a/packages/server/src/mcp/mcp-service.ts
+++ b/packages/server/src/mcp/mcp-service.ts
@@ -1,0 +1,185 @@
+import { nanoid } from "nanoid";
+import { eq } from "drizzle-orm";
+import { getDb, schema } from "../db/index.js";
+import type {
+  McpServerConfig,
+  McpServerCreate,
+  McpServerUpdate,
+  McpToolMeta,
+} from "@otterbot/shared";
+import { validateCommand, validateArgs, validateSseUrl } from "./mcp-security.js";
+
+const SECRET_PATTERN = /passw|secret|token|key|auth/i;
+
+export class McpServerService {
+  list(): McpServerConfig[] {
+    const db = getDb();
+    const rows = db.select().from(schema.mcpServers).all();
+    return rows.map((r) => this.toConfig(r));
+  }
+
+  get(id: string): McpServerConfig | null {
+    const db = getDb();
+    const row = db
+      .select()
+      .from(schema.mcpServers)
+      .where(eq(schema.mcpServers.id, id))
+      .get();
+    return row ? this.toConfig(row) : null;
+  }
+
+  create(data: McpServerCreate): McpServerConfig {
+    // Validate command for stdio
+    if (data.transport === "stdio") {
+      if (!data.command) {
+        throw new Error("command is required for stdio transport");
+      }
+      const cmdResult = validateCommand(data.command);
+      if (!cmdResult.valid) throw new Error(cmdResult.error);
+      const argsResult = validateArgs(data.args ?? []);
+      if (!argsResult.valid) throw new Error(argsResult.error);
+    }
+
+    // Validate URL for SSE
+    if (data.transport === "sse") {
+      if (!data.url) {
+        throw new Error("url is required for sse transport");
+      }
+      const urlResult = validateSseUrl(data.url);
+      if (!urlResult.valid) throw new Error(urlResult.error);
+    }
+
+    const db = getDb();
+    const now = new Date().toISOString();
+    const id = nanoid();
+
+    const row = {
+      id,
+      name: data.name,
+      enabled: false,
+      transport: data.transport,
+      command: data.command ?? null,
+      args: (data.args ?? []) as any,
+      env: (data.env ?? {}) as any,
+      url: data.url ?? null,
+      headers: (data.headers ?? {}) as any,
+      autoStart: data.autoStart ?? false,
+      timeout: data.timeout ?? 30000,
+      allowedTools: null as any,
+      discoveredTools: null as any,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    db.insert(schema.mcpServers).values(row).run();
+    return this.toConfig(row);
+  }
+
+  update(id: string, data: McpServerUpdate): McpServerConfig | null {
+    const existing = this.get(id);
+    if (!existing) return null;
+
+    const transport = data.transport ?? existing.transport;
+
+    // Validate command if changing stdio fields
+    if (transport === "stdio" && data.command !== undefined) {
+      const cmdResult = validateCommand(data.command!);
+      if (!cmdResult.valid) throw new Error(cmdResult.error);
+    }
+    if (transport === "stdio" && data.args !== undefined) {
+      const argsResult = validateArgs(data.args!);
+      if (!argsResult.valid) throw new Error(argsResult.error);
+    }
+
+    // Validate URL if changing SSE fields
+    if (transport === "sse" && data.url !== undefined) {
+      const urlResult = validateSseUrl(data.url!);
+      if (!urlResult.valid) throw new Error(urlResult.error);
+    }
+
+    const db = getDb();
+    const updates: Record<string, unknown> = {
+      updatedAt: new Date().toISOString(),
+    };
+
+    if (data.name !== undefined) updates.name = data.name;
+    if (data.enabled !== undefined) updates.enabled = data.enabled;
+    if (data.transport !== undefined) updates.transport = data.transport;
+    if (data.command !== undefined) updates.command = data.command;
+    if (data.args !== undefined) updates.args = data.args;
+    if (data.env !== undefined) updates.env = data.env;
+    if (data.url !== undefined) updates.url = data.url;
+    if (data.headers !== undefined) updates.headers = data.headers;
+    if (data.autoStart !== undefined) updates.autoStart = data.autoStart;
+    if (data.timeout !== undefined) updates.timeout = data.timeout;
+    if (data.allowedTools !== undefined) updates.allowedTools = data.allowedTools;
+
+    db.update(schema.mcpServers)
+      .set(updates)
+      .where(eq(schema.mcpServers.id, id))
+      .run();
+
+    return this.get(id);
+  }
+
+  updateDiscoveredTools(id: string, tools: McpToolMeta[]): void {
+    const db = getDb();
+    db.update(schema.mcpServers)
+      .set({
+        discoveredTools: tools as any,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(schema.mcpServers.id, id))
+      .run();
+  }
+
+  delete(id: string): boolean {
+    const db = getDb();
+    const result = db
+      .delete(schema.mcpServers)
+      .where(eq(schema.mcpServers.id, id))
+      .run();
+    return result.changes > 0;
+  }
+
+  /** Return config with secrets masked for API responses */
+  maskSecrets(config: McpServerConfig): McpServerConfig {
+    return {
+      ...config,
+      env: this.maskRecord(config.env),
+      headers: this.maskRecord(config.headers),
+    };
+  }
+
+  private maskRecord(record: Record<string, string>): Record<string, string> {
+    const masked: Record<string, string> = {};
+    for (const [key, value] of Object.entries(record)) {
+      if (SECRET_PATTERN.test(key) && value.length > 4) {
+        masked[key] = "****" + value.slice(-4);
+      } else {
+        masked[key] = value;
+      }
+    }
+    return masked;
+  }
+
+  private toConfig(row: any): McpServerConfig {
+    return {
+      id: row.id,
+      name: row.name,
+      enabled: row.enabled,
+      transport: row.transport,
+      command: row.command ?? undefined,
+      args: row.args ?? [],
+      env: row.env ?? {},
+      url: row.url ?? undefined,
+      headers: row.headers ?? {},
+      autoStart: row.autoStart,
+      timeout: row.timeout,
+      allowedTools: row.allowedTools ?? null,
+      discoveredTools: row.discoveredTools ?? null,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+}

--- a/packages/server/src/tools/tool-factory.ts
+++ b/packages/server/src/tools/tool-factory.ts
@@ -35,6 +35,8 @@ import { SkillService } from "../skills/skill-service.js";
 import { CustomToolService } from "./custom-tool-service.js";
 import { executeCustomTool } from "./custom-tool-executor.js";
 import { createMemorySaveTool } from "./memory-save.js";
+import { McpClientManager } from "../mcp/mcp-client-manager.js";
+import { McpServerService as McpServerServiceRef } from "../mcp/mcp-service.js";
 
 type ToolCreator = (ctx: ToolContext) => unknown;
 
@@ -109,6 +111,14 @@ export function createTools(
       tools[name] = createCustomToolWrapper(customTool);
       continue;
     }
+    // Check MCP tools (naming convention: mcp_<serverName>_<toolName>)
+    if (name.startsWith("mcp_")) {
+      const mcpTool = createMcpToolWrapper(name);
+      if (mcpTool) {
+        tools[name] = mcpTool;
+        continue;
+      }
+    }
     console.warn(`[tool-factory] Unknown tool "${name}" requested — skipping.`);
   }
   return tools;
@@ -169,10 +179,12 @@ export function createToolsForAgent(
 export function getAvailableToolNames(): string[] {
   const customToolService = new CustomToolService();
   const customNames = customToolService.list().map((t) => t.name);
+  const mcpNames = McpClientManager.getAllEnabledToolNames();
   return [
     ...Object.keys(TOOL_REGISTRY),
     ...Object.keys(CONTEXTLESS_TOOL_REGISTRY),
     ...customNames,
+    ...mcpNames,
   ];
 }
 
@@ -498,6 +510,24 @@ export function getToolsWithMeta(): {
     };
   }
 
+  // Add MCP tools
+  const mcpService = new McpServerServiceRef();
+  const mcpServers = mcpService.list().filter((s) => s.enabled);
+  for (const server of mcpServers) {
+    if (!McpClientManager.isConnected(server.id)) continue;
+    const tools = server.discoveredTools ?? [];
+    for (const t of tools) {
+      if (server.allowedTools !== null && !server.allowedTools.includes(t.name)) continue;
+      const fullName = `mcp_${McpClientManager.sanitizeName(server.name)}_${t.name}`;
+      toolMeta[fullName] = {
+        description: t.description,
+        builtIn: false,
+        parameters: extractMcpToolParams(t.inputSchema),
+        category: `MCP: ${server.name}`,
+      };
+    }
+  }
+
   return { builtInTools: builtInNames, customTools: customs, toolMeta };
 }
 
@@ -626,4 +656,100 @@ function createTestCustomToolTool() {
       }
     },
   });
+}
+
+// =========================================================================
+// MCP Tool Helpers
+// =========================================================================
+
+/**
+ * Create a Vercel AI SDK tool wrapper for an MCP tool.
+ * Tool names follow the convention: mcp_<serverName>_<toolName>
+ */
+function createMcpToolWrapper(fullName: string): unknown | null {
+  // fullName = mcp_<sanitizedServerName>_<toolName>
+  const mcpService = new McpServerServiceRef();
+  const servers = mcpService.list().filter((s) => s.enabled);
+
+  for (const server of servers) {
+    if (!McpClientManager.isConnected(server.id)) continue;
+    const prefix = `mcp_${McpClientManager.sanitizeName(server.name)}_`;
+    if (!fullName.startsWith(prefix)) continue;
+
+    const toolName = fullName.slice(prefix.length);
+    const tools = server.discoveredTools ?? [];
+    const mcpTool = tools.find((t) => t.name === toolName);
+    if (!mcpTool) continue;
+
+    // Check allowed tools gate
+    if (server.allowedTools !== null && !server.allowedTools.includes(toolName)) continue;
+
+    // Convert JSON Schema to Zod
+    const zodSchema = jsonSchemaToZod(mcpTool.inputSchema);
+
+    return tool({
+      description: mcpTool.description || `MCP tool: ${toolName}`,
+      parameters: zodSchema,
+      execute: async (params: Record<string, unknown>) => {
+        const result = await McpClientManager.callTool(server.id, toolName, params);
+        return JSON.stringify(result);
+      },
+    });
+  }
+
+  return null;
+}
+
+/** Convert a JSON Schema object to a Zod schema (basic support) */
+function jsonSchemaToZod(schema: Record<string, unknown>): z.ZodTypeAny {
+  if (!schema || schema.type !== "object") {
+    return z.object({});
+  }
+
+  const properties = (schema.properties ?? {}) as Record<string, Record<string, unknown>>;
+  const required = new Set((schema.required ?? []) as string[]);
+  const shape: Record<string, z.ZodTypeAny> = {};
+
+  for (const [key, prop] of Object.entries(properties)) {
+    let fieldSchema: z.ZodTypeAny;
+    const desc = (prop.description as string) || "";
+
+    switch (prop.type) {
+      case "number":
+      case "integer":
+        fieldSchema = z.number().describe(desc);
+        break;
+      case "boolean":
+        fieldSchema = z.boolean().describe(desc);
+        break;
+      case "array":
+        fieldSchema = z.array(z.unknown()).describe(desc);
+        break;
+      case "object":
+        fieldSchema = z.record(z.unknown()).describe(desc);
+        break;
+      default:
+        fieldSchema = z.string().describe(desc);
+    }
+
+    shape[key] = required.has(key) ? fieldSchema : fieldSchema.optional();
+  }
+
+  return z.object(shape);
+}
+
+/** Extract parameter metadata from a JSON Schema for UI display */
+function extractMcpToolParams(
+  schema: Record<string, unknown>,
+): ToolParamMeta[] {
+  if (!schema || schema.type !== "object") return [];
+  const properties = (schema.properties ?? {}) as Record<string, Record<string, unknown>>;
+  const required = new Set((schema.required ?? []) as string[]);
+
+  return Object.entries(properties).map(([name, prop]) => ({
+    name,
+    type: (prop.type as string) || "string",
+    required: required.has(name),
+    description: (prop.description as string) || "",
+  }));
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,3 +18,4 @@ export * from "./types/opencode.js";
 export * from "./types/memory.js";
 export * from "./types/module.js";
 export * from "./types/merge-queue.js";
+export * from "./types/mcp-server.js";

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -7,6 +7,7 @@ import type { CodingAgentSession, CodingAgentMessage, CodingAgentFileDiff, Codin
 import type { SoulDocument, Memory, MemoryEpisode, SoulSuggestion } from "./memory.js";
 import type { Todo } from "./todo.js";
 import type { MergeQueueEntry } from "./merge-queue.js";
+import type { McpServerRuntime } from "./mcp-server.js";
 
 /** Events emitted from server to client */
 export interface ServerToClientEvents {
@@ -71,6 +72,7 @@ export interface ServerToClientEvents {
   "nextcloud-talk:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
   "merge-queue:updated": (data: { entries: MergeQueueEntry[] }) => void;
   "merge-queue:entry-updated": (entry: MergeQueueEntry) => void;
+  "mcp:status": (runtime: McpServerRuntime) => void;
 }
 
 /** Events emitted from client to server */

--- a/packages/shared/src/types/mcp-server.ts
+++ b/packages/shared/src/types/mcp-server.ts
@@ -1,0 +1,60 @@
+export interface McpToolMeta {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface McpServerConfig {
+  id: string;
+  name: string;
+  enabled: boolean;
+  transport: "stdio" | "sse";
+  command?: string;
+  args: string[];
+  env: Record<string, string>;
+  url?: string;
+  headers: Record<string, string>;
+  autoStart: boolean;
+  timeout: number;
+  allowedTools: string[] | null;
+  discoveredTools: McpToolMeta[] | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface McpServerCreate {
+  name: string;
+  transport: "stdio" | "sse";
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+  autoStart?: boolean;
+  timeout?: number;
+}
+
+export interface McpServerUpdate {
+  name?: string;
+  enabled?: boolean;
+  transport?: "stdio" | "sse";
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+  autoStart?: boolean;
+  timeout?: number;
+  allowedTools?: string[] | null;
+}
+
+export type McpServerStatus = "disconnected" | "connecting" | "connected" | "error";
+
+export interface McpServerRuntime {
+  id: string;
+  status: McpServerStatus;
+  error?: string;
+  pid?: number;
+  connectedAt?: string;
+  toolCount: number;
+}

--- a/packages/web/src/components/settings/McpServersSection.tsx
+++ b/packages/web/src/components/settings/McpServersSection.tsx
@@ -1,0 +1,749 @@
+import { useState, useEffect } from "react";
+import { useMcpStore } from "../../stores/mcp-store";
+import type { McpServerConfig, McpServerCreate, McpServerUpdate, McpServerRuntime } from "@otterbot/shared";
+import { getSocket } from "../../lib/socket";
+
+type ViewMode = "list" | "add" | "edit" | "tools";
+
+const STATUS_COLORS: Record<string, string> = {
+  connected: "bg-green-500",
+  connecting: "bg-yellow-500",
+  disconnected: "bg-zinc-500",
+  error: "bg-red-500",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  connected: "Connected",
+  connecting: "Connecting...",
+  disconnected: "Disconnected",
+  error: "Error",
+};
+
+export function McpServersSection() {
+  const {
+    servers,
+    statuses,
+    warnings,
+    loading,
+    error,
+    loadServers,
+    createServer,
+    updateServer,
+    deleteServer,
+    startServer,
+    stopServer,
+    restartServer,
+    testServer,
+    updateAllowedTools,
+    updateStatus,
+  } = useMcpStore();
+
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [toolsServerId, setToolsServerId] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    loadServers();
+  }, []);
+
+  // Listen for real-time status updates
+  useEffect(() => {
+    const socket = getSocket();
+    const handler = (runtime: McpServerRuntime) => {
+      updateStatus(runtime);
+    };
+    socket.on("mcp:status", handler);
+    return () => {
+      socket.off("mcp:status", handler);
+    };
+  }, [updateStatus]);
+
+  const setLoading = (id: string, val: boolean) => {
+    setActionLoading((prev) => ({ ...prev, [id]: val }));
+  };
+
+  const handleStart = async (id: string) => {
+    setLoading(id, true);
+    await startServer(id);
+    setLoading(id, false);
+    await loadServers();
+  };
+
+  const handleStop = async (id: string) => {
+    setLoading(id, true);
+    await stopServer(id);
+    setLoading(id, false);
+  };
+
+  const handleRestart = async (id: string) => {
+    setLoading(id, true);
+    await restartServer(id);
+    setLoading(id, false);
+    await loadServers();
+  };
+
+  const handleTest = async (id: string) => {
+    setLoading(id, true);
+    await testServer(id);
+    setLoading(id, false);
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteServer(id);
+    setConfirmDelete(null);
+  };
+
+  const handleToggleEnabled = async (server: McpServerConfig) => {
+    await updateServer(server.id, { enabled: !server.enabled });
+  };
+
+  const handleEditTools = (id: string) => {
+    setToolsServerId(id);
+    setViewMode("tools");
+  };
+
+  const handleEdit = (id: string) => {
+    setEditingId(id);
+    setViewMode("edit");
+  };
+
+  const handleBack = () => {
+    setViewMode("list");
+    setEditingId(null);
+    setToolsServerId(null);
+  };
+
+  if (viewMode === "add") {
+    return (
+      <McpServerForm
+        onSave={async (data) => {
+          await createServer(data as McpServerCreate);
+          handleBack();
+        }}
+        onCancel={handleBack}
+      />
+    );
+  }
+
+  if (viewMode === "edit" && editingId) {
+    const server = servers.find((s) => s.id === editingId);
+    if (!server) {
+      handleBack();
+      return null;
+    }
+    return (
+      <McpServerForm
+        server={server}
+        onSave={async (data) => {
+          await updateServer(editingId, data as McpServerUpdate);
+          handleBack();
+        }}
+        onCancel={handleBack}
+      />
+    );
+  }
+
+  if (viewMode === "tools" && toolsServerId) {
+    const server = servers.find((s) => s.id === toolsServerId);
+    if (!server) {
+      handleBack();
+      return null;
+    }
+    return (
+      <McpToolApproval
+        server={server}
+        onSave={async (allowedTools) => {
+          await updateAllowedTools(toolsServerId, allowedTools);
+          handleBack();
+        }}
+        onCancel={handleBack}
+      />
+    );
+  }
+
+  return (
+    <div className="p-5 space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-base font-medium">MCP Servers</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Connect external tool servers using the Model Context Protocol
+          </p>
+        </div>
+        <button
+          onClick={() => setViewMode("add")}
+          className="text-xs bg-primary text-primary-foreground px-3 py-1.5 rounded-md hover:bg-primary/90"
+        >
+          Add Server
+        </button>
+      </div>
+
+      {error && (
+        <div className="border border-red-500/30 bg-red-500/10 rounded-lg p-3 text-xs text-red-400">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center h-32 text-sm text-muted-foreground">
+          Loading...
+        </div>
+      ) : servers.length === 0 ? (
+        <div className="border border-border rounded-lg p-8 text-center text-sm text-muted-foreground">
+          No MCP servers configured. Click "Add Server" to connect one.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {servers.map((server) => {
+            const status = statuses[server.id] ?? { id: server.id, status: "disconnected", toolCount: 0 };
+            const serverWarnings = warnings[server.id] ?? [];
+            const isLoading = actionLoading[server.id] ?? false;
+
+            return (
+              <div key={server.id} className="border border-border rounded-lg p-4 space-y-3">
+                {/* Header row */}
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    {/* Toggle */}
+                    <button
+                      onClick={() => handleToggleEnabled(server)}
+                      className={`relative w-9 h-5 rounded-full transition-colors ${
+                        server.enabled ? "bg-primary" : "bg-secondary"
+                      }`}
+                    >
+                      <div
+                        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+                          server.enabled ? "translate-x-4" : ""
+                        }`}
+                      />
+                    </button>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium">{server.name}</span>
+                        <span className={`inline-block w-2 h-2 rounded-full ${STATUS_COLORS[status.status]}`} />
+                        <span className="text-[10px] text-muted-foreground">
+                          {STATUS_LABELS[status.status]}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-3 text-[10px] text-muted-foreground mt-0.5">
+                        <span className="font-mono">{server.transport}</span>
+                        {server.transport === "stdio" && server.command && (
+                          <span className="font-mono">{server.command} {server.args.join(" ")}</span>
+                        )}
+                        {server.transport === "sse" && server.url && (
+                          <span className="font-mono truncate max-w-[200px]">{server.url}</span>
+                        )}
+                        {status.toolCount > 0 && (
+                          <span>{status.toolCount} tools</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Warnings */}
+                {serverWarnings.length > 0 && (
+                  <div className="border border-yellow-500/30 bg-yellow-500/10 rounded-md p-2 space-y-1">
+                    {serverWarnings.map((w, i) => (
+                      <p key={i} className="text-[10px] text-yellow-400">{w.message}</p>
+                    ))}
+                  </div>
+                )}
+
+                {/* Error display */}
+                {status.status === "error" && status.error && (
+                  <div className="border border-red-500/30 bg-red-500/10 rounded-md p-2">
+                    <p className="text-[10px] text-red-400">{status.error}</p>
+                  </div>
+                )}
+
+                {/* Actions */}
+                <div className="flex items-center gap-2 flex-wrap">
+                  {status.status === "connected" ? (
+                    <>
+                      <button
+                        onClick={() => handleStop(server.id)}
+                        disabled={isLoading}
+                        className="text-xs text-muted-foreground hover:text-foreground px-2 py-1 disabled:opacity-50"
+                      >
+                        {isLoading ? "Stopping..." : "Stop"}
+                      </button>
+                      <button
+                        onClick={() => handleRestart(server.id)}
+                        disabled={isLoading}
+                        className="text-xs text-muted-foreground hover:text-foreground px-2 py-1 disabled:opacity-50"
+                      >
+                        Restart
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      onClick={() => handleStart(server.id)}
+                      disabled={isLoading}
+                      className="text-xs text-muted-foreground hover:text-foreground px-2 py-1 disabled:opacity-50"
+                    >
+                      {isLoading ? "Starting..." : "Start"}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => handleTest(server.id)}
+                    disabled={isLoading}
+                    className="text-xs text-muted-foreground hover:text-foreground px-2 py-1 disabled:opacity-50"
+                  >
+                    {isLoading ? "Testing..." : "Test"}
+                  </button>
+                  <button
+                    onClick={() => handleEditTools(server.id)}
+                    className="text-xs text-muted-foreground hover:text-foreground px-2 py-1"
+                  >
+                    Tools
+                  </button>
+                  <button
+                    onClick={() => handleEdit(server.id)}
+                    className="text-xs text-muted-foreground hover:text-foreground px-2 py-1"
+                  >
+                    Edit
+                  </button>
+                  {confirmDelete === server.id ? (
+                    <div className="flex items-center gap-1">
+                      <button
+                        onClick={() => handleDelete(server.id)}
+                        className="text-xs bg-red-500/10 text-red-500 rounded-md px-2 py-1"
+                      >
+                        Confirm
+                      </button>
+                      <button
+                        onClick={() => setConfirmDelete(null)}
+                        className="text-xs text-muted-foreground px-2 py-1"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setConfirmDelete(server.id)}
+                      className="text-xs text-red-500 hover:text-red-400 px-2 py-1"
+                    >
+                      Delete
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ===========================================================================
+// Server Add/Edit Form
+// ===========================================================================
+
+function McpServerForm({
+  server,
+  onSave,
+  onCancel,
+}: {
+  server?: McpServerConfig;
+  onSave: (data: McpServerCreate | McpServerUpdate) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(server?.name ?? "");
+  const [transport, setTransport] = useState<"stdio" | "sse">(server?.transport ?? "stdio");
+  const [command, setCommand] = useState(server?.command ?? "");
+  const [args, setArgs] = useState(server?.args.join(" ") ?? "");
+  const [envText, setEnvText] = useState(
+    Object.entries(server?.env ?? {})
+      .map(([k, v]) => `${k}=${v}`)
+      .join("\n"),
+  );
+  const [url, setUrl] = useState(server?.url ?? "");
+  const [headersText, setHeadersText] = useState(
+    Object.entries(server?.headers ?? {})
+      .map(([k, v]) => `${k}: ${v}`)
+      .join("\n"),
+  );
+  const [autoStart, setAutoStart] = useState(server?.autoStart ?? false);
+  const [timeout, setTimeout_] = useState(String(server?.timeout ?? 30000));
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const parseEnv = (text: string): Record<string, string> => {
+    const env: Record<string, string> = {};
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const idx = trimmed.indexOf("=");
+      if (idx > 0) {
+        env[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
+      }
+    }
+    return env;
+  };
+
+  const parseHeaders = (text: string): Record<string, string> => {
+    const headers: Record<string, string> = {};
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const idx = trimmed.indexOf(":");
+      if (idx > 0) {
+        headers[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
+      }
+    }
+    return headers;
+  };
+
+  const handleSubmit = async () => {
+    setFormError(null);
+    if (!name.trim()) {
+      setFormError("Name is required");
+      return;
+    }
+    if (transport === "stdio" && !command.trim()) {
+      setFormError("Command is required for stdio transport");
+      return;
+    }
+    if (transport === "sse" && !url.trim()) {
+      setFormError("URL is required for SSE transport");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const data: McpServerCreate | McpServerUpdate = {
+        name: name.trim(),
+        transport,
+        ...(transport === "stdio" && {
+          command: command.trim(),
+          args: args.trim() ? args.trim().split(/\s+/) : [],
+          env: parseEnv(envText),
+        }),
+        ...(transport === "sse" && {
+          url: url.trim(),
+          headers: parseHeaders(headersText),
+        }),
+        autoStart,
+        timeout: parseInt(timeout) || 30000,
+      };
+      await onSave(data);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputClass = "w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary";
+  const labelClass = "text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block";
+
+  return (
+    <div className="p-5 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-medium">
+          {server ? "Edit MCP Server" : "Add MCP Server"}
+        </h2>
+        <button onClick={onCancel} className="text-xs text-muted-foreground hover:text-foreground">
+          Back
+        </button>
+      </div>
+
+      {formError && (
+        <div className="border border-red-500/30 bg-red-500/10 rounded-lg p-3 text-xs text-red-400">
+          {formError}
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <div>
+          <label className={labelClass}>Name</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My MCP Server"
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label className={labelClass}>Transport</label>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setTransport("stdio")}
+              className={`text-xs px-3 py-1.5 rounded-md ${
+                transport === "stdio" ? "bg-primary text-primary-foreground" : "bg-secondary"
+              }`}
+            >
+              stdio
+            </button>
+            <button
+              onClick={() => setTransport("sse")}
+              className={`text-xs px-3 py-1.5 rounded-md ${
+                transport === "sse" ? "bg-primary text-primary-foreground" : "bg-secondary"
+              }`}
+            >
+              SSE
+            </button>
+          </div>
+        </div>
+
+        {transport === "stdio" && (
+          <>
+            <div>
+              <label className={labelClass}>Command</label>
+              <input
+                value={command}
+                onChange={(e) => setCommand(e.target.value)}
+                placeholder="npx"
+                className={`${inputClass} font-mono`}
+              />
+              <p className="text-[10px] text-muted-foreground mt-1">
+                Allowed: npx, node, python, python3, uvx, docker, deno
+              </p>
+            </div>
+
+            <div>
+              <label className={labelClass}>Arguments</label>
+              <input
+                value={args}
+                onChange={(e) => setArgs(e.target.value)}
+                placeholder="-y @modelcontextprotocol/server-filesystem /tmp"
+                className={`${inputClass} font-mono`}
+              />
+            </div>
+
+            <div>
+              <label className={labelClass}>Environment Variables</label>
+              <textarea
+                value={envText}
+                onChange={(e) => setEnvText(e.target.value)}
+                placeholder={"KEY=value\nANOTHER_KEY=another_value"}
+                rows={3}
+                className={`${inputClass} font-mono resize-none`}
+              />
+              <p className="text-[10px] text-muted-foreground mt-1">
+                One per line: KEY=value. Sensitive vars are stored encrypted.
+              </p>
+            </div>
+          </>
+        )}
+
+        {transport === "sse" && (
+          <>
+            <div>
+              <label className={labelClass}>URL</label>
+              <input
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://mcp-server.example.com/sse"
+                className={`${inputClass} font-mono`}
+              />
+              <p className="text-[10px] text-muted-foreground mt-1">
+                HTTPS required for non-localhost URLs
+              </p>
+            </div>
+
+            <div>
+              <label className={labelClass}>Headers</label>
+              <textarea
+                value={headersText}
+                onChange={(e) => setHeadersText(e.target.value)}
+                placeholder={"Authorization: Bearer your-token"}
+                rows={2}
+                className={`${inputClass} font-mono resize-none`}
+              />
+            </div>
+          </>
+        )}
+
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setAutoStart(!autoStart)}
+              className={`relative w-9 h-5 rounded-full transition-colors ${
+                autoStart ? "bg-primary" : "bg-secondary"
+              }`}
+            >
+              <div
+                className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+                  autoStart ? "translate-x-4" : ""
+                }`}
+              />
+            </button>
+            <span className="text-xs text-muted-foreground">Auto-start on boot</span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-muted-foreground">Timeout (ms):</label>
+            <input
+              value={timeout}
+              onChange={(e) => setTimeout_(e.target.value)}
+              className="w-20 bg-secondary rounded-md px-2 py-1 text-xs font-mono outline-none focus:ring-1 ring-primary"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex gap-2 pt-2">
+        <button
+          onClick={handleSubmit}
+          disabled={saving}
+          className="text-xs bg-primary text-primary-foreground px-4 py-1.5 rounded-md hover:bg-primary/90 disabled:opacity-50"
+        >
+          {saving ? "Saving..." : server ? "Save Changes" : "Create Server"}
+        </button>
+        <button
+          onClick={onCancel}
+          className="text-xs text-muted-foreground hover:text-foreground px-3 py-1.5"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ===========================================================================
+// Tool Approval Panel
+// ===========================================================================
+
+function McpToolApproval({
+  server,
+  onSave,
+  onCancel,
+}: {
+  server: McpServerConfig;
+  onSave: (allowedTools: string[] | null) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const tools = server.discoveredTools ?? [];
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    if (server.allowedTools === null) return new Set(tools.map((t) => t.name));
+    return new Set(server.allowedTools);
+  });
+  const [allowAll, setAllowAll] = useState(server.allowedTools === null);
+  const [saving, setSaving] = useState(false);
+
+  const toggleTool = (name: string) => {
+    const next = new Set(selected);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    setNext(next);
+  };
+
+  const setNext = (next: Set<string>) => {
+    setSelected(next);
+    setAllowAll(false);
+  };
+
+  const handleAllowAll = () => {
+    setSelected(new Set(tools.map((t) => t.name)));
+    setAllowAll(true);
+  };
+
+  const handleDenyAll = () => {
+    setSelected(new Set());
+    setAllowAll(false);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      if (allowAll) {
+        await onSave(null);
+      } else {
+        await onSave([...selected]);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="p-5 space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-base font-medium">Tools - {server.name}</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Select which tools from this server are available to agents
+          </p>
+        </div>
+        <button onClick={onCancel} className="text-xs text-muted-foreground hover:text-foreground">
+          Back
+        </button>
+      </div>
+
+      {tools.length === 0 ? (
+        <div className="border border-border rounded-lg p-8 text-center text-sm text-muted-foreground">
+          No tools discovered. Start or test the server first.
+        </div>
+      ) : (
+        <>
+          <div className="flex gap-2">
+            <button
+              onClick={handleAllowAll}
+              className="text-xs text-muted-foreground hover:text-foreground px-2 py-1"
+            >
+              Allow All
+            </button>
+            <button
+              onClick={handleDenyAll}
+              className="text-xs text-muted-foreground hover:text-foreground px-2 py-1"
+            >
+              Deny All
+            </button>
+            {allowAll && (
+              <span className="text-[10px] text-yellow-400 flex items-center">
+                All tools allowed (including future discoveries)
+              </span>
+            )}
+          </div>
+
+          <div className="space-y-1 max-h-[400px] overflow-y-auto">
+            {tools.map((tool) => (
+              <label
+                key={tool.name}
+                className="flex items-start gap-3 p-2 rounded-md hover:bg-secondary/50 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={selected.has(tool.name)}
+                  onChange={() => toggleTool(tool.name)}
+                  className="mt-0.5 accent-primary"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-mono">{tool.name}</div>
+                  {tool.description && (
+                    <div className="text-[10px] text-muted-foreground mt-0.5 line-clamp-2">
+                      {tool.description}
+                    </div>
+                  )}
+                </div>
+              </label>
+            ))}
+          </div>
+
+          <div className="flex gap-2 pt-2">
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="text-xs bg-primary text-primary-foreground px-4 py-1.5 rounded-md hover:bg-primary/90 disabled:opacity-50"
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+            <button
+              onClick={onCancel}
+              className="text-xs text-muted-foreground hover:text-foreground px-3 py-1.5"
+            >
+              Cancel
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -27,6 +27,7 @@ import { GoogleSection } from "./GoogleSection";
 import { SecuritySection } from "./SecuritySection";
 import { ModulesSection } from "./ModulesSection";
 import { WorkerNamesSection } from "./WorkerNamesSection";
+import { McpServersSection } from "./McpServersSection";
 import type { SettingsSection } from "./settings-nav";
 
 interface SettingsPageProps {
@@ -64,6 +65,7 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
     if (activeSection === "mattermost") return <MattermostSection />;
     if (activeSection === "nextcloud-talk") return <NextcloudTalkSection />;
     if (activeSection === "worker-names") return <WorkerNamesSection />;
+    if (activeSection === "mcp-servers") return <McpServersSection />;
     if (activeSection === "security") return <SecuritySection />;
     if (activeSection === "soul") return <SoulTab />;
     if (activeSection === "memory") return <MemoryTab />;

--- a/packages/web/src/components/settings/settings-nav.ts
+++ b/packages/web/src/components/settings/settings-nav.ts
@@ -24,6 +24,7 @@ export type SettingsSection =
   | "mattermost"
   | "nextcloud-talk"
   | "worker-names"
+  | "mcp-servers"
   | "security";
 
 export interface NavItem {
@@ -70,6 +71,7 @@ export const SETTINGS_NAV: NavGroup[] = [
       { id: "opencode", label: "Coding Agents" },
       { id: "scheduled", label: "Scheduled Tasks" },
       { id: "modules", label: "Modules" },
+      { id: "mcp-servers", label: "MCP Servers" },
     ],
   },
   {

--- a/packages/web/src/stores/mcp-store.ts
+++ b/packages/web/src/stores/mcp-store.ts
@@ -1,0 +1,223 @@
+import { create } from "zustand";
+import type {
+  McpServerConfig,
+  McpServerCreate,
+  McpServerUpdate,
+  McpServerRuntime,
+  McpToolMeta,
+} from "@otterbot/shared";
+
+interface SecurityWarning {
+  type: string;
+  message: string;
+}
+
+interface McpState {
+  servers: McpServerConfig[];
+  statuses: Record<string, McpServerRuntime>;
+  warnings: Record<string, SecurityWarning[]>;
+  loading: boolean;
+  error: string | null;
+
+  loadServers: () => Promise<void>;
+  createServer: (data: McpServerCreate) => Promise<McpServerConfig | null>;
+  updateServer: (id: string, data: McpServerUpdate) => Promise<McpServerConfig | null>;
+  deleteServer: (id: string) => Promise<boolean>;
+  startServer: (id: string) => Promise<boolean>;
+  stopServer: (id: string) => Promise<boolean>;
+  restartServer: (id: string) => Promise<boolean>;
+  testServer: (id: string) => Promise<{ ok: boolean; tools?: McpToolMeta[]; error?: string }>;
+  discoverTools: (id: string) => Promise<McpToolMeta[]>;
+  updateAllowedTools: (id: string, allowedTools: string[] | null) => Promise<McpServerConfig | null>;
+  updateStatus: (runtime: McpServerRuntime) => void;
+}
+
+export const useMcpStore = create<McpState>((set, get) => ({
+  servers: [],
+  statuses: {},
+  warnings: {},
+  loading: false,
+  error: null,
+
+  loadServers: async () => {
+    set({ loading: true, error: null });
+    try {
+      const res = await fetch("/api/settings/mcp-servers");
+      if (!res.ok) throw new Error("Failed to load MCP servers");
+      const data = await res.json();
+      set({
+        servers: data.servers ?? [],
+        statuses: data.statuses ?? {},
+        warnings: data.warnings ?? {},
+        loading: false,
+      });
+    } catch (err) {
+      set({
+        loading: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  },
+
+  createServer: async (data) => {
+    set({ error: null });
+    try {
+      const res = await fetch("/api/settings/mcp-servers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to create MCP server");
+      }
+      const server = await res.json();
+      await get().loadServers();
+      return server as McpServerConfig;
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+      return null;
+    }
+  },
+
+  updateServer: async (id, data) => {
+    set({ error: null });
+    try {
+      const res = await fetch(`/api/settings/mcp-servers/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to update MCP server");
+      }
+      const server = await res.json();
+      await get().loadServers();
+      return server as McpServerConfig;
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+      return null;
+    }
+  },
+
+  deleteServer: async (id) => {
+    set({ error: null });
+    try {
+      const res = await fetch(`/api/settings/mcp-servers/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to delete MCP server");
+      }
+      await get().loadServers();
+      return true;
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+      return false;
+    }
+  },
+
+  startServer: async (id) => {
+    try {
+      const res = await fetch(`/api/settings/mcp-servers/${id}/start`, { method: "POST" });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to start MCP server");
+      }
+      const data = await res.json();
+      if (data.status) {
+        set((s) => ({ statuses: { ...s.statuses, [id]: data.status } }));
+      }
+      return true;
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+      return false;
+    }
+  },
+
+  stopServer: async (id) => {
+    try {
+      const res = await fetch(`/api/settings/mcp-servers/${id}/stop`, { method: "POST" });
+      if (!res.ok) return false;
+      const data = await res.json();
+      if (data.status) {
+        set((s) => ({ statuses: { ...s.statuses, [id]: data.status } }));
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  restartServer: async (id) => {
+    try {
+      const res = await fetch(`/api/settings/mcp-servers/${id}/restart`, { method: "POST" });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to restart MCP server");
+      }
+      const data = await res.json();
+      if (data.status) {
+        set((s) => ({ statuses: { ...s.statuses, [id]: data.status } }));
+      }
+      return true;
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+      return false;
+    }
+  },
+
+  testServer: async (id) => {
+    try {
+      const res = await fetch(`/api/settings/mcp-servers/${id}/test`, { method: "POST" });
+      const data = await res.json();
+      if (!res.ok) return { ok: false, error: data.error || "Test failed" };
+      if (data.status) {
+        set((s) => ({ statuses: { ...s.statuses, [id]: data.status } }));
+      }
+      await get().loadServers();
+      return { ok: true, tools: data.tools };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : "Unknown error" };
+    }
+  },
+
+  discoverTools: async (id) => {
+    try {
+      const res = await fetch(`/api/settings/mcp-servers/${id}/discover`, { method: "POST" });
+      if (!res.ok) return [];
+      const data = await res.json();
+      await get().loadServers();
+      return data.tools ?? [];
+    } catch {
+      return [];
+    }
+  },
+
+  updateAllowedTools: async (id, allowedTools) => {
+    set({ error: null });
+    try {
+      const res = await fetch(`/api/settings/mcp-servers/${id}/tools`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ allowedTools }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to update tools");
+      }
+      const server = await res.json();
+      await get().loadServers();
+      return server as McpServerConfig;
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Unknown error" });
+      return null;
+    }
+  },
+
+  updateStatus: (runtime) => {
+    set((s) => ({
+      statuses: { ...s.statuses, [runtime.id]: runtime },
+    }));
+  },
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@huggingface/transformers':
         specifier: ^3.4.1
         version: 3.8.1
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.1
+        version: 1.27.1(zod@3.25.76)
       '@opencode-ai/sdk':
         specifier: ^1.2.6
         version: 1.2.6
@@ -1290,6 +1293,12 @@ packages:
   '@fastify/static@8.3.0':
     resolution: {integrity: sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==}
 
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@huggingface/jinja@0.5.5':
     resolution: {integrity: sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ==}
     engines: {node: '>=18'}
@@ -1508,6 +1517,16 @@ packages:
 
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@monogrid/gainmap-js@3.4.0':
     resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
@@ -3422,6 +3441,10 @@ packages:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -3429,6 +3452,12 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.2.1:
+    resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -3816,6 +3845,10 @@ packages:
   hls.js@1.6.15:
     resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
 
+  hono@4.12.2:
+    resolution: {integrity: sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -3892,6 +3925,10 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  ip-address@10.0.1:
+    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+    engines: {node: '>= 12'}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -4124,6 +4161,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -4163,6 +4203,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -4861,6 +4904,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -7035,6 +7082,10 @@ snapshots:
       fastq: 1.20.1
       glob: 11.1.0
 
+  '@hono/node-server@1.19.9(hono@4.12.2)':
+    dependencies:
+      hono: 4.12.2
+
   '@huggingface/jinja@0.5.5': {}
 
   '@huggingface/transformers@3.8.1':
@@ -7199,6 +7250,28 @@ snapshots:
   '@mermaid-js/parser@0.6.3':
     dependencies:
       langium: 3.3.1
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.2)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.2
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@monogrid/gainmap-js@3.4.0(three@0.182.0)':
     dependencies:
@@ -9367,9 +9440,18 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.2.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.0.1
 
   express@5.2.1:
     dependencies:
@@ -9882,6 +9964,8 @@ snapshots:
 
   hls.js@1.6.15: {}
 
+  hono@4.12.2: {}
+
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
@@ -9969,6 +10053,8 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
+
+  ip-address@10.0.1: {}
 
   ip-address@10.1.0: {}
 
@@ -10197,6 +10283,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jose@6.1.3: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -10229,6 +10317,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -11158,6 +11248,8 @@ snapshots:
       thread-stream: 4.0.0
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds full MCP (Model Context Protocol) server integration so agents can use tools from external MCP servers
- Supports both **stdio** (child process) and **SSE** (remote HTTP) transports
- Includes security hardening: command allowlist, env var filtering, HTTPS enforcement, per-tool approval
- New settings UI section for managing MCP server connections

### New files
- `packages/shared/src/types/mcp-server.ts` — shared types
- `packages/server/src/mcp/mcp-security.ts` — security validation module
- `packages/server/src/mcp/mcp-service.ts` — CRUD service with secret masking
- `packages/server/src/mcp/mcp-client-manager.ts` — singleton client manager using `@modelcontextprotocol/sdk`
- `packages/web/src/stores/mcp-store.ts` — Zustand store
- `packages/web/src/components/settings/McpServersSection.tsx` — settings UI

### Modified files
- DB schema + migration for `mcp_servers` table
- 12 REST endpoints under `/api/settings/mcp-servers`
- Tool factory integration with `mcp_<server>_<tool>` naming
- Socket event `mcp:status` for real-time status updates
- Settings nav + page wiring

## Test plan
- [ ] All 872 existing tests pass
- [ ] Server and shared packages type-check cleanly
- [ ] Manual test: add an MCP server via UI (e.g. `npx -y @modelcontextprotocol/server-filesystem@latest /tmp`), verify tools appear in agent workshop
- [ ] Verify disallowed commands are rejected (e.g. `curl`)
- [ ] Verify `OTTERBOT_DB_KEY` is stripped from MCP process env
- [ ] Verify HTTPS required for non-localhost SSE URLs