### PR TITLE
feat: enable general tasks without project creation

### DIFF
--- a/packages/server/src/agents/admin-assistant.ts
+++ b/packages/server/src/agents/admin-assistant.ts
@@ -70,7 +70,7 @@ export class AdminAssistant extends BaseAgent {
     // Cap tool-call rounds — the admin assistant should never need more than
     // a few tool calls per think(). The default maxSteps=20 lets models loop
     // and re-call the same tool (e.g. todo_create) many times.
-    this.llmConfig.maxSteps = 5;
+    this.llmConfig.maxSteps = 8;
     this.onStream = deps.onStream;
     this.onThinking = deps.onThinking;
     this.onThinkingEnd = deps.onThinkingEnd;

--- a/packages/server/src/agents/coo.ts
+++ b/packages/server/src/agents/coo.ts
@@ -682,9 +682,10 @@ The user can see everything on the desktop in real-time.`;
       }),
       delegate_to_admin: tool({
         description:
-          "Delegate a personal/administrative task to the Admin Assistant. " +
-          "Use this for: todos, reminders, email, calendar, and other personal productivity tasks. " +
-          "Do NOT create a project for these — they are personal tasks, not engineering work.",
+          "Delegate a task to the Admin Assistant for direct execution. " +
+          "Use this for: todos, reminders, email, calendar, SSH commands, remote server operations, " +
+          "memory/notes, custom tools, and other tasks that don't require a full project. " +
+          "Do NOT create a project for these — they are operational tasks, not engineering work.",
         parameters: z.object({
           request: z.string().describe(
             "The request to send to the Admin Assistant, in natural language"
@@ -698,7 +699,7 @@ The user can see everything on the desktop in real-time.`;
               type: MessageType.Chat,
               content: request,
             },
-            30_000,
+            60_000,
           );
           if (!reply) {
             return "The Admin Assistant did not respond in time. Please try again.";

--- a/packages/server/src/agents/prompts/admin-assistant.ts
+++ b/packages/server/src/agents/prompts/admin-assistant.ts
@@ -1,5 +1,5 @@
 export function buildAdminAssistantPrompt(name: string): string {
-  return `You are ${name}, the Admin Assistant in Otterbot. You help the CEO (the human user) with personal productivity tasks — managing emails, calendars, and todos.
+  return `You are ${name}, the Admin Assistant in Otterbot. You help the CEO (the human user) with personal productivity tasks and operational tasks — managing emails, calendars, todos, SSH commands, memory, and more.
 ${ADMIN_ASSISTANT_PROMPT_BODY}`;
 }
 
@@ -12,7 +12,7 @@ const ADMIN_ASSISTANT_PROMPT_BODY = `
 - When listing items, use clear formatting
 
 ## Your Capabilities
-You manage three key areas:
+You manage the following areas:
 
 ### Todos
 - List, create, update, and delete personal todos
@@ -40,10 +40,26 @@ You manage three key areas:
 - The local calendar works without any Google account
 - When Google Calendar is connected, events from both are merged
 
+### SSH & Remote Servers
+- Execute commands on remote servers via SSH using \`ssh_exec\`
+- List available SSH keys with \`ssh_list_keys\`
+- List configured SSH hosts with \`ssh_list_hosts\`
+- Connect/test SSH connections with \`ssh_connect\`
+- Useful for: checking disk space, restarting services, viewing logs, system status, etc.
+
+### Memory
+- Save important information for later recall using \`memory_save\`
+- Use this when the CEO says "remember this", "save this", "note that...", etc.
+
+### Custom Tools
+- You may have additional custom tools configured by the user
+- Use whatever tools are available to fulfill the request
+
 ## How You Work
 - When asked about schedule/calendar, use calendar_list_events with appropriate time ranges
 - When asked about emails, use gmail_list with relevant search queries
 - For todo management, use the todo tools
+- For SSH tasks: if the user doesn't specify a host or key, use \`ssh_list_keys\` and \`ssh_list_hosts\` first to discover available connections, then use \`ssh_exec\` to run the command
 - Always confirm destructive actions (delete, archive) before executing
 - If Google is not connected and the user asks for Gmail or Google Calendar, let them know they need to connect in Settings > Google
 

--- a/packages/server/src/agents/prompts/coo.ts
+++ b/packages/server/src/agents/prompts/coo.ts
@@ -21,21 +21,23 @@ You can:
 8. **Manage models** — list configured LLM providers, view and change default models per agent tier (COO, Team Lead, Worker), and test provider connections.
 9. **Manage search** — list, configure, activate, and test web search providers (SearXNG, Brave Search, Tavily). Workers use the active search provider for web research.
 10. **Query GitHub** — list and view issues and pull requests on any GitHub repo using the \`github_*\` tools. Read-only — write operations (commenting, creating PRs) are handled by Team Leads and Workers.
+11. **Handle quick operational tasks** — answer web questions via \`web_search\`, delegate SSH/remote-server tasks and memory operations to the Admin Assistant, or run quick local checks via \`run_command\`.
 
 ## How You Work
 When the CEO gives you a goal:
-1. Assess if the goal is clear enough to act on. If not, ask clarifying questions about goals and scope.
-2. **Always check active projects first.** If an existing project covers this goal, use \`send_directive\` to send additional work to its Team Lead. NEVER create a new project for work that belongs to an existing project.
-3. Only create a new project if no active project already addresses the goal. You must call \`get_project_status\` first.
-4. **Project creation requires CEO approval.** When you call \`create_project\`, the CEO will be asked to confirm. The project will only be created once they approve. Do NOT assume the project was created — wait for confirmation.
-5. When creating a project, write a **charter** in markdown that captures:
+1. **Classify the request.** Is this a quick, one-off task (web lookup, SSH command, system check, memory/notes) or substantial engineering work? If it can be completed in a single tool call or a short delegation, handle it directly — do NOT create a project. See "General / One-Off Tasks" below.
+2. Assess if the goal is clear enough to act on. If not, ask clarifying questions about goals and scope.
+3. **Always check active projects first.** If an existing project covers this goal, use \`send_directive\` to send additional work to its Team Lead. NEVER create a new project for work that belongs to an existing project.
+4. Only create a new project if no active project already addresses the goal. You must call \`get_project_status\` first.
+5. **Project creation requires CEO approval.** When you call \`create_project\`, the CEO will be asked to confirm. The project will only be created once they approve. Do NOT assume the project was created — wait for confirmation.
+6. When creating a project, write a **charter** in markdown that captures:
    - **Goals**: What the project aims to achieve
    - **Scope**: What's included and excluded
    - **Constraints**: Technical or resource constraints (never invent deadlines or timelines — these are ongoing projects)
    - **Deliverables**: What will be produced
    - **Approach**: High-level strategy
-5. Give the Team Lead a clear directive with the goal and expectations.
-6. Monitor progress and report back to the CEO.
+7. Give the Team Lead a clear directive with the goal and expectations.
+8. Monitor progress and report back to the CEO.
 
 ## Managing Multiple Projects
 Projects are **long-lived workspaces** — each one represents a codebase or domain of work. Once created, a project persists and accepts follow-up directives over time.
@@ -65,6 +67,17 @@ Delegate to the Admin Assistant when you hear things like:
 - "Remind me to X" / "Don't let me forget X"
 - "Check my email" / "Send an email to..."
 - "What's on my calendar?" / "Schedule a meeting..."
+
+## General / One-Off Tasks
+Not everything is a project. Many requests are quick, one-off tasks that should be handled immediately:
+
+- **Web questions** ("What are the latest AI news?", "Look up X") → use \`web_search\` directly.
+- **SSH / remote server operations** ("Check disk space on server X", "Restart nginx on prod") → use \`delegate_to_admin\`. The Admin Assistant has SSH tools for remote command execution.
+- **Quick local system checks** ("What's the uptime?", "How much disk space is left?") → use \`run_command\` directly.
+- **Memory and notes** ("Remember that X", "Save this for later") → use \`delegate_to_admin\`. The Admin Assistant has memory tools.
+- **Custom tool operations** → use \`delegate_to_admin\`. The Admin Assistant has access to all custom tools configured in the system.
+
+**Rule of thumb:** If the request can be completed in a single tool call or a short delegation, do NOT create a project. Projects are for substantial, multi-step engineering work.
 
 ## GitHub Queries
 When the CEO asks about GitHub issues or pull requests (e.g. "show me open issues", "what PRs are open on X"):


### PR DESCRIPTION
## Summary
- Add task classification to COO workflow so quick one-off tasks (web lookups, SSH commands, system checks, memory operations) are handled directly instead of spinning up full projects
- Widen `delegate_to_admin` tool description to cover SSH, memory, and custom tools — not just personal/admin tasks
- Document AdminAssistant's SSH, memory, and custom tool capabilities so the LLM knows to use them
- Bump AdminAssistant maxSteps (5→8) and delegate timeout (30s→60s) to support multi-step SSH workflows

## Test plan
- [ ] "Check free disk space on server X via SSH" → delegates to AdminAssistant, no project created
- [ ] "What are the latest news about AI?" → COO uses `web_search` directly
- [ ] "Build me a React todo app" → still creates a project as before
- [ ] "Restart nginx on prod-server-1" → delegates to AdminAssistant
- [ ] "What's the uptime of this machine?" → COO uses `run_command`