### PR TITLE
feat: add SSH module for remote host management

### DIFF
--- a/packages/server/src/db/__tests__/migration-ssh.test.ts
+++ b/packages/server/src/db/__tests__/migration-ssh.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrateDb, resetDb, getDb, schema } from "../index.js";
+import { eq } from "drizzle-orm";
+
+// Mock auth (required by seed.js which is called from migrateDb)
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn(() => undefined),
+  setConfig: vi.fn(),
+  deleteConfig: vi.fn(),
+}));
+
+describe("DB Migration — SSH tables", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-db-ssh-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+  });
+
+  afterEach(() => {
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates ssh_keys table", () => {
+    const db = getDb();
+    const now = new Date().toISOString();
+
+    db.insert(schema.sshKeys)
+      .values({
+        id: "test-key-1",
+        name: "Test Key",
+        username: "testuser",
+        privateKeyPath: "/tmp/test",
+        fingerprint: "SHA256:abc123",
+        keyType: "ed25519",
+        allowedHosts: ["host1", "host2"],
+        port: 22,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    const key = db.select().from(schema.sshKeys).where(eq(schema.sshKeys.id, "test-key-1")).get();
+    expect(key).toBeTruthy();
+    expect(key!.name).toBe("Test Key");
+    expect(key!.username).toBe("testuser");
+    expect(key!.privateKeyPath).toBe("/tmp/test");
+    expect(key!.fingerprint).toBe("SHA256:abc123");
+    expect(key!.keyType).toBe("ed25519");
+    expect(key!.allowedHosts).toEqual(["host1", "host2"]);
+    expect(key!.port).toBe(22);
+  });
+
+  it("creates ssh_sessions table", () => {
+    const db = getDb();
+    const now = new Date().toISOString();
+
+    db.insert(schema.sshSessions)
+      .values({
+        id: "test-session-1",
+        sshKeyId: "key-1",
+        host: "example.com",
+        status: "active",
+        startedAt: now,
+        initiatedBy: "user",
+        createdAt: now,
+      })
+      .run();
+
+    const session = db.select().from(schema.sshSessions).where(eq(schema.sshSessions.id, "test-session-1")).get();
+    expect(session).toBeTruthy();
+    expect(session!.sshKeyId).toBe("key-1");
+    expect(session!.host).toBe("example.com");
+    expect(session!.status).toBe("active");
+    expect(session!.initiatedBy).toBe("user");
+    expect(session!.completedAt).toBeNull();
+    expect(session!.terminalBuffer).toBeNull();
+  });
+
+  it("supports session terminal buffer", () => {
+    const db = getDb();
+    const now = new Date().toISOString();
+
+    db.insert(schema.sshSessions)
+      .values({
+        id: "test-session-buf",
+        sshKeyId: "key-1",
+        host: "example.com",
+        status: "completed",
+        startedAt: now,
+        completedAt: now,
+        terminalBuffer: "$ echo hello\nhello\n$ ",
+        initiatedBy: "agent-123",
+        createdAt: now,
+      })
+      .run();
+
+    const session = db.select().from(schema.sshSessions).where(eq(schema.sshSessions.id, "test-session-buf")).get();
+    expect(session!.terminalBuffer).toBe("$ echo hello\nhello\n$ ");
+    expect(session!.initiatedBy).toBe("agent-123");
+  });
+
+  it("stores allowedHosts as JSON array", () => {
+    const db = getDb();
+    const now = new Date().toISOString();
+    const hosts = ["192.168.1.1", "10.0.0.1", "prod.example.com"];
+
+    db.insert(schema.sshKeys)
+      .values({
+        id: "test-hosts",
+        name: "Hosts Test",
+        username: "root",
+        privateKeyPath: "/tmp/k",
+        fingerprint: "SHA256:xyz",
+        keyType: "rsa",
+        allowedHosts: hosts,
+        port: 2222,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    const key = db.select().from(schema.sshKeys).where(eq(schema.sshKeys.id, "test-hosts")).get();
+    expect(key!.allowedHosts).toEqual(hosts);
+    expect(key!.keyType).toBe("rsa");
+    expect(key!.port).toBe(2222);
+  });
+
+  it("seeds SSH Administrator registry entry", () => {
+    const db = getDb();
+    const entry = db.select().from(schema.registryEntries).where(eq(schema.registryEntries.id, "builtin-ssh-administrator")).get();
+    expect(entry).toBeTruthy();
+    expect(entry!.name).toBe("SSH Administrator");
+    expect(entry!.role).toBe("worker");
+    expect(entry!.builtIn).toBe(true);
+  });
+
+  it("seeds SSH administration skill", () => {
+    const db = getDb();
+    const skill = db.select().from(schema.skills).where(eq(schema.skills.id, "builtin-skill-ssh-administration")).get();
+    expect(skill).toBeTruthy();
+    expect(skill!.name).toBe("SSH Administration");
+    expect(skill!.tools).toContain("ssh_exec");
+    expect(skill!.tools).toContain("ssh_list_keys");
+    expect(skill!.tools).toContain("ssh_list_hosts");
+    expect(skill!.tools).toContain("ssh_connect");
+  });
+
+  it("assigns SSH skill to SSH Administrator", () => {
+    const db = getDb();
+    const assignments = db.select().from(schema.agentSkills)
+      .where(eq(schema.agentSkills.registryEntryId, "builtin-ssh-administrator"))
+      .all();
+    expect(assignments.some((a) => a.skillId === "builtin-skill-ssh-administration")).toBe(true);
+  });
+});

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -645,6 +645,33 @@ export async function migrateDb() {
     updated_at TEXT NOT NULL
   )`);
 
+  // SSH keys table
+  db.run(sql`CREATE TABLE IF NOT EXISTS ssh_keys (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    username TEXT NOT NULL,
+    private_key_path TEXT NOT NULL,
+    fingerprint TEXT NOT NULL,
+    key_type TEXT NOT NULL DEFAULT 'ed25519',
+    allowed_hosts TEXT NOT NULL DEFAULT '[]',
+    port INTEGER NOT NULL DEFAULT 22,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`);
+
+  // SSH sessions table
+  db.run(sql`CREATE TABLE IF NOT EXISTS ssh_sessions (
+    id TEXT PRIMARY KEY,
+    ssh_key_id TEXT NOT NULL,
+    host TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    started_at TEXT NOT NULL,
+    completed_at TEXT,
+    terminal_buffer TEXT,
+    initiated_by TEXT NOT NULL DEFAULT 'user',
+    created_at TEXT NOT NULL
+  )`);
+
   // FTS5 full-text search index for memories
   try {
     db.run(sql`CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { sqliteTable, text, integer, primaryKey, unique } from "drizzle-orm/sqlite-core";
-import type { ScanFinding, SkillScanStatus, CodingAgentPart, CodingAgentType, MemoryCategory, MemorySource, McpToolMeta } from "@otterbot/shared";
+import type { ScanFinding, SkillScanStatus, CodingAgentPart, CodingAgentType, MemoryCategory, MemorySource, McpToolMeta, SshKeyType, SshSessionStatus } from "@otterbot/shared";
 
 export const agents = sqliteTable("agents", {
   id: text("id").primaryKey(),
@@ -506,6 +506,40 @@ export const mcpServers = sqliteTable("mcp_servers", {
     .notNull()
     .$defaultFn(() => new Date().toISOString()),
   updatedAt: text("updated_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+});
+
+export const sshKeys = sqliteTable("ssh_keys", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  username: text("username").notNull(),
+  privateKeyPath: text("private_key_path").notNull(),
+  fingerprint: text("fingerprint").notNull(),
+  keyType: text("key_type").$type<SshKeyType>().notNull().default("ed25519"),
+  allowedHosts: text("allowed_hosts", { mode: "json" })
+    .$type<string[]>()
+    .notNull()
+    .default([]),
+  port: integer("port").notNull().default(22),
+  createdAt: text("created_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+  updatedAt: text("updated_at")
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+});
+
+export const sshSessions = sqliteTable("ssh_sessions", {
+  id: text("id").primaryKey(),
+  sshKeyId: text("ssh_key_id").notNull(),
+  host: text("host").notNull(),
+  status: text("status").$type<SshSessionStatus>().notNull().default("active"),
+  startedAt: text("started_at").notNull(),
+  completedAt: text("completed_at"),
+  terminalBuffer: text("terminal_buffer"),
+  initiatedBy: text("initiated_by").notNull().default("user"),
+  createdAt: text("created_at")
     .notNull()
     .$defaultFn(() => new Date().toISOString()),
 });

--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -218,6 +218,19 @@ Guidelines:
     role: "worker" as const,
   },
   {
+    id: "builtin-ssh-administrator",
+    name: "SSH Administrator",
+    description:
+      "Manages remote servers via SSH. Can execute commands, check system status, and open interactive sessions for debugging.",
+    systemPrompt: "See assigned skills for instructions.",
+    capabilities: [] as string[],
+    defaultModel: "claude-sonnet-4-5-20250929",
+    defaultProvider: "anthropic",
+    tools: [] as string[],
+    builtIn: true,
+    role: "worker" as const,
+  },
+  {
     id: "builtin-tool-builder",
     name: "Tool Builder",
     description:

--- a/packages/server/src/skills/seed-skills.ts
+++ b/packages/server/src/skills/seed-skills.ts
@@ -460,6 +460,39 @@ automatically filters to your assigned issues. Do not pick up unassigned issues.
     },
   },
   {
+    id: "builtin-skill-ssh-administration",
+    data: {
+      meta: {
+        name: "SSH Administration",
+        description:
+          "SSH key management and remote command execution for system administration.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: ["ssh_exec", "ssh_list_keys", "ssh_list_hosts", "ssh_connect"],
+        capabilities: ["ssh", "remote-management", "system-administration"],
+        parameters: {},
+        tags: ["built-in", "ssh"],
+      },
+      body: `You are an SSH administration specialist. You manage remote servers via SSH.
+
+## Workflow
+1. **Always start by listing available SSH keys** using ssh_list_keys
+2. **Check allowed hosts** for the relevant key using ssh_list_hosts
+3. **Use targeted commands** — run specific, well-scoped commands rather than broad operations
+4. **Report output clearly** — summarize command results for the user
+
+## Tool Selection
+- Use \`ssh_exec\` for quick one-shot commands (status checks, log tailing, service management)
+- Use \`ssh_connect\` for interactive debugging sessions that need sustained terminal access
+
+## Security Rules
+- NEVER modify remote authorized_keys files
+- NEVER run shutdown, reboot, or destructive filesystem commands unless explicitly instructed
+- Always verify you're connecting to the correct host before running commands
+- Report any connection failures or unexpected output immediately`,
+    },
+  },
+  {
     id: "builtin-skill-tool-building",
     data: {
       meta: {
@@ -531,6 +564,7 @@ const ENTRY_SKILL_ASSIGNMENTS: Record<string, string[]> = {
   "builtin-codex-coder": ["builtin-skill-codex-delegation", "builtin-skill-github-tools"],
   "builtin-triage": ["builtin-skill-github-tools"],
   "builtin-browser-agent": ["builtin-skill-browser-automation"],
+  "builtin-ssh-administrator": ["builtin-skill-ssh-administration"],
   "builtin-tool-builder": ["builtin-skill-tool-building"],
 };
 

--- a/packages/server/src/ssh/__tests__/ssh-service.test.ts
+++ b/packages/server/src/ssh/__tests__/ssh-service.test.ts
@@ -1,0 +1,409 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Mock auth (required by seed.js which is called from migrateDb)
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn(() => undefined),
+  setConfig: vi.fn(),
+  deleteConfig: vi.fn(),
+}));
+
+import { migrateDb, resetDb, getDb, schema } from "../../db/index.js";
+import { SshService } from "../ssh-service.js";
+
+describe("SshService", () => {
+  let tmpDir: string;
+  let svc: SshService;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-ssh-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    // Set HOME so keys are generated in the temp dir
+    process.env.HOME = tmpDir;
+    await migrateDb();
+    svc = new SshService();
+  });
+
+  afterEach(() => {
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    // Restore HOME to avoid side effects
+    delete process.env.HOME;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ─── Key Generation ─────────────────────────────────────────
+
+  describe("generateKey", () => {
+    it("generates an ed25519 key pair", () => {
+      const key = svc.generateKey({
+        name: "test-key",
+        username: "testuser",
+        allowedHosts: ["192.168.1.1", "example.com"],
+      });
+
+      expect(key.id).toBeTruthy();
+      expect(key.name).toBe("test-key");
+      expect(key.username).toBe("testuser");
+      expect(key.keyType).toBe("ed25519");
+      expect(key.allowedHosts).toEqual(["192.168.1.1", "example.com"]);
+      expect(key.port).toBe(22);
+      expect(key.fingerprint).toContain("SHA256:");
+      expect(key.createdAt).toBeTruthy();
+      expect(key.updatedAt).toBeTruthy();
+    });
+
+    it("generates an RSA key pair", () => {
+      const key = svc.generateKey({
+        name: "rsa-key",
+        username: "admin",
+        allowedHosts: ["host1.example.com"],
+        keyType: "rsa",
+      });
+
+      expect(key.keyType).toBe("rsa");
+      expect(key.fingerprint).toContain("SHA256:");
+    });
+
+    it("creates key files with correct permissions", () => {
+      const key = svc.generateKey({
+        name: "perms-test",
+        username: "user",
+        allowedHosts: [],
+      });
+
+      const keyPath = svc.getKeyPath(key.id)!;
+      expect(existsSync(keyPath)).toBe(true);
+      expect(existsSync(`${keyPath}.pub`)).toBe(true);
+
+      // Private key should be 0600
+      const stats = statSync(keyPath);
+      expect(stats.mode & 0o777).toBe(0o600);
+    });
+
+    it("uses custom port", () => {
+      const key = svc.generateKey({
+        name: "custom-port",
+        username: "user",
+        allowedHosts: [],
+        port: 2222,
+      });
+
+      expect(key.port).toBe(2222);
+    });
+
+    it("persists key to database", () => {
+      const key = svc.generateKey({
+        name: "db-test",
+        username: "user",
+        allowedHosts: ["host1"],
+      });
+
+      const retrieved = svc.get(key.id);
+      expect(retrieved).toBeTruthy();
+      expect(retrieved!.name).toBe("db-test");
+      expect(retrieved!.username).toBe("user");
+      expect(retrieved!.allowedHosts).toEqual(["host1"]);
+    });
+  });
+
+  // ─── Key Import ─────────────────────────────────────────────
+
+  describe("importKey", () => {
+    it("imports a valid private key", () => {
+      // First generate a key to have a valid private key to import
+      const generated = svc.generateKey({
+        name: "source",
+        username: "gen",
+        allowedHosts: [],
+      });
+      const keyPath = svc.getKeyPath(generated.id)!;
+      const privateKeyContent = readFileSync(keyPath, "utf-8");
+
+      const imported = svc.importKey({
+        name: "imported-key",
+        username: "importuser",
+        privateKey: privateKeyContent,
+        allowedHosts: ["10.0.0.1"],
+        port: 2222,
+      });
+
+      expect(imported.name).toBe("imported-key");
+      expect(imported.username).toBe("importuser");
+      expect(imported.allowedHosts).toEqual(["10.0.0.1"]);
+      expect(imported.port).toBe(2222);
+      expect(imported.fingerprint).toContain("SHA256:");
+    });
+
+    it("rejects an invalid private key", () => {
+      expect(() =>
+        svc.importKey({
+          name: "bad-key",
+          username: "user",
+          privateKey: "not a valid key",
+          allowedHosts: [],
+        }),
+      ).toThrow("Invalid private key");
+    });
+  });
+
+  // ─── Key CRUD ───────────────────────────────────────────────
+
+  describe("list", () => {
+    it("returns empty array when no keys exist", () => {
+      expect(svc.list()).toEqual([]);
+    });
+
+    it("returns all keys ordered by creation date", () => {
+      svc.generateKey({ name: "key1", username: "u1", allowedHosts: [] });
+      svc.generateKey({ name: "key2", username: "u2", allowedHosts: [] });
+
+      const keys = svc.list();
+      expect(keys).toHaveLength(2);
+      // Most recent first
+      expect(keys[0].name).toBe("key2");
+      expect(keys[1].name).toBe("key1");
+    });
+  });
+
+  describe("get", () => {
+    it("returns null for non-existent key", () => {
+      expect(svc.get("nonexistent")).toBeNull();
+    });
+
+    it("returns key by ID", () => {
+      const key = svc.generateKey({ name: "find-me", username: "u", allowedHosts: [] });
+      const found = svc.get(key.id);
+      expect(found).toBeTruthy();
+      expect(found!.name).toBe("find-me");
+    });
+  });
+
+  describe("update", () => {
+    it("updates key metadata", () => {
+      const key = svc.generateKey({ name: "old-name", username: "old", allowedHosts: ["h1"] });
+
+      const updated = svc.update(key.id, {
+        name: "new-name",
+        username: "newuser",
+        allowedHosts: ["h1", "h2"],
+        port: 3333,
+      });
+
+      expect(updated).toBeTruthy();
+      expect(updated!.name).toBe("new-name");
+      expect(updated!.username).toBe("newuser");
+      expect(updated!.allowedHosts).toEqual(["h1", "h2"]);
+      expect(updated!.port).toBe(3333);
+    });
+
+    it("returns null for non-existent key", () => {
+      expect(svc.update("nonexistent", { name: "nope" })).toBeNull();
+    });
+
+    it("supports partial updates", () => {
+      const key = svc.generateKey({ name: "partial", username: "u", allowedHosts: ["h1"], port: 22 });
+      const updated = svc.update(key.id, { name: "updated-name" });
+
+      expect(updated!.name).toBe("updated-name");
+      expect(updated!.username).toBe("u"); // unchanged
+      expect(updated!.allowedHosts).toEqual(["h1"]); // unchanged
+    });
+  });
+
+  describe("deleteKey", () => {
+    it("deletes key and removes files", () => {
+      const key = svc.generateKey({ name: "delete-me", username: "u", allowedHosts: [] });
+      const keyPath = svc.getKeyPath(key.id)!;
+
+      expect(existsSync(keyPath)).toBe(true);
+      expect(svc.deleteKey(key.id)).toBe(true);
+      expect(existsSync(keyPath)).toBe(false);
+      expect(svc.get(key.id)).toBeNull();
+    });
+
+    it("returns false for non-existent key", () => {
+      expect(svc.deleteKey("nonexistent")).toBe(false);
+    });
+  });
+
+  describe("getPublicKey", () => {
+    it("returns public key text", () => {
+      const key = svc.generateKey({ name: "pubkey-test", username: "u", allowedHosts: [] });
+      const pubKey = svc.getPublicKey(key.id);
+
+      expect(pubKey).toBeTruthy();
+      expect(pubKey).toContain("ssh-ed25519");
+    });
+
+    it("returns null for non-existent key", () => {
+      expect(svc.getPublicKey("nonexistent")).toBeNull();
+    });
+  });
+
+  // ─── Host Validation ────────────────────────────────────────
+
+  describe("validateHost", () => {
+    it("allows a host in the allowlist", () => {
+      const key = svc.generateKey({ name: "vhost", username: "u", allowedHosts: ["10.0.0.1", "example.com"] });
+      expect(svc.validateHost(key.id, "10.0.0.1")).toEqual({ ok: true });
+      expect(svc.validateHost(key.id, "example.com")).toEqual({ ok: true });
+    });
+
+    it("rejects a host not in the allowlist", () => {
+      const key = svc.generateKey({ name: "vhost2", username: "u", allowedHosts: ["10.0.0.1"] });
+      const result = svc.validateHost(key.id, "evil.com");
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("not in the allowlist");
+    });
+
+    it("rejects when no hosts configured", () => {
+      const key = svc.generateKey({ name: "vhost3", username: "u", allowedHosts: [] });
+      const result = svc.validateHost(key.id, "any.host");
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("No hosts configured");
+    });
+
+    it("returns error for non-existent key", () => {
+      const result = svc.validateHost("nonexistent", "host");
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("SSH key not found");
+    });
+  });
+
+  // ─── Exec (blocked commands) ────────────────────────────────
+
+  describe("exec", () => {
+    it("blocks dangerous commands", () => {
+      const key = svc.generateKey({ name: "exec-test", username: "u", allowedHosts: ["host1"] });
+
+      const blockedCommands = [
+        { cmd: "rm -rf /etc", reason: "rm targeting root filesystem" },
+        { cmd: "shutdown now", reason: "shutdown" },
+        { cmd: "reboot", reason: "reboot" },
+        { cmd: "mkfs.ext4 /dev/sda1", reason: "mkfs" },
+        { cmd: "dd if=/dev/zero of=/dev/sda", reason: "dd" },
+        { cmd: "halt", reason: "halt" },
+        { cmd: "poweroff", reason: "poweroff" },
+      ];
+
+      for (const { cmd } of blockedCommands) {
+        const result = svc.exec({ keyId: key.id, host: "host1", command: cmd });
+        expect(result.ok, `Expected "${cmd}" to be blocked`).toBe(false);
+        expect(result.error, `Expected "${cmd}" to have 'Blocked command' error`).toContain("Blocked command");
+      }
+    });
+
+    it("rejects non-allowlisted hosts", () => {
+      const key = svc.generateKey({ name: "exec-host", username: "u", allowedHosts: ["good.host"] });
+      const result = svc.exec({ keyId: key.id, host: "evil.host", command: "echo hi" });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("not in the allowlist");
+    });
+
+    it("rejects non-existent key", () => {
+      const result = svc.exec({ keyId: "fake", host: "host", command: "echo hi" });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("SSH key not found");
+    });
+  });
+
+  // ─── Session Management ─────────────────────────────────────
+
+  describe("session management", () => {
+    it("creates and retrieves a session", () => {
+      const key = svc.generateKey({ name: "sess-key", username: "u", allowedHosts: ["h1"] });
+      const sessionId = svc.createSession({
+        sshKeyId: key.id,
+        host: "h1",
+        initiatedBy: "user",
+      });
+
+      expect(sessionId).toBeTruthy();
+
+      const session = svc.getSession(sessionId);
+      expect(session).toBeTruthy();
+      expect(session!.sshKeyId).toBe(key.id);
+      expect(session!.host).toBe("h1");
+      expect(session!.status).toBe("active");
+      expect(session!.username).toBe("u");
+      expect(session!.initiatedBy).toBe("user");
+    });
+
+    it("updates session status", () => {
+      const key = svc.generateKey({ name: "sess-update", username: "u", allowedHosts: ["h1"] });
+      const sessionId = svc.createSession({ sshKeyId: key.id, host: "h1", initiatedBy: "agent-123" });
+
+      svc.updateSession(sessionId, {
+        status: "completed",
+        completedAt: new Date().toISOString(),
+      });
+
+      const session = svc.getSession(sessionId);
+      expect(session!.status).toBe("completed");
+      expect(session!.completedAt).toBeTruthy();
+    });
+
+    it("lists sessions ordered by creation date", () => {
+      const key = svc.generateKey({ name: "sess-list", username: "u", allowedHosts: ["h1"] });
+      svc.createSession({ sshKeyId: key.id, host: "h1", initiatedBy: "user" });
+      svc.createSession({ sshKeyId: key.id, host: "h1", initiatedBy: "agent-1" });
+
+      const sessions = svc.listSessions();
+      expect(sessions).toHaveLength(2);
+    });
+
+    it("deletes a session", () => {
+      const key = svc.generateKey({ name: "sess-del", username: "u", allowedHosts: ["h1"] });
+      const sessionId = svc.createSession({ sshKeyId: key.id, host: "h1", initiatedBy: "user" });
+
+      expect(svc.deleteSession(sessionId)).toBe(true);
+      expect(svc.getSession(sessionId)).toBeNull();
+    });
+
+    it("returns false when deleting non-existent session", () => {
+      expect(svc.deleteSession("nonexistent")).toBe(false);
+    });
+
+    it("returns null for non-existent session", () => {
+      expect(svc.getSession("nonexistent")).toBeNull();
+    });
+
+    it("persists terminal buffer on update", () => {
+      const key = svc.generateKey({ name: "sess-buf", username: "u", allowedHosts: ["h1"] });
+      const sessionId = svc.createSession({ sshKeyId: key.id, host: "h1", initiatedBy: "user" });
+
+      svc.updateSession(sessionId, {
+        status: "completed",
+        terminalBuffer: "$ whoami\nroot\n$ ",
+      });
+
+      const session = svc.getSession(sessionId);
+      expect(session!.terminalBuffer).toBe("$ whoami\nroot\n$ ");
+    });
+  });
+
+  // ─── getKeyPath ─────────────────────────────────────────────
+
+  describe("getKeyPath", () => {
+    it("returns the file path for a key", () => {
+      const key = svc.generateKey({ name: "path-test", username: "u", allowedHosts: [] });
+      const path = svc.getKeyPath(key.id);
+      expect(path).toBeTruthy();
+      expect(path).toContain(`otterbot_ssh_${key.id}`);
+      expect(existsSync(path!)).toBe(true);
+    });
+
+    it("returns null for non-existent key", () => {
+      expect(svc.getKeyPath("nonexistent")).toBeNull();
+    });
+  });
+});

--- a/packages/server/src/ssh/ssh-pty-client.ts
+++ b/packages/server/src/ssh/ssh-pty-client.ts
@@ -1,0 +1,152 @@
+/**
+ * SSH PTY client — spawns an `ssh` process in a pseudo-terminal
+ * and streams raw terminal output to the browser via Socket.IO + xterm.js.
+ *
+ * Follows the same pattern as ClaudeCodePtyClient but for SSH sessions.
+ * Implements the PtyClient interface from worker.ts.
+ */
+
+import type { SshService } from "./ssh-service.js";
+import type { PtyClient } from "../agents/worker.js";
+
+/** Ring buffer size for late-joining clients (~100KB) */
+const RING_BUFFER_SIZE = 100 * 1024;
+
+export interface SshPtyConfig {
+  keyId: string;
+  host: string;
+  sshService: SshService;
+  /** Callback for raw PTY data — stream to Socket.IO clients */
+  onData?: (data: string) => void;
+  /** Callback when process exits */
+  onExit?: (exitCode: number) => void;
+}
+
+export class SshPtyClient implements PtyClient {
+  private config: SshPtyConfig;
+  private ptyProcess: any | null = null;
+  private ringBuffer = "";
+  private _killed = false;
+
+  constructor(config: SshPtyConfig) {
+    this.config = config;
+  }
+
+  /** Connect to the remote host via PTY */
+  async connect(): Promise<void> {
+    const { keyId, host, sshService } = this.config;
+
+    // Validate host
+    const hostCheck = sshService.validateHost(keyId, host);
+    if (!hostCheck.ok) {
+      throw new Error(hostCheck.error);
+    }
+
+    // Get key details
+    const key = sshService.get(keyId);
+    if (!key) throw new Error("SSH key not found");
+
+    const keyPath = sshService.getKeyPath(keyId);
+    if (!keyPath) throw new Error("SSH key file not found");
+
+    // Dynamic import to avoid loading native module at module init
+    const nodePty = await import("node-pty");
+
+    const args = [
+      "-i", keyPath,
+      "-o", "StrictHostKeyChecking=accept-new",
+      "-p", String(key.port),
+      `${key.username}@${host}`,
+    ];
+
+    this.ptyProcess = nodePty.spawn("ssh", args, {
+      name: "xterm-256color",
+      cols: 120,
+      rows: 40,
+      env: { ...(process.env as Record<string, string>) },
+    });
+
+    this.ptyProcess.onData((data: string) => {
+      // Append to ring buffer (trim to size)
+      this.ringBuffer += data;
+      if (this.ringBuffer.length > RING_BUFFER_SIZE) {
+        this.ringBuffer = this.ringBuffer.slice(-RING_BUFFER_SIZE);
+      }
+      this.config.onData?.(data);
+    });
+
+    this.ptyProcess.onExit(({ exitCode }: { exitCode: number; signal?: number }) => {
+      console.log(`[SSH PTY] Session to ${host} exited with code ${exitCode}`);
+      this.config.onExit?.(exitCode);
+      this.ptyProcess = null;
+    });
+  }
+
+  /** Write user keystrokes to PTY stdin */
+  writeInput(data: string): void {
+    this.ptyProcess?.write(data);
+  }
+
+  /** Resize PTY dimensions */
+  resize(cols: number, rows: number): void {
+    try {
+      this.ptyProcess?.resize(cols, rows);
+    } catch {
+      // Ignore resize errors (process may have exited)
+    }
+  }
+
+  /** Get the ring buffer contents for late-joining clients */
+  getReplayBuffer(): string {
+    return this.ringBuffer;
+  }
+
+  /** Kill the PTY process */
+  kill(): void {
+    if (!this.ptyProcess) return;
+    this._killed = true;
+
+    try {
+      this.ptyProcess.kill("SIGTERM");
+    } catch {
+      // Already dead
+    }
+
+    // Force kill after 3 seconds
+    setTimeout(() => {
+      try {
+        this.ptyProcess?.kill("SIGKILL");
+      } catch {
+        // Already dead
+      }
+    }, 3000);
+  }
+
+  /** Gracefully terminate the PTY process */
+  gracefulExit(): void {
+    if (!this.ptyProcess) return;
+    // Send exit command then SIGTERM
+    try {
+      this.ptyProcess.write("exit\n");
+    } catch {
+      // ignore
+    }
+
+    setTimeout(() => {
+      try {
+        this.ptyProcess?.kill("SIGTERM");
+      } catch {
+        // Already dead
+      }
+
+      // Force kill after 3 more seconds
+      setTimeout(() => {
+        try {
+          this.ptyProcess?.kill("SIGKILL");
+        } catch {
+          // Already dead
+        }
+      }, 3000);
+    }, 1000);
+  }
+}

--- a/packages/server/src/ssh/ssh-service.ts
+++ b/packages/server/src/ssh/ssh-service.ts
@@ -1,0 +1,410 @@
+import { execSync } from "node:child_process";
+import { writeFileSync, readFileSync, unlinkSync, existsSync, chmodSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { nanoid } from "nanoid";
+import { eq, desc } from "drizzle-orm";
+import { getDb, schema } from "../db/index.js";
+import type { SshKeyInfo, SshKeyType, SshSession, SshSessionStatus } from "@otterbot/shared";
+
+const MAX_OUTPUT_SIZE = 50_000; // 50KB
+const DEFAULT_TIMEOUT = 120_000; // 2 minutes
+const CONNECT_TIMEOUT = 10; // seconds
+
+/** Commands blocked from one-shot exec to prevent destructive remote actions */
+const BLOCKED_REMOTE_COMMANDS: { pattern: RegExp; reason: string }[] = [
+  { pattern: /\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+)?\/\b/, reason: "rm targeting root filesystem is not permitted" },
+  { pattern: /\bmkfs\b/, reason: "Formatting filesystems is not permitted" },
+  { pattern: /\bdd\b.*\bof=\/dev\//, reason: "Raw disk writes are not permitted" },
+  { pattern: /\bshutdown\b/, reason: "System shutdown is not permitted" },
+  { pattern: /\breboot\b/, reason: "System reboot is not permitted" },
+  { pattern: /\bhalt\b/, reason: "System halt is not permitted" },
+  { pattern: /\bpoweroff\b/, reason: "System poweroff is not permitted" },
+];
+
+function getSshKeyDir(): string {
+  const home = process.env.HOME || process.env.USERPROFILE || "/tmp";
+  const dir = join(home, ".ssh");
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function getKeyPath(id: string): string {
+  return join(getSshKeyDir(), `otterbot_ssh_${id}`);
+}
+
+export class SshService {
+  /** List all SSH keys */
+  list(): SshKeyInfo[] {
+    const db = getDb();
+    const rows = db.select().from(schema.sshKeys).orderBy(desc(schema.sshKeys.createdAt)).all();
+    return rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      username: r.username,
+      fingerprint: r.fingerprint,
+      keyType: r.keyType,
+      allowedHosts: r.allowedHosts,
+      port: r.port,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+    }));
+  }
+
+  /** Get a single SSH key by ID */
+  get(id: string): SshKeyInfo | null {
+    const db = getDb();
+    const row = db.select().from(schema.sshKeys).where(eq(schema.sshKeys.id, id)).get();
+    if (!row) return null;
+    return {
+      id: row.id,
+      name: row.name,
+      username: row.username,
+      fingerprint: row.fingerprint,
+      keyType: row.keyType,
+      allowedHosts: row.allowedHosts,
+      port: row.port,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  /** Generate a new SSH key pair */
+  generateKey(opts: {
+    name: string;
+    username: string;
+    allowedHosts: string[];
+    keyType?: SshKeyType;
+    port?: number;
+  }): SshKeyInfo {
+    const id = nanoid();
+    const keyPath = getKeyPath(id);
+    const keyType = opts.keyType ?? "ed25519";
+
+    // Generate key pair
+    execSync(
+      `ssh-keygen -t ${keyType} -f ${keyPath} -N "" -C "otterbot-${opts.name}"`,
+      { stdio: "pipe" },
+    );
+
+    // Set permissions
+    chmodSync(keyPath, 0o600);
+    chmodSync(`${keyPath}.pub`, 0o644);
+
+    // Get fingerprint
+    const fingerprint = execSync(`ssh-keygen -lf ${keyPath}.pub`, { encoding: "utf-8" }).trim();
+
+    const now = new Date().toISOString();
+    const db = getDb();
+    db.insert(schema.sshKeys)
+      .values({
+        id,
+        name: opts.name,
+        username: opts.username,
+        privateKeyPath: keyPath,
+        fingerprint,
+        keyType,
+        allowedHosts: opts.allowedHosts,
+        port: opts.port ?? 22,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    return {
+      id,
+      name: opts.name,
+      username: opts.username,
+      fingerprint,
+      keyType,
+      allowedHosts: opts.allowedHosts,
+      port: opts.port ?? 22,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  /** Import an existing private key */
+  importKey(opts: {
+    name: string;
+    username: string;
+    privateKey: string;
+    allowedHosts: string[];
+    port?: number;
+  }): SshKeyInfo {
+    const id = nanoid();
+    const keyPath = getKeyPath(id);
+
+    // Write private key
+    writeFileSync(keyPath, opts.privateKey, { mode: 0o600 });
+
+    // Derive public key
+    try {
+      execSync(`ssh-keygen -y -f ${keyPath} > ${keyPath}.pub`, { stdio: "pipe" });
+      chmodSync(`${keyPath}.pub`, 0o644);
+    } catch (err) {
+      // Clean up on failure
+      try { unlinkSync(keyPath); } catch { /* ignore */ }
+      throw new Error("Invalid private key: could not derive public key");
+    }
+
+    // Get fingerprint
+    const fingerprint = execSync(`ssh-keygen -lf ${keyPath}.pub`, { encoding: "utf-8" }).trim();
+
+    // Detect key type from fingerprint line (e.g. "256 SHA256:... comment (ED25519)")
+    let keyType: SshKeyType = "ed25519";
+    if (/\(RSA\)/i.test(fingerprint)) {
+      keyType = "rsa";
+    }
+
+    const now = new Date().toISOString();
+    const db = getDb();
+    db.insert(schema.sshKeys)
+      .values({
+        id,
+        name: opts.name,
+        username: opts.username,
+        privateKeyPath: keyPath,
+        fingerprint,
+        keyType,
+        allowedHosts: opts.allowedHosts,
+        port: opts.port ?? 22,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    return {
+      id,
+      name: opts.name,
+      username: opts.username,
+      fingerprint,
+      keyType,
+      allowedHosts: opts.allowedHosts,
+      port: opts.port ?? 22,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  /** Delete an SSH key and its files */
+  deleteKey(id: string): boolean {
+    const db = getDb();
+    const row = db.select().from(schema.sshKeys).where(eq(schema.sshKeys.id, id)).get();
+    if (!row) return false;
+
+    // Remove key files
+    try { unlinkSync(row.privateKeyPath); } catch { /* ignore */ }
+    try { unlinkSync(`${row.privateKeyPath}.pub`); } catch { /* ignore */ }
+
+    db.delete(schema.sshKeys).where(eq(schema.sshKeys.id, id)).run();
+    return true;
+  }
+
+  /** Update SSH key metadata */
+  update(
+    id: string,
+    data: { name?: string; username?: string; allowedHosts?: string[]; port?: number },
+  ): SshKeyInfo | null {
+    const db = getDb();
+    const existing = db.select().from(schema.sshKeys).where(eq(schema.sshKeys.id, id)).get();
+    if (!existing) return null;
+
+    const now = new Date().toISOString();
+    db.update(schema.sshKeys)
+      .set({
+        ...(data.name !== undefined && { name: data.name }),
+        ...(data.username !== undefined && { username: data.username }),
+        ...(data.allowedHosts !== undefined && { allowedHosts: data.allowedHosts }),
+        ...(data.port !== undefined && { port: data.port }),
+        updatedAt: now,
+      })
+      .where(eq(schema.sshKeys.id, id))
+      .run();
+
+    return this.get(id);
+  }
+
+  /** Get the public key text for a key */
+  getPublicKey(id: string): string | null {
+    const db = getDb();
+    const row = db.select().from(schema.sshKeys).where(eq(schema.sshKeys.id, id)).get();
+    if (!row) return null;
+
+    const pubPath = `${row.privateKeyPath}.pub`;
+    if (!existsSync(pubPath)) return null;
+    return readFileSync(pubPath, "utf-8").trim();
+  }
+
+  /** Validate that a host is in the key's allowlist */
+  validateHost(keyId: string, host: string): { ok: boolean; error?: string } {
+    const key = this.get(keyId);
+    if (!key) return { ok: false, error: "SSH key not found" };
+    if (key.allowedHosts.length === 0) return { ok: false, error: "No hosts configured for this key" };
+    if (!key.allowedHosts.includes(host)) {
+      return { ok: false, error: `Host "${host}" is not in the allowlist for key "${key.name}". Allowed: ${key.allowedHosts.join(", ")}` };
+    }
+    return { ok: true };
+  }
+
+  /** Execute a command on a remote host (one-shot) */
+  exec(opts: {
+    keyId: string;
+    host: string;
+    command: string;
+    timeout?: number;
+  }): { ok: boolean; output?: string; error?: string } {
+    // Validate host
+    const hostCheck = this.validateHost(opts.keyId, opts.host);
+    if (!hostCheck.ok) return { ok: false, error: hostCheck.error };
+
+    // Check blocked commands
+    for (const blocked of BLOCKED_REMOTE_COMMANDS) {
+      if (blocked.pattern.test(opts.command)) {
+        return { ok: false, error: `Blocked command: ${blocked.reason}` };
+      }
+    }
+
+    const key = this.get(opts.keyId)!;
+    const db = getDb();
+    const row = db.select().from(schema.sshKeys).where(eq(schema.sshKeys.id, opts.keyId)).get()!;
+    const keyPath = row.privateKeyPath;
+
+    const timeout = Math.min(opts.timeout ?? DEFAULT_TIMEOUT, DEFAULT_TIMEOUT);
+
+    const sshArgs = [
+      "ssh",
+      "-i", keyPath,
+      "-o", "BatchMode=yes",
+      "-o", `ConnectTimeout=${CONNECT_TIMEOUT}`,
+      "-o", "StrictHostKeyChecking=accept-new",
+      "-p", String(key.port),
+      `${key.username}@${opts.host}`,
+      opts.command,
+    ];
+
+    try {
+      let output = execSync(sshArgs.join(" "), {
+        encoding: "utf-8",
+        timeout,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      // Cap output
+      if (output.length > MAX_OUTPUT_SIZE) {
+        output = output.slice(0, MAX_OUTPUT_SIZE) + "\n... (output truncated at 50KB)";
+      }
+
+      return { ok: true, output };
+    } catch (err: unknown) {
+      const execErr = err as { stderr?: string; stdout?: string; message?: string };
+      const stderr = execErr.stderr || "";
+      const stdout = execErr.stdout || "";
+      const combined = (stdout + "\n" + stderr).trim();
+      return {
+        ok: false,
+        output: combined || undefined,
+        error: combined || execErr.message || "SSH command failed",
+      };
+    }
+  }
+
+  /** Test SSH connection to a host */
+  testConnection(opts: { keyId: string; host: string }): { ok: boolean; error?: string } {
+    const result = this.exec({ keyId: opts.keyId, host: opts.host, command: "echo ok", timeout: 15_000 });
+    if (result.ok && result.output?.trim() === "ok") {
+      return { ok: true };
+    }
+    return { ok: false, error: result.error || "Connection test failed" };
+  }
+
+  // ─── Session management ─────────────────────────────────────
+
+  /** Create a session record */
+  createSession(opts: {
+    sshKeyId: string;
+    host: string;
+    initiatedBy: string;
+  }): string {
+    const id = nanoid();
+    const now = new Date().toISOString();
+    const db = getDb();
+    db.insert(schema.sshSessions)
+      .values({
+        id,
+        sshKeyId: opts.sshKeyId,
+        host: opts.host,
+        status: "active",
+        startedAt: now,
+        initiatedBy: opts.initiatedBy,
+        createdAt: now,
+      })
+      .run();
+    return id;
+  }
+
+  /** Update session status */
+  updateSession(id: string, data: { status?: SshSessionStatus; completedAt?: string; terminalBuffer?: string }): void {
+    const db = getDb();
+    db.update(schema.sshSessions)
+      .set(data)
+      .where(eq(schema.sshSessions.id, id))
+      .run();
+  }
+
+  /** List sessions */
+  listSessions(limit = 20): SshSession[] {
+    const db = getDb();
+    const rows = db.select().from(schema.sshSessions)
+      .orderBy(desc(schema.sshSessions.createdAt))
+      .limit(limit)
+      .all();
+
+    return rows.map((r) => {
+      // Look up the username from the key
+      const key = this.get(r.sshKeyId);
+      return {
+        id: r.id,
+        sshKeyId: r.sshKeyId,
+        host: r.host,
+        username: key?.username ?? "unknown",
+        status: r.status,
+        startedAt: r.startedAt,
+        completedAt: r.completedAt ?? null,
+        initiatedBy: r.initiatedBy,
+      };
+    });
+  }
+
+  /** Get a session by ID */
+  getSession(id: string): (SshSession & { terminalBuffer?: string | null }) | null {
+    const db = getDb();
+    const row = db.select().from(schema.sshSessions).where(eq(schema.sshSessions.id, id)).get();
+    if (!row) return null;
+    const key = this.get(row.sshKeyId);
+    return {
+      id: row.id,
+      sshKeyId: row.sshKeyId,
+      host: row.host,
+      username: key?.username ?? "unknown",
+      status: row.status,
+      startedAt: row.startedAt,
+      completedAt: row.completedAt ?? null,
+      initiatedBy: row.initiatedBy,
+      terminalBuffer: row.terminalBuffer,
+    };
+  }
+
+  /** Delete a session record */
+  deleteSession(id: string): boolean {
+    const db = getDb();
+    const result = db.delete(schema.sshSessions).where(eq(schema.sshSessions.id, id)).run();
+    return result.changes > 0;
+  }
+
+  /** Get the internal key path (for PTY client use) */
+  getKeyPath(id: string): string | null {
+    const db = getDb();
+    const row = db.select().from(schema.sshKeys).where(eq(schema.sshKeys.id, id)).get();
+    return row?.privateKeyPath ?? null;
+  }
+}

--- a/packages/server/src/tools/__tests__/ssh-tools.test.ts
+++ b/packages/server/src/tools/__tests__/ssh-tools.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Mock auth (required by seed.js which is called from migrateDb)
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn(() => undefined),
+  setConfig: vi.fn(),
+  deleteConfig: vi.fn(),
+}));
+
+import { migrateDb, resetDb } from "../../db/index.js";
+import { createSshExecTool } from "../ssh-exec.js";
+import { createSshListKeysTool } from "../ssh-list-keys.js";
+import { createSshListHostsTool } from "../ssh-list-hosts.js";
+import { createSshConnectTool } from "../ssh-connect.js";
+import { SshService } from "../../ssh/ssh-service.js";
+
+describe("SSH Tools", () => {
+  let tmpDir: string;
+  let svc: SshService;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-ssh-tools-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    process.env.HOME = tmpDir;
+    await migrateDb();
+    svc = new SshService();
+  });
+
+  afterEach(() => {
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    delete process.env.HOME;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("ssh_list_keys", () => {
+    it("returns empty message when no keys configured", async () => {
+      const tool = createSshListKeysTool();
+      const result = JSON.parse(await (tool as any).execute({}));
+      expect(result.keys).toEqual([]);
+      expect(result.message).toContain("No SSH keys configured");
+    });
+
+    it("returns all keys with metadata", async () => {
+      svc.generateKey({ name: "key1", username: "user1", allowedHosts: ["h1"] });
+      svc.generateKey({ name: "key2", username: "user2", allowedHosts: ["h2", "h3"] });
+
+      const tool = createSshListKeysTool();
+      const result = JSON.parse(await (tool as any).execute({}));
+      expect(result.keys).toHaveLength(2);
+      expect(result.keys[0].name).toBeTruthy();
+      expect(result.keys[0].username).toBeTruthy();
+      expect(result.keys[0].fingerprint).toBeTruthy();
+    });
+  });
+
+  describe("ssh_list_hosts", () => {
+    it("returns hosts for a valid key", async () => {
+      const key = svc.generateKey({ name: "hosts-key", username: "admin", allowedHosts: ["10.0.0.1", "10.0.0.2"], port: 2222 });
+
+      const tool = createSshListHostsTool();
+      const result = JSON.parse(await (tool as any).execute({ keyId: key.id }));
+      expect(result.allowedHosts).toEqual(["10.0.0.1", "10.0.0.2"]);
+      expect(result.username).toBe("admin");
+      expect(result.port).toBe(2222);
+    });
+
+    it("returns error for non-existent key", async () => {
+      const tool = createSshListHostsTool();
+      const result = JSON.parse(await (tool as any).execute({ keyId: "fake" }));
+      expect(result.error).toContain("not found");
+    });
+  });
+
+  describe("ssh_exec", () => {
+    it("rejects non-allowlisted host", async () => {
+      const key = svc.generateKey({ name: "exec-key", username: "u", allowedHosts: ["good.host"] });
+
+      const tool = createSshExecTool();
+      const result = JSON.parse(await (tool as any).execute({
+        keyId: key.id,
+        host: "bad.host",
+        command: "echo hi",
+      }));
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("not in the allowlist");
+    });
+
+    it("rejects blocked commands", async () => {
+      const key = svc.generateKey({ name: "exec-block", username: "u", allowedHosts: ["h1"] });
+
+      const tool = createSshExecTool();
+      const result = JSON.parse(await (tool as any).execute({
+        keyId: key.id,
+        host: "h1",
+        command: "rm -rf /etc",
+      }));
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("Blocked command");
+    });
+
+    it("rejects non-existent key", async () => {
+      const tool = createSshExecTool();
+      const result = JSON.parse(await (tool as any).execute({
+        keyId: "nonexistent",
+        host: "h1",
+        command: "echo hi",
+      }));
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("SSH key not found");
+    });
+  });
+
+  describe("ssh_connect", () => {
+    it("validates key exists", async () => {
+      const tool = createSshConnectTool();
+      const result = JSON.parse(await (tool as any).execute({
+        keyId: "nonexistent",
+        host: "h1",
+      }));
+
+      expect(result.error).toContain("not found");
+    });
+
+    it("validates host is in allowlist", async () => {
+      const key = svc.generateKey({ name: "connect-key", username: "u", allowedHosts: ["good.host"] });
+
+      const tool = createSshConnectTool();
+      const result = JSON.parse(await (tool as any).execute({
+        keyId: key.id,
+        host: "bad.host",
+      }));
+
+      expect(result.error).toContain("not in the allowlist");
+    });
+
+    it("returns connection parameters for valid request", async () => {
+      const key = svc.generateKey({ name: "connect-ok", username: "admin", allowedHosts: ["myhost"], port: 2222 });
+
+      const tool = createSshConnectTool();
+      const result = JSON.parse(await (tool as any).execute({
+        keyId: key.id,
+        host: "myhost",
+      }));
+
+      expect(result.ok).toBe(true);
+      expect(result.keyId).toBe(key.id);
+      expect(result.host).toBe("myhost");
+      expect(result.username).toBe("admin");
+      expect(result.port).toBe(2222);
+    });
+  });
+});

--- a/packages/server/src/tools/ssh-connect.ts
+++ b/packages/server/src/tools/ssh-connect.ts
@@ -1,0 +1,48 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { SshService } from "../ssh/ssh-service.js";
+
+/**
+ * Creates the ssh_connect tool.
+ * The actual PTY session setup is handled by the socket handler that intercepts
+ * the tool result — this tool just validates and returns connection parameters.
+ *
+ * The socket handler in handlers.ts listens for ssh:connect events and creates
+ * the SshPtyClient, registers it with registerPtySession(), and emits ssh:session-start.
+ */
+export function createSshConnectTool() {
+  return tool({
+    description:
+      "Start an interactive SSH session to a remote host. Opens a live terminal in the SSH View that the user can watch and interact with. Use this for debugging, monitoring, or tasks that need interactive terminal access. For quick one-shot commands, prefer ssh_exec instead.",
+    parameters: z.object({
+      keyId: z.string().describe("The SSH key ID to authenticate with"),
+      host: z.string().describe("The remote hostname or IP to connect to (must be in the key's allowlist)"),
+    }),
+    execute: async ({ keyId, host }) => {
+      const svc = new SshService();
+
+      // Validate key exists
+      const key = svc.get(keyId);
+      if (!key) {
+        return JSON.stringify({ error: "SSH key not found" });
+      }
+
+      // Validate host
+      const hostCheck = svc.validateHost(keyId, host);
+      if (!hostCheck.ok) {
+        return JSON.stringify({ error: hostCheck.error });
+      }
+
+      // The actual PTY connection is initiated by the agent framework
+      // We return the validated parameters so the caller can set up the session
+      return JSON.stringify({
+        ok: true,
+        message: `Interactive SSH session requested to ${key.username}@${host}:${key.port}. The session will appear in the SSH View.`,
+        keyId,
+        host,
+        username: key.username,
+        port: key.port,
+      });
+    },
+  });
+}

--- a/packages/server/src/tools/ssh-exec.ts
+++ b/packages/server/src/tools/ssh-exec.ts
@@ -1,0 +1,21 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { SshService } from "../ssh/ssh-service.js";
+
+export function createSshExecTool() {
+  return tool({
+    description:
+      "Execute a command on a remote host via SSH. Use ssh_list_keys to find available keys and ssh_list_hosts to see allowed hosts. Output is capped at 50KB with a 2-minute timeout.",
+    parameters: z.object({
+      keyId: z.string().describe("The SSH key ID to authenticate with"),
+      host: z.string().describe("The remote hostname or IP to connect to (must be in the key's allowlist)"),
+      command: z.string().describe("The shell command to execute on the remote host"),
+      timeout: z.number().optional().describe("Timeout in milliseconds (default: 120000, max: 120000)"),
+    }),
+    execute: async ({ keyId, host, command, timeout }) => {
+      const svc = new SshService();
+      const result = svc.exec({ keyId, host, command, timeout });
+      return JSON.stringify(result);
+    },
+  });
+}

--- a/packages/server/src/tools/ssh-list-hosts.ts
+++ b/packages/server/src/tools/ssh-list-hosts.ts
@@ -1,0 +1,27 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { SshService } from "../ssh/ssh-service.js";
+
+export function createSshListHostsTool() {
+  return tool({
+    description:
+      "List the allowed hosts for a specific SSH key. Shows which remote hosts this key can connect to.",
+    parameters: z.object({
+      keyId: z.string().describe("The SSH key ID to list hosts for"),
+    }),
+    execute: async ({ keyId }) => {
+      const svc = new SshService();
+      const key = svc.get(keyId);
+      if (!key) {
+        return JSON.stringify({ error: "SSH key not found" });
+      }
+      return JSON.stringify({
+        keyId: key.id,
+        name: key.name,
+        username: key.username,
+        port: key.port,
+        allowedHosts: key.allowedHosts,
+      });
+    },
+  });
+}

--- a/packages/server/src/tools/ssh-list-keys.ts
+++ b/packages/server/src/tools/ssh-list-keys.ts
@@ -1,0 +1,19 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { SshService } from "../ssh/ssh-service.js";
+
+export function createSshListKeysTool() {
+  return tool({
+    description:
+      "List all configured SSH keys with their metadata (name, username, key type, fingerprint, allowed hosts, port).",
+    parameters: z.object({}),
+    execute: async () => {
+      const svc = new SshService();
+      const keys = svc.list();
+      if (keys.length === 0) {
+        return JSON.stringify({ keys: [], message: "No SSH keys configured. The user needs to add SSH keys in Settings > SSH Keys." });
+      }
+      return JSON.stringify({ keys });
+    },
+  });
+}

--- a/packages/server/src/tools/tool-factory.ts
+++ b/packages/server/src/tools/tool-factory.ts
@@ -35,6 +35,10 @@ import { SkillService } from "../skills/skill-service.js";
 import { CustomToolService } from "./custom-tool-service.js";
 import { executeCustomTool } from "./custom-tool-executor.js";
 import { createMemorySaveTool } from "./memory-save.js";
+import { createSshExecTool } from "./ssh-exec.js";
+import { createSshListKeysTool } from "./ssh-list-keys.js";
+import { createSshListHostsTool } from "./ssh-list-hosts.js";
+import { createSshConnectTool } from "./ssh-connect.js";
 import { McpClientManager } from "../mcp/mcp-client-manager.js";
 import { McpServerService as McpServerServiceRef } from "../mcp/mcp-service.js";
 
@@ -81,6 +85,11 @@ const CONTEXTLESS_TOOL_REGISTRY: Record<string, () => unknown> = {
   test_custom_tool: createTestCustomToolTool,
   // Memory tools
   memory_save: createMemorySaveTool,
+  // SSH tools
+  ssh_exec: createSshExecTool,
+  ssh_list_keys: createSshListKeysTool,
+  ssh_list_hosts: createSshListHostsTool,
+  ssh_connect: createSshConnectTool,
 };
 
 /**
@@ -482,6 +491,36 @@ export function getToolsWithMeta(): {
       parameters: [
         { name: "id", type: "string", required: true, description: "The tool ID to test" },
         { name: "params", type: "object", required: true, description: "Parameters to pass to the tool" },
+      ],
+    },
+    ssh_exec: {
+      description: "Execute a command on a remote host via SSH. Output capped at 50KB, timeout 2 minutes.",
+      category: "SSH",
+      parameters: [
+        { name: "keyId", type: "string", required: true, description: "The SSH key ID to authenticate with" },
+        { name: "host", type: "string", required: true, description: "The remote hostname or IP" },
+        { name: "command", type: "string", required: true, description: "The shell command to execute" },
+        { name: "timeout", type: "number", required: false, description: "Timeout in milliseconds (default: 120000)" },
+      ],
+    },
+    ssh_list_keys: {
+      description: "List all configured SSH keys with metadata.",
+      category: "SSH",
+      parameters: [],
+    },
+    ssh_list_hosts: {
+      description: "List allowed hosts for a specific SSH key.",
+      category: "SSH",
+      parameters: [
+        { name: "keyId", type: "string", required: true, description: "The SSH key ID" },
+      ],
+    },
+    ssh_connect: {
+      description: "Start an interactive SSH session to a remote host. Opens a live terminal in the SSH View.",
+      category: "SSH",
+      parameters: [
+        { name: "keyId", type: "string", required: true, description: "The SSH key ID to authenticate with" },
+        { name: "host", type: "string", required: true, description: "The remote hostname or IP" },
       ],
     },
   };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,3 +19,4 @@ export * from "./types/memory.js";
 export * from "./types/module.js";
 export * from "./types/merge-queue.js";
 export * from "./types/mcp-server.js";
+export * from "./types/ssh.js";

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -8,6 +8,7 @@ import type { SoulDocument, Memory, MemoryEpisode, SoulSuggestion } from "./memo
 import type { Todo } from "./todo.js";
 import type { MergeQueueEntry } from "./merge-queue.js";
 import type { McpServerRuntime } from "./mcp-server.js";
+import type { SshSessionStatus } from "./ssh.js";
 
 /** Events emitted from server to client */
 export interface ServerToClientEvents {
@@ -73,6 +74,8 @@ export interface ServerToClientEvents {
   "merge-queue:updated": (data: { entries: MergeQueueEntry[] }) => void;
   "merge-queue:entry-updated": (entry: MergeQueueEntry) => void;
   "mcp:status": (runtime: McpServerRuntime) => void;
+  "ssh:session-start": (data: { sessionId: string; keyId: string; host: string; username: string; agentId: string }) => void;
+  "ssh:session-end": (data: { sessionId: string; agentId: string; status: SshSessionStatus }) => void;
 }
 
 /** Events emitted from client to server */
@@ -252,6 +255,16 @@ export interface ClientToServerEvents {
   ) => void;
   "project:set-branch": (
     data: { projectId: string; branch: string },
+    callback?: (ack: { ok: boolean; error?: string }) => void,
+  ) => void;
+
+  // SSH sessions
+  "ssh:connect": (
+    data: { keyId: string; host: string },
+    callback?: (ack: { ok: boolean; sessionId?: string; agentId?: string; error?: string }) => void,
+  ) => void;
+  "ssh:disconnect": (
+    data: { sessionId: string },
     callback?: (ack: { ok: boolean; error?: string }) => void,
   ) => void;
 }

--- a/packages/shared/src/types/ssh.ts
+++ b/packages/shared/src/types/ssh.ts
@@ -1,0 +1,26 @@
+export type SshKeyType = "ed25519" | "rsa";
+
+export interface SshKeyInfo {
+  id: string;
+  name: string;
+  username: string;
+  fingerprint: string;
+  keyType: SshKeyType;
+  allowedHosts: string[];
+  port: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type SshSessionStatus = "active" | "completed" | "error";
+
+export interface SshSession {
+  id: string;
+  sshKeyId: string;
+  host: string;
+  username: string;
+  status: SshSessionStatus;
+  startedAt: string;
+  completedAt: string | null;
+  initiatedBy: string;
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -25,6 +25,7 @@ import { TodoView } from "./components/todos/TodoView";
 import { InboxView } from "./components/inbox/InboxView";
 import { CalendarView } from "./components/calendar/CalendarView";
 import { CodeView } from "./components/code/CodeView";
+import { SshView } from "./components/ssh/SshView";
 import { ProjectSettings } from "./components/project/ProjectSettings";
 import { MergeQueueView } from "./components/project/MergeQueueView";
 import { DetachedLiveView } from "./components/live-view/DetachedLiveView";
@@ -456,6 +457,8 @@ function ResizableLayout({
         return <DesktopView />;
       case "code":
         return <CodeView projectId={activeProjectId} />;
+      case "ssh":
+        return <SshView />;
       case "settings":
         return activeProjectId ? (
           <ProjectSettings projectId={activeProjectId} />

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -28,6 +28,7 @@ import { SecuritySection } from "./SecuritySection";
 import { ModulesSection } from "./ModulesSection";
 import { WorkerNamesSection } from "./WorkerNamesSection";
 import { McpServersSection } from "./McpServersSection";
+import { SshTab } from "./SshTab";
 import type { SettingsSection } from "./settings-nav";
 
 interface SettingsPageProps {
@@ -66,6 +67,7 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
     if (activeSection === "nextcloud-talk") return <NextcloudTalkSection />;
     if (activeSection === "worker-names") return <WorkerNamesSection />;
     if (activeSection === "mcp-servers") return <McpServersSection />;
+    if (activeSection === "ssh") return <SshTab />;
     if (activeSection === "security") return <SecuritySection />;
     if (activeSection === "soul") return <SoulTab />;
     if (activeSection === "memory") return <MemoryTab />;

--- a/packages/web/src/components/settings/SshTab.tsx
+++ b/packages/web/src/components/settings/SshTab.tsx
@@ -1,0 +1,516 @@
+import { useState, useEffect } from "react";
+import { useSshStore } from "../../stores/ssh-store";
+import type { SshKeyInfo, SshKeyType } from "@otterbot/shared";
+
+type ViewMode = "list" | "generate" | "import" | "edit";
+
+export function SshTab() {
+  const {
+    sshKeys,
+    sshKeysLoading,
+    loadKeys,
+    generateKey,
+    importKey,
+    updateKey,
+    deleteKey,
+    getPublicKey,
+    testConnection,
+  } = useSshStore();
+
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const [editingKey, setEditingKey] = useState<SshKeyInfo | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [publicKeyModal, setPublicKeyModal] = useState<{ id: string; publicKey: string } | null>(null);
+  const [testResults, setTestResults] = useState<Record<string, { ok: boolean; error?: string; testing: boolean }>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadKeys();
+  }, []);
+
+  const handleCopyPublicKey = async (id: string) => {
+    const pubKey = await getPublicKey(id);
+    if (pubKey) {
+      await navigator.clipboard.writeText(pubKey);
+      setPublicKeyModal({ id, publicKey: pubKey });
+    }
+  };
+
+  const handleTestConnection = async (keyId: string, host: string) => {
+    const testKey = `${keyId}:${host}`;
+    setTestResults((prev) => ({ ...prev, [testKey]: { ok: false, testing: true } }));
+    const result = await testConnection(keyId, host);
+    setTestResults((prev) => ({ ...prev, [testKey]: { ...result, testing: false } }));
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteKey(id);
+    setConfirmDelete(null);
+  };
+
+  if (viewMode === "generate") {
+    return (
+      <div className="p-6 space-y-6">
+        <div className="flex items-center gap-2">
+          <button onClick={() => setViewMode("list")} className="text-xs text-muted-foreground hover:text-foreground">&larr; Back</button>
+          <h2 className="text-lg font-semibold">Generate SSH Key</h2>
+        </div>
+        <GenerateKeyForm
+          onGenerate={async (data) => {
+            const result = await generateKey(data);
+            if (result.error) {
+              setError(result.error);
+            } else {
+              setViewMode("list");
+              setError(null);
+            }
+          }}
+          error={error}
+        />
+      </div>
+    );
+  }
+
+  if (viewMode === "import") {
+    return (
+      <div className="p-6 space-y-6">
+        <div className="flex items-center gap-2">
+          <button onClick={() => setViewMode("list")} className="text-xs text-muted-foreground hover:text-foreground">&larr; Back</button>
+          <h2 className="text-lg font-semibold">Import SSH Key</h2>
+        </div>
+        <ImportKeyForm
+          onImport={async (data) => {
+            const result = await importKey(data);
+            if (result.error) {
+              setError(result.error);
+            } else {
+              setViewMode("list");
+              setError(null);
+            }
+          }}
+          error={error}
+        />
+      </div>
+    );
+  }
+
+  if (viewMode === "edit" && editingKey) {
+    return (
+      <div className="p-6 space-y-6">
+        <div className="flex items-center gap-2">
+          <button onClick={() => { setViewMode("list"); setEditingKey(null); }} className="text-xs text-muted-foreground hover:text-foreground">&larr; Back</button>
+          <h2 className="text-lg font-semibold">Edit Key: {editingKey.name}</h2>
+        </div>
+        <EditKeyForm
+          keyInfo={editingKey}
+          onSave={async (data) => {
+            const result = await updateKey(editingKey.id, data);
+            if (result.error) {
+              setError(result.error);
+            } else {
+              setViewMode("list");
+              setEditingKey(null);
+              setError(null);
+            }
+          }}
+          error={error}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">SSH Keys</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Manage SSH keys for remote server access. Keys are stored locally with restricted permissions.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => { setViewMode("generate"); setError(null); }}
+            className="text-xs px-3 py-1.5 bg-primary text-primary-foreground rounded hover:bg-primary/90"
+          >
+            Generate Key
+          </button>
+          <button
+            onClick={() => { setViewMode("import"); setError(null); }}
+            className="text-xs px-3 py-1.5 bg-secondary text-foreground rounded hover:bg-secondary/80"
+          >
+            Import Key
+          </button>
+        </div>
+      </div>
+
+      {sshKeysLoading ? (
+        <div className="text-sm text-muted-foreground">Loading keys...</div>
+      ) : sshKeys.length === 0 ? (
+        <div className="border border-dashed border-border rounded-lg p-8 text-center text-sm text-muted-foreground">
+          No SSH keys configured. Generate or import a key to get started.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {sshKeys.map((key) => (
+            <div key={key.id} className="border border-border rounded-lg p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="font-medium text-sm">{key.name}</div>
+                  <div className="text-xs text-muted-foreground mt-0.5">
+                    {key.username} &middot; {key.keyType.toUpperCase()} &middot; Port {key.port}
+                  </div>
+                  <div className="text-xs text-muted-foreground font-mono mt-1 truncate max-w-md">
+                    {key.fingerprint}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => handleCopyPublicKey(key.id)}
+                    className="text-xs px-2 py-1 rounded bg-secondary hover:bg-secondary/80"
+                    title="Copy public key"
+                  >
+                    Copy Pub Key
+                  </button>
+                  <button
+                    onClick={() => { setEditingKey(key); setViewMode("edit"); setError(null); }}
+                    className="text-xs px-2 py-1 rounded bg-secondary hover:bg-secondary/80"
+                  >
+                    Edit
+                  </button>
+                  {confirmDelete === key.id ? (
+                    <div className="flex items-center gap-1">
+                      <button
+                        onClick={() => handleDelete(key.id)}
+                        className="text-xs px-2 py-1 rounded bg-red-600 text-white hover:bg-red-700"
+                      >
+                        Confirm
+                      </button>
+                      <button
+                        onClick={() => setConfirmDelete(null)}
+                        className="text-xs px-2 py-1 rounded bg-secondary hover:bg-secondary/80"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setConfirmDelete(key.id)}
+                      className="text-xs px-2 py-1 rounded text-red-400 hover:bg-red-500/10"
+                    >
+                      Delete
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              {/* Allowed hosts */}
+              {key.allowedHosts.length > 0 && (
+                <div className="space-y-1">
+                  <div className="text-xs text-muted-foreground">Allowed Hosts:</div>
+                  <div className="flex flex-wrap gap-1">
+                    {key.allowedHosts.map((host) => {
+                      const testKey = `${key.id}:${host}`;
+                      const testResult = testResults[testKey];
+                      return (
+                        <div key={host} className="flex items-center gap-1">
+                          <span className="text-xs px-2 py-0.5 bg-secondary rounded font-mono">
+                            {host}
+                          </span>
+                          <button
+                            onClick={() => handleTestConnection(key.id, host)}
+                            disabled={testResult?.testing}
+                            className="text-[10px] px-1.5 py-0.5 rounded bg-secondary hover:bg-secondary/80 disabled:opacity-50"
+                          >
+                            {testResult?.testing ? "..." : "Test"}
+                          </button>
+                          {testResult && !testResult.testing && (
+                            <span className={`text-[10px] ${testResult.ok ? "text-green-400" : "text-red-400"}`}>
+                              {testResult.ok ? "OK" : testResult.error?.slice(0, 30) || "Failed"}
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Public key modal */}
+      {publicKeyModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setPublicKeyModal(null)}>
+          <div className="bg-card border border-border rounded-lg p-6 max-w-lg w-full mx-4 space-y-3" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-sm font-semibold">Public Key (copied to clipboard)</h3>
+            <pre className="text-xs bg-secondary p-3 rounded overflow-x-auto font-mono whitespace-pre-wrap break-all">
+              {publicKeyModal.publicKey}
+            </pre>
+            <p className="text-xs text-muted-foreground">
+              Add this key to the remote host's ~/.ssh/authorized_keys file.
+            </p>
+            <button
+              onClick={() => setPublicKeyModal(null)}
+              className="text-xs px-3 py-1.5 bg-secondary rounded hover:bg-secondary/80"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Sub-forms ────────────────────────────────────────────────────
+
+function GenerateKeyForm({
+  onGenerate,
+  error,
+}: {
+  onGenerate: (data: { name: string; username: string; allowedHosts: string[]; keyType?: SshKeyType; port?: number }) => Promise<void>;
+  error: string | null;
+}) {
+  const [name, setName] = useState("");
+  const [username, setUsername] = useState("root");
+  const [keyType, setKeyType] = useState<SshKeyType>("ed25519");
+  const [port, setPort] = useState(22);
+  const [hostsInput, setHostsInput] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!name.trim() || !username.trim()) return;
+    const allowedHosts = hostsInput.split(/[,\n]/).map((h) => h.trim()).filter(Boolean);
+    setSubmitting(true);
+    await onGenerate({ name: name.trim(), username: username.trim(), allowedHosts, keyType, port });
+    setSubmitting(false);
+  };
+
+  return (
+    <div className="space-y-4 max-w-md">
+      <div>
+        <label className="text-xs font-medium block mb-1">Key Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. production-server"
+          className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1">SSH Username</label>
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="e.g. root"
+          className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1">Key Type</label>
+        <select
+          value={keyType}
+          onChange={(e) => setKeyType(e.target.value as SshKeyType)}
+          className="text-sm px-3 py-2 bg-secondary border border-border rounded"
+        >
+          <option value="ed25519">Ed25519 (recommended)</option>
+          <option value="rsa">RSA</option>
+        </select>
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1">Port</label>
+        <input
+          type="number"
+          value={port}
+          onChange={(e) => setPort(parseInt(e.target.value, 10) || 22)}
+          className="w-24 text-sm px-3 py-2 bg-secondary border border-border rounded"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1">Allowed Hosts (one per line or comma-separated)</label>
+        <textarea
+          value={hostsInput}
+          onChange={(e) => setHostsInput(e.target.value)}
+          placeholder="192.168.1.100&#10;myserver.example.com"
+          rows={3}
+          className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded font-mono"
+        />
+      </div>
+      {error && <div className="text-xs text-red-400">{error}</div>}
+      <button
+        onClick={handleSubmit}
+        disabled={submitting || !name.trim() || !username.trim()}
+        className="text-xs px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90 disabled:opacity-50"
+      >
+        {submitting ? "Generating..." : "Generate Key"}
+      </button>
+    </div>
+  );
+}
+
+function ImportKeyForm({
+  onImport,
+  error,
+}: {
+  onImport: (data: { name: string; username: string; privateKey: string; allowedHosts: string[]; port?: number }) => Promise<void>;
+  error: string | null;
+}) {
+  const [name, setName] = useState("");
+  const [username, setUsername] = useState("root");
+  const [privateKey, setPrivateKey] = useState("");
+  const [port, setPort] = useState(22);
+  const [hostsInput, setHostsInput] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!name.trim() || !username.trim() || !privateKey.trim()) return;
+    const allowedHosts = hostsInput.split(/[,\n]/).map((h) => h.trim()).filter(Boolean);
+    setSubmitting(true);
+    await onImport({ name: name.trim(), username: username.trim(), privateKey: privateKey.trim(), allowedHosts, port });
+    setSubmitting(false);
+  };
+
+  return (
+    <div className="space-y-4 max-w-md">
+      <div>
+        <label className="text-xs font-medium block mb-1">Key Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. production-server"
+          className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1">SSH Username</label>
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="e.g. root"
+          className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1">Private Key (paste contents)</label>
+        <textarea
+          value={privateKey}
+          onChange={(e) => setPrivateKey(e.target.value)}
+          placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;..."
+          rows={6}
+          className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded font-mono"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1">Port</label>
+        <input
+          type="number"
+          value={port}
+          onChange={(e) => setPort(parseInt(e.target.value, 10) || 22)}
+          className="w-24 text-sm px-3 py-2 bg-secondary border border-border rounded"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1">Allowed Hosts (one per line or comma-separated)</label>
+        <textarea
+          value={hostsInput}
+          onChange={(e) => setHostsInput(e.target.value)}
+          placeholder="192.168.1.100&#10;myserver.example.com"
+          rows={3}
+          className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded font-mono"
+        />
+      </div>
+      {error && <div className="text-xs text-red-400">{error}</div>}
+      <button
+        onClick={handleSubmit}
+        disabled={submitting || !name.trim() || !username.trim() || !privateKey.trim()}
+        className="text-xs px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90 disabled:opacity-50"
+      >
+        {submitting ? "Importing..." : "Import Key"}
+      </button>
+    </div>
+  );
+}
+
+function EditKeyForm({
+  keyInfo,
+  onSave,
+  error,
+}: {
+  keyInfo: SshKeyInfo;
+  onSave: (data: { name?: string; username?: string; allowedHosts?: string[]; port?: number }) => Promise<void>;
+  error: string | null;
+}) {
+  const [name, setName] = useState(keyInfo.name);
+  const [username, setUsername] = useState(keyInfo.username);
+  const [port, setPort] = useState(keyInfo.port);
+  const [hostsInput, setHostsInput] = useState(keyInfo.allowedHosts.join("\n"));
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!name.trim() || !username.trim()) return;
+    const allowedHosts = hostsInput.split(/[,\n]/).map((h) => h.trim()).filter(Boolean);
+    setSubmitting(true);
+    await onSave({ name: name.trim(), username: username.trim(), allowedHosts, port });
+    setSubmitting(false);
+  };
+
+  return (
+    <div className="space-y-4 max-w-md">
+      <div>
+        <label className="text-xs font-medium block mb-1">Key Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1">SSH Username</label>
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1">Port</label>
+        <input
+          type="number"
+          value={port}
+          onChange={(e) => setPort(parseInt(e.target.value, 10) || 22)}
+          className="w-24 text-sm px-3 py-2 bg-secondary border border-border rounded"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1">Allowed Hosts (one per line or comma-separated)</label>
+        <textarea
+          value={hostsInput}
+          onChange={(e) => setHostsInput(e.target.value)}
+          rows={4}
+          className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded font-mono"
+        />
+      </div>
+      <div className="text-xs text-muted-foreground">
+        <span className="font-medium">Type:</span> {keyInfo.keyType.toUpperCase()} &middot;{" "}
+        <span className="font-medium">Fingerprint:</span>{" "}
+        <span className="font-mono">{keyInfo.fingerprint}</span>
+      </div>
+      {error && <div className="text-xs text-red-400">{error}</div>}
+      <button
+        onClick={handleSubmit}
+        disabled={submitting || !name.trim() || !username.trim()}
+        className="text-xs px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90 disabled:opacity-50"
+      >
+        {submitting ? "Saving..." : "Save Changes"}
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/settings-nav.ts
+++ b/packages/web/src/components/settings/settings-nav.ts
@@ -25,6 +25,7 @@ export type SettingsSection =
   | "nextcloud-talk"
   | "worker-names"
   | "mcp-servers"
+  | "ssh"
   | "security";
 
 export interface NavItem {
@@ -72,6 +73,7 @@ export const SETTINGS_NAV: NavGroup[] = [
       { id: "scheduled", label: "Scheduled Tasks" },
       { id: "modules", label: "Modules" },
       { id: "mcp-servers", label: "MCP Servers" },
+      { id: "ssh", label: "SSH Keys" },
     ],
   },
   {

--- a/packages/web/src/components/ssh/SshView.tsx
+++ b/packages/web/src/components/ssh/SshView.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useState } from "react";
+import { useSshStore } from "../../stores/ssh-store";
+import { TerminalView } from "../code/TerminalView";
+import { getSocket } from "../../lib/socket";
+import type { SshKeyInfo, SshSessionStatus } from "@otterbot/shared";
+
+const STATUS_DOT: Record<SshSessionStatus, string> = {
+  active: "bg-green-500",
+  completed: "bg-zinc-500",
+  error: "bg-red-500",
+};
+
+export function SshView() {
+  const {
+    sessions,
+    selectedSessionId,
+    sshKeys,
+    loadSessions,
+    loadKeys,
+    selectSession,
+    deleteSession,
+    connectToHost,
+    disconnectSession,
+    handleSessionStart,
+    handleSessionEnd,
+  } = useSshStore();
+
+  const [connectDialog, setConnectDialog] = useState(false);
+  const [connectKeyId, setConnectKeyId] = useState("");
+  const [connectHost, setConnectHost] = useState("");
+  const [connecting, setConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadSessions();
+    loadKeys();
+
+    // Socket listeners
+    const socket = getSocket();
+    const onStart = (data: { sessionId: string; keyId: string; host: string; username: string; agentId: string }) => {
+      handleSessionStart(data);
+    };
+    const onEnd = (data: { sessionId: string; agentId: string; status: SshSessionStatus }) => {
+      handleSessionEnd(data);
+    };
+    socket.on("ssh:session-start", onStart);
+    socket.on("ssh:session-end", onEnd);
+    return () => {
+      socket.off("ssh:session-start", onStart);
+      socket.off("ssh:session-end", onEnd);
+    };
+  }, []);
+
+  const selectedSession = sessions.find((s) => s.id === selectedSessionId);
+  const agentId = selectedSession ? `ssh-${selectedSession.id}` : null;
+
+  const handleConnect = async () => {
+    if (!connectKeyId || !connectHost.trim()) return;
+    setConnecting(true);
+    setConnectError(null);
+    const result = await connectToHost(connectKeyId, connectHost.trim());
+    setConnecting(false);
+    if (result.ok) {
+      setConnectDialog(false);
+      setConnectHost("");
+    } else {
+      setConnectError(result.error || "Connection failed");
+    }
+  };
+
+  const handleDisconnect = (sessionId: string) => {
+    disconnectSession(sessionId);
+  };
+
+  // Get hosts for selected key in connect dialog
+  const selectedKey = sshKeys.find((k) => k.id === connectKeyId);
+
+  return (
+    <div className="h-full flex">
+      {/* Left sidebar: session list */}
+      <div className="w-56 border-r border-border flex flex-col bg-card">
+        <div className="p-2 border-b border-border flex items-center justify-between">
+          <span className="text-xs font-medium text-muted-foreground">SSH Sessions</span>
+          <button
+            onClick={() => {
+              setConnectDialog(true);
+              setConnectError(null);
+              if (sshKeys.length > 0 && !connectKeyId) {
+                setConnectKeyId(sshKeys[0].id);
+              }
+            }}
+            className="text-[10px] px-2 py-0.5 bg-primary text-primary-foreground rounded hover:bg-primary/90"
+          >
+            Connect
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {sessions.length === 0 ? (
+            <div className="p-3 text-xs text-muted-foreground text-center">
+              No sessions yet. Click Connect to start.
+            </div>
+          ) : (
+            sessions.map((session) => (
+              <button
+                key={session.id}
+                onClick={() => selectSession(session.id)}
+                className={`w-full text-left px-3 py-2 border-b border-border hover:bg-secondary/50 transition-colors ${
+                  selectedSessionId === session.id ? "bg-secondary" : ""
+                }`}
+              >
+                <div className="flex items-center gap-1.5">
+                  <div className={`w-1.5 h-1.5 rounded-full ${STATUS_DOT[session.status]}`} />
+                  <span className="text-xs font-medium truncate">{session.host}</span>
+                </div>
+                <div className="text-[10px] text-muted-foreground mt-0.5">
+                  {session.username} &middot; {new Date(session.startedAt).toLocaleTimeString()}
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Main area */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {selectedSession ? (
+          <>
+            {/* Session header */}
+            <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-card">
+              <div className="flex items-center gap-2">
+                <div className={`w-2 h-2 rounded-full ${STATUS_DOT[selectedSession.status]}`} />
+                <span className="text-sm font-medium">
+                  {selectedSession.username}@{selectedSession.host}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {selectedSession.status === "active" ? "Connected" : selectedSession.status}
+                </span>
+              </div>
+              <div className="flex items-center gap-1">
+                {selectedSession.status === "active" && (
+                  <button
+                    onClick={() => handleDisconnect(selectedSession.id)}
+                    className="text-xs px-2 py-1 rounded text-red-400 hover:bg-red-500/10"
+                  >
+                    Disconnect
+                  </button>
+                )}
+                {selectedSession.status !== "active" && (
+                  <button
+                    onClick={() => deleteSession(selectedSession.id)}
+                    className="text-xs px-2 py-1 rounded text-muted-foreground hover:bg-secondary"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Terminal */}
+            <div className="flex-1 min-h-0 relative">
+              {agentId && (
+                <TerminalView
+                  agentId={agentId}
+                  readOnly={selectedSession.status !== "active"}
+                />
+              )}
+              {selectedSession.status !== "active" && (
+                <div className="absolute bottom-0 left-0 right-0 bg-zinc-900/90 border-t border-border px-4 py-2 text-center">
+                  <span className="text-xs text-muted-foreground">
+                    Session ended
+                    {selectedSession.completedAt && (
+                      <> &middot; {new Date(selectedSession.completedAt).toLocaleString()}</>
+                    )}
+                  </span>
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+            {sessions.length > 0
+              ? "Select a session from the sidebar"
+              : "No SSH sessions. Click Connect to start one."}
+          </div>
+        )}
+      </div>
+
+      {/* Connect dialog */}
+      {connectDialog && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setConnectDialog(false)}>
+          <div className="bg-card border border-border rounded-lg p-6 w-96 space-y-4" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-sm font-semibold">Connect to Host</h3>
+
+            {sshKeys.length === 0 ? (
+              <div className="text-xs text-muted-foreground">
+                No SSH keys configured. Go to Settings &gt; SSH Keys to add one.
+              </div>
+            ) : (
+              <>
+                <div>
+                  <label className="text-xs font-medium block mb-1">SSH Key</label>
+                  <select
+                    value={connectKeyId}
+                    onChange={(e) => {
+                      setConnectKeyId(e.target.value);
+                      setConnectHost("");
+                    }}
+                    className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded"
+                  >
+                    {sshKeys.map((key) => (
+                      <option key={key.id} value={key.id}>
+                        {key.name} ({key.username})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="text-xs font-medium block mb-1">Host</label>
+                  {selectedKey && selectedKey.allowedHosts.length > 0 ? (
+                    <select
+                      value={connectHost}
+                      onChange={(e) => setConnectHost(e.target.value)}
+                      className="w-full text-sm px-3 py-2 bg-secondary border border-border rounded"
+                    >
+                      <option value="">Select a host...</option>
+                      {selectedKey.allowedHosts.map((host) => (
+                        <option key={host} value={host}>
+                          {host}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <div className="text-xs text-muted-foreground">
+                      No hosts configured for this key.
+                    </div>
+                  )}
+                </div>
+
+                {connectError && <div className="text-xs text-red-400">{connectError}</div>}
+
+                <div className="flex justify-end gap-2">
+                  <button
+                    onClick={() => setConnectDialog(false)}
+                    className="text-xs px-3 py-1.5 bg-secondary rounded hover:bg-secondary/80"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={handleConnect}
+                    disabled={connecting || !connectHost.trim()}
+                    className="text-xs px-3 py-1.5 bg-primary text-primary-foreground rounded hover:bg-primary/90 disabled:opacity-50"
+                  >
+                    {connecting ? "Connecting..." : "Connect"}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/get-center-tabs.test.ts
+++ b/packages/web/src/lib/get-center-tabs.test.ts
@@ -4,17 +4,22 @@ import { getCenterTabs, centerViewLabels } from "./get-center-tabs";
 describe("getCenterTabs", () => {
   it("returns project-scoped tabs when a project is active", () => {
     const tabs = getCenterTabs("project-123");
-    expect(tabs).toEqual(["dashboard", "kanban", "charter", "files", "code", "settings", "merge-queue"]);
+    expect(tabs).toEqual(["dashboard", "kanban", "charter", "files", "code", "ssh", "settings", "merge-queue"]);
   });
 
   it("returns global tabs when no project is active (null)", () => {
     const tabs = getCenterTabs(null);
-    expect(tabs).toEqual(["dashboard", "todos", "inbox", "calendar", "code", "usage"]);
+    expect(tabs).toEqual(["dashboard", "todos", "inbox", "calendar", "code", "ssh", "usage"]);
   });
 
   it("includes 'code' in both project and global tabs", () => {
     expect(getCenterTabs("proj-1")).toContain("code");
     expect(getCenterTabs(null)).toContain("code");
+  });
+
+  it("includes 'ssh' in both project and global tabs", () => {
+    expect(getCenterTabs("proj-1")).toContain("ssh");
+    expect(getCenterTabs(null)).toContain("ssh");
   });
 
   it("does not include graph in project tabs", () => {
@@ -36,7 +41,7 @@ describe("centerViewLabels", () => {
   it("has a label for every CenterView value", () => {
     const allViews = [
       "graph", "live3d", "dashboard", "charter", "kanban",
-      "files", "todos", "inbox", "calendar", "code", "settings", "merge-queue", "usage", "desktop",
+      "files", "todos", "inbox", "calendar", "code", "ssh", "settings", "merge-queue", "usage", "desktop",
     ] as const;
     for (const view of allViews) {
       expect(centerViewLabels[view]).toBeDefined();

--- a/packages/web/src/lib/get-center-tabs.ts
+++ b/packages/web/src/lib/get-center-tabs.ts
@@ -10,6 +10,7 @@ export type CenterView =
   | "inbox"
   | "calendar"
   | "code"
+  | "ssh"
   | "settings"
   | "merge-queue"
   | "dashboard";
@@ -25,14 +26,15 @@ export const centerViewLabels: Record<CenterView, string> = {
   inbox: "Inbox",
   calendar: "Calendar",
   code: "Code",
+  ssh: "SSH",
   settings: "Settings",
   "merge-queue": "Merge Queue",
   usage: "Usage",
   desktop: "Desktop",
 };
 
-const projectTabs: CenterView[] = ["dashboard", "kanban", "charter", "files", "code", "settings", "merge-queue"];
-const globalTabs: CenterView[] = ["dashboard", "todos", "inbox", "calendar", "code", "usage"];
+const projectTabs: CenterView[] = ["dashboard", "kanban", "charter", "files", "code", "ssh", "settings", "merge-queue"];
+const globalTabs: CenterView[] = ["dashboard", "todos", "inbox", "calendar", "code", "ssh", "usage"];
 
 export function getCenterTabs(activeProjectId: string | null): CenterView[] {
   return activeProjectId ? projectTabs : globalTabs;

--- a/packages/web/src/stores/ssh-store.ts
+++ b/packages/web/src/stores/ssh-store.ts
@@ -1,0 +1,207 @@
+import { create } from "zustand";
+import type { SshSession, SshKeyInfo, SshKeyType } from "@otterbot/shared";
+import { getSocket } from "../lib/socket";
+
+interface SshState {
+  sessions: SshSession[];
+  selectedSessionId: string | null;
+  sshKeys: SshKeyInfo[];
+  sshKeysLoading: boolean;
+
+  // Session actions
+  loadSessions: () => Promise<void>;
+  selectSession: (id: string | null) => void;
+  deleteSession: (id: string) => Promise<void>;
+  connectToHost: (keyId: string, host: string) => Promise<{ ok: boolean; sessionId?: string; agentId?: string; error?: string }>;
+  disconnectSession: (sessionId: string) => Promise<void>;
+
+  // Key management actions
+  loadKeys: () => Promise<void>;
+  generateKey: (data: { name: string; username: string; allowedHosts: string[]; keyType?: SshKeyType; port?: number }) => Promise<{ key?: SshKeyInfo; error?: string }>;
+  importKey: (data: { name: string; username: string; privateKey: string; allowedHosts: string[]; port?: number }) => Promise<{ key?: SshKeyInfo; error?: string }>;
+  updateKey: (id: string, data: { name?: string; username?: string; allowedHosts?: string[]; port?: number }) => Promise<{ key?: SshKeyInfo; error?: string }>;
+  deleteKey: (id: string) => Promise<boolean>;
+  getPublicKey: (id: string) => Promise<string | null>;
+  testConnection: (keyId: string, host: string) => Promise<{ ok: boolean; error?: string }>;
+
+  // Socket event handlers
+  handleSessionStart: (data: { sessionId: string; keyId: string; host: string; username: string; agentId: string }) => void;
+  handleSessionEnd: (data: { sessionId: string; agentId: string; status: string }) => void;
+}
+
+export const useSshStore = create<SshState>((set, get) => ({
+  sessions: [],
+  selectedSessionId: null,
+  sshKeys: [],
+  sshKeysLoading: false,
+
+  loadSessions: async () => {
+    try {
+      const res = await fetch("/api/ssh/sessions");
+      const data = await res.json();
+      set({ sessions: data.sessions ?? [] });
+    } catch (err) {
+      console.error("Failed to load SSH sessions:", err);
+    }
+  },
+
+  loadKeys: async () => {
+    set({ sshKeysLoading: true });
+    try {
+      const res = await fetch("/api/settings/ssh/keys");
+      const data = await res.json();
+      set({ sshKeys: data.keys ?? [], sshKeysLoading: false });
+    } catch (err) {
+      console.error("Failed to load SSH keys:", err);
+      set({ sshKeysLoading: false });
+    }
+  },
+
+  selectSession: (id) => set({ selectedSessionId: id }),
+
+  deleteSession: async (id) => {
+    try {
+      await fetch(`/api/ssh/sessions/${id}`, { method: "DELETE" });
+      set((s) => ({
+        sessions: s.sessions.filter((session) => session.id !== id),
+        selectedSessionId: s.selectedSessionId === id ? null : s.selectedSessionId,
+      }));
+    } catch (err) {
+      console.error("Failed to delete SSH session:", err);
+    }
+  },
+
+  connectToHost: (keyId, host) => {
+    return new Promise((resolve) => {
+      const socket = getSocket();
+      socket.emit("ssh:connect", { keyId, host }, (ack) => {
+        resolve(ack ?? { ok: false, error: "No response" });
+      });
+    });
+  },
+
+  disconnectSession: async (sessionId) => {
+    const socket = getSocket();
+    socket.emit("ssh:disconnect", { sessionId });
+  },
+
+  generateKey: async (data) => {
+    try {
+      const res = await fetch("/api/settings/ssh/keys/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      const result = await res.json();
+      if (result.key) {
+        set((s) => ({ sshKeys: [result.key, ...s.sshKeys] }));
+        return { key: result.key };
+      }
+      return { error: result.error || "Failed to generate key" };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : "Failed to generate key" };
+    }
+  },
+
+  importKey: async (data) => {
+    try {
+      const res = await fetch("/api/settings/ssh/keys/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      const result = await res.json();
+      if (result.key) {
+        set((s) => ({ sshKeys: [result.key, ...s.sshKeys] }));
+        return { key: result.key };
+      }
+      return { error: result.error || "Failed to import key" };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : "Failed to import key" };
+    }
+  },
+
+  updateKey: async (id, data) => {
+    try {
+      const res = await fetch(`/api/settings/ssh/keys/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      const result = await res.json();
+      if (result.key) {
+        set((s) => ({
+          sshKeys: s.sshKeys.map((k) => (k.id === id ? result.key : k)),
+        }));
+        return { key: result.key };
+      }
+      return { error: result.error || "Failed to update key" };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : "Failed to update key" };
+    }
+  },
+
+  deleteKey: async (id) => {
+    try {
+      const res = await fetch(`/api/settings/ssh/keys/${id}`, { method: "DELETE" });
+      const result = await res.json();
+      if (result.ok) {
+        set((s) => ({ sshKeys: s.sshKeys.filter((k) => k.id !== id) }));
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  },
+
+  getPublicKey: async (id) => {
+    try {
+      const res = await fetch(`/api/settings/ssh/keys/${id}/public-key`);
+      const result = await res.json();
+      return result.publicKey ?? null;
+    } catch {
+      return null;
+    }
+  },
+
+  testConnection: async (keyId, host) => {
+    try {
+      const res = await fetch("/api/settings/ssh/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ keyId, host }),
+      });
+      return await res.json();
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : "Test failed" };
+    }
+  },
+
+  handleSessionStart: (data) => {
+    const session: SshSession = {
+      id: data.sessionId,
+      sshKeyId: data.keyId,
+      host: data.host,
+      username: data.username,
+      status: "active",
+      startedAt: new Date().toISOString(),
+      completedAt: null,
+      initiatedBy: "user",
+    };
+    set((s) => ({
+      sessions: [session, ...s.sessions],
+      selectedSessionId: data.sessionId,
+    }));
+  },
+
+  handleSessionEnd: (data) => {
+    set((s) => ({
+      sessions: s.sessions.map((session) =>
+        session.id === data.sessionId
+          ? { ...session, status: data.status as SshSession["status"], completedAt: new Date().toISOString() }
+          : session,
+      ),
+    }));
+  },
+}));


### PR DESCRIPTION
## Summary
- Add complete SSH module enabling AI agents to SSH into remote hosts, run commands, and manage machines
- Key management (generate ed25519/RSA, import, CRUD) with host allowlisting and blocked command safety checks
- Interactive PTY sessions reusing existing terminal infrastructure (xterm.js, socket routing)
- Dedicated SSH View tab in both project and global contexts, plus SSH Keys settings tab
- New SSH Administrator agent with `ssh_exec`, `ssh_list_keys`, `ssh_list_hosts`, `ssh_connect` tools
- Comprehensive test coverage (40 new tests across 3 test files + updated existing tests)

## Test plan
- [x] All 964 tests pass (67 test files)
- [x] Server and shared packages type-check cleanly
- [ ] Manual: Settings > SSH Keys — generate, import, edit, delete keys
- [ ] Manual: SSH View tab — connect to host, interactive terminal, disconnect
- [ ] Manual: Agent uses ssh_exec for one-shot commands, ssh_connect for interactive sessions
- [ ] Manual: Host allowlist enforcement blocks non-allowlisted hosts