### PR TITLE
feat: expose target branch setting in project settings

### DIFF
--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -244,4 +244,14 @@ export interface ClientToServerEvents {
     data: { entryId: string; newPosition: number },
     callback?: (ack: { ok: boolean; error?: string }) => void,
   ) => void;
+
+  // Target branch
+  "project:get-branch": (
+    data: { projectId: string },
+    callback: (result: { branch: string | null }) => void,
+  ) => void;
+  "project:set-branch": (
+    data: { projectId: string; branch: string },
+    callback?: (ack: { ok: boolean; error?: string }) => void,
+  ) => void;
 }


### PR DESCRIPTION
## Summary
- Adds `project:get-branch` and `project:set-branch` socket events (shared types + server handlers)
- Server handler reads from config key first, falls back to DB column; setter updates both to keep them in sync
- Adds a "Target Branch" text input to `ProjectSettings`, visible only for GitHub projects, saved alongside existing settings

## Test plan
- [x] All 912 tests pass (`npx pnpm test`)
- [x] No new type errors introduced
- [ ] Manual: open a GitHub project's settings, verify branch field shows current value, change it, save, refresh — confirm it persists
- [ ] Verify pipeline reads the updated value via `getConfig(project:{id}:github:branch)`