### PR TITLE
feat: add Mistral LLM provider support

### DIFF
--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -274,7 +274,7 @@ export const providers = sqliteTable("providers", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   type: text("type", {
-    enum: ["anthropic", "openai", "google", "ollama", "openai-compatible", "openrouter", "github-copilot", "huggingface", "nvidia", "minimax", "xai", "zai", "perplexity", "deepgram", "bedrock", "lmstudio", "deepseek"],
+    enum: ["anthropic", "openai", "google", "ollama", "openai-compatible", "openrouter", "github-copilot", "huggingface", "nvidia", "minimax", "xai", "zai", "perplexity", "deepgram", "bedrock", "lmstudio", "deepseek", "mistral"],
   }).notNull(),
   apiKey: text("api_key"),
   baseUrl: text("base_url"),

--- a/packages/server/src/llm/adapter.ts
+++ b/packages/server/src/llm/adapter.ts
@@ -226,6 +226,14 @@ export function resolveModel(config: LLMConfig): LanguageModel {
       return deepseek(config.model);
     }
 
+    case "mistral": {
+      const mistral = createOpenAI({
+        baseURL: config.baseUrl ?? resolved.baseUrl ?? "https://api.mistral.ai/v1",
+        apiKey: config.apiKey ?? resolved.apiKey ?? "",
+      });
+      return mistral(config.model);
+    }
+
     default:
       throw new Error(`Unknown LLM provider: ${config.provider} (type: ${resolved.type})`);
   }

--- a/packages/server/src/settings/model-pricing.ts
+++ b/packages/server/src/settings/model-pricing.ts
@@ -37,6 +37,11 @@ const DEFAULT_MODEL_PRICES: Record<string, ModelPrice> = {
   // DeepSeek
   "deepseek-chat": { inputPerMillion: 0.27, outputPerMillion: 1.10 },
   "deepseek-reasoner": { inputPerMillion: 0.55, outputPerMillion: 2.19 },
+  // Mistral
+  "mistral-large-latest": { inputPerMillion: 2, outputPerMillion: 6 },
+  "mistral-small-latest": { inputPerMillion: 0.1, outputPerMillion: 0.3 },
+  "codestral-latest": { inputPerMillion: 0.3, outputPerMillion: 0.9 },
+  "mistral-medium-latest": { inputPerMillion: 2.7, outputPerMillion: 8.1 },
   // Google
   "gemini-2.5-pro": { inputPerMillion: 1.25, outputPerMillion: 10 },
   "gemini-2.5-flash": { inputPerMillion: 0.15, outputPerMillion: 0.6 },

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -1,4 +1,4 @@
-export type ProviderType = "anthropic" | "openai" | "google" | "ollama" | "openai-compatible" | "openrouter" | "github-copilot" | "huggingface" | "nvidia" | "minimax" | "xai" | "zai" | "perplexity" | "deepgram" | "bedrock" | "lmstudio" | "deepseek";
+export type ProviderType = "anthropic" | "openai" | "google" | "ollama" | "openai-compatible" | "openrouter" | "github-copilot" | "huggingface" | "nvidia" | "minimax" | "xai" | "zai" | "perplexity" | "deepgram" | "bedrock" | "lmstudio" | "deepseek" | "mistral";
 
 export interface NamedProvider {
   id: string;

--- a/packages/web/src/components/settings/ProvidersTab.tsx
+++ b/packages/web/src/components/settings/ProvidersTab.tsx
@@ -12,6 +12,7 @@ const TYPE_LABELS: Record<string, string> = {
   nvidia: "NVIDIA",
   lmstudio: "LM Studio",
   deepseek: "DeepSeek",
+  mistral: "Mistral",
 };
 
 export function ProvidersTab() {


### PR DESCRIPTION
## Summary
- Adds Mistral as a new LLM provider for OpenClaw parity
- Supports models: Mistral Large, Mistral Small, Codestral, Mistral Medium
- Uses OpenAI-compatible adapter pointing at `https://api.mistral.ai/v1`

Closes #221

## Changes
- **shared/types**: Added `"mistral"` to `ProviderType` union
- **server/db/schema**: Added `"mistral"` to provider type enum
- **server/llm/adapter**: Added `mistral` case using `createOpenAI` with Mistral base URL
- **server/settings**: Added provider metadata, fallback models, pricing, and model fetching
- **web/ProvidersTab**: Added display label

## Test plan
- [ ] Verify existing tests pass (`npx pnpm test`)
- [ ] Verify build succeeds (`npx pnpm build`)
- [ ] Configure a Mistral provider with API key and verify model list fetches
- [ ] Send a chat message using Mistral Large and verify response

🤖 Generated with [Claude Code](https://claude.com/claude-code)