### PR TITLE
fix: wire up --max-turns for Claude Code and update default to 75

### DIFF
--- a/packages/server/src/coding-agents/claude-code-pty-client.ts
+++ b/packages/server/src/coding-agents/claude-code-pty-client.ts
@@ -73,6 +73,12 @@ export class ClaudeCodePtyClient implements CodingAgentClient {
         args.unshift("--model", model);
       }
 
+      // Add max-turns flag if configured
+      const maxTurns = getConfig("claude-code:max_turns");
+      if (maxTurns) {
+        args.unshift("--max-turns", maxTurns);
+      }
+
       if (approvalMode === "full-auto") {
         args.unshift("--dangerously-skip-permissions");
         // Ensure the "are you sure?" confirmation for --dangerously-skip-permissions

--- a/packages/server/src/settings/__tests__/coding-agent-settings.test.ts
+++ b/packages/server/src/settings/__tests__/coding-agent-settings.test.ts
@@ -89,7 +89,7 @@ describe("Coding agent settings", () => {
       expect(settings.model).toBe("claude-sonnet-4-5-20250929");
       expect(settings.approvalMode).toBe("full-auto");
       expect(settings.timeoutMs).toBe(1200000);
-      expect(settings.maxTurns).toBe(50);
+      expect(settings.maxTurns).toBe(75);
     });
 
     it("updateClaudeCodeSettings persists values", async () => {

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -1461,7 +1461,7 @@ export function getClaudeCodeSettings(): ClaudeCodeSettingsResponse {
     model: getConfig("claude-code:model") ?? "claude-sonnet-4-5-20250929",
     approvalMode: (getConfig("claude-code:approval_mode") ?? "full-auto") as "full-auto" | "auto-edit",
     timeoutMs: parseInt(getConfig("claude-code:timeout_ms") ?? "1200000", 10),
-    maxTurns: parseInt(getConfig("claude-code:max_turns") ?? "50", 10),
+    maxTurns: parseInt(getConfig("claude-code:max_turns") ?? "75", 10),
   };
 }
 

--- a/packages/web/src/components/settings/CodingAgentsTab.tsx
+++ b/packages/web/src/components/settings/CodingAgentsTab.tsx
@@ -229,7 +229,7 @@ function ClaudeCodeSection() {
         <SelectField label="Approval Mode" value={localApprovalMode} onChange={(v) => setLocalApprovalMode(v as "full-auto" | "auto-edit")}
           options={[{ value: "full-auto", label: "Full Auto (YOLO)" }, { value: "auto-edit", label: "Auto Edit (ask for tool use)" }]} />
         <InputField label="Timeout (ms)" value={localTimeoutMs} onChange={setLocalTimeoutMs} placeholder="1200000" type="number" />
-        <InputField label="Max Turns" value={localMaxTurns} onChange={setLocalMaxTurns} placeholder="50" type="number" />
+        <InputField label="Max Turns" value={localMaxTurns} onChange={setLocalMaxTurns} placeholder="75" type="number" />
 
         <ActionButtons saving={saving} onSave={handleSave} onTest={testClaudeCodeConnection} testResult={testResult} />
       </div>

--- a/packages/web/src/stores/settings-store.ts
+++ b/packages/web/src/stores/settings-store.ts
@@ -512,7 +512,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   claudeCodeModel: "claude-sonnet-4-5-20250929",
   claudeCodeApprovalMode: "full-auto",
   claudeCodeTimeoutMs: 1200000,
-  claudeCodeMaxTurns: 50,
+  claudeCodeMaxTurns: 75,
   claudeCodeTestResult: null,
   codexEnabled: false,
   codexAuthMode: "api-key",


### PR DESCRIPTION
## Summary
- Wire up the `--max-turns` flag in the Claude Code PTY client — the setting was saved to config but never actually passed to the CLI
- Update the default `maxTurns` from 50 to 75 across server settings, frontend store, and UI placeholder

## Test plan
- [x] All 964 tests pass (`npx pnpm test`)
- [ ] Configure a `maxTurns` value in Claude Code settings, dispatch a task, verify `--max-turns` appears in spawned process args