### PR TITLE
fix: remove auto-enqueue from pipeline completion

### DIFF
--- a/packages/server/src/pipeline/pipeline-manager.ts
+++ b/packages/server/src/pipeline/pipeline-manager.ts
@@ -814,17 +814,6 @@ export class PipelineManager {
       await this.completeTask(taskId, state, workerReport);
       this.pipelines.delete(taskId);
 
-      // Auto-enqueue in merge queue if the pipeline created a PR.
-      // The pipeline's own reviewer stage PASS verdict serves as the approval —
-      // without this, tasks sit in "in_review" waiting for an external GitHub
-      // approval that never comes for bot-created PRs.
-      if (this.mergeQueue && (state.prNumber || state.prBranch)) {
-        const entry = this.mergeQueue.approveForMerge(taskId);
-        if (entry) {
-          console.log(`[PipelineManager] Auto-enqueued task ${taskId} in merge queue after pipeline completion`);
-        }
-      }
-
       // Post completion comment
       if (state.issueNumber && state.repo) {
         const token = getConfig("github:token");


### PR DESCRIPTION
## Summary
- Removed the auto-enqueue block in `advancePipeline` that immediately called `mergeQueue.approveForMerge()` after pipeline completion, bypassing human PR review
- Tasks now remain in `in_review` until the PR monitor detects a GitHub APPROVED review and enqueues them
- Updated test to assert `approveForMerge` is **not** called on pipeline completion

## Test plan
- [x] All 912 tests pass
- [x] TypeScript type-check passes (pre-existing errors only)