### PR TITLE
fix: use worker/agent names instead of IDs in chat updates

### DIFF
--- a/packages/server/src/agents/coo.ts
+++ b/packages/server/src/agents/coo.ts
@@ -361,7 +361,7 @@ The user can see everything on the desktop in real-time.`;
     // Process the Team Lead's report with a strong instruction to relay.
     // Use thinkWithoutTools so the COO just summarises instead of looping
     // on get_project_status or other tools — it only needs to relay.
-    const summary = `[IMPORTANT: Summarize this report and relay it to the CEO immediately. Do NOT call any tools — just write your summary.]\n\n[Report from Team Lead ${message.fromAgentId}]: ${message.content}`;
+    const summary = `[IMPORTANT: Summarize this report and relay it to the CEO immediately. Do NOT call any tools — just write your summary.]\n\n[Report from Team Lead ${this.getAgentName(message.fromAgentId ?? '')}]: ${message.content}`;
     const { text, thinking } = await this.thinkWithoutTools(
       summary,
       (token, messageId) => {
@@ -393,6 +393,13 @@ The user can see everything on the desktop in real-time.`;
       thinking ? { thinking } : undefined,
       this.currentConversationId ?? undefined,
     );
+  }
+
+  private getAgentName(agentId: string): string {
+    for (const tl of this.teamLeads.values()) {
+      if (tl.id === agentId) return tl.name ?? agentId;
+    }
+    return agentId;
   }
 
   /** Reset per-cycle tool call counters before each LLM invocation */

--- a/packages/server/src/agents/team-lead.ts
+++ b/packages/server/src/agents/team-lead.ts
@@ -815,7 +815,7 @@ export class TeamLead extends BaseAgent {
         actionRequired;
 
       const waitSummary =
-        `[Worker ${message.fromAgentId} report]: ${message.content}\n\n` +
+        `[Worker ${(message.fromAgentId && this.workers.get(message.fromAgentId)?.name) ?? message.fromAgentId} report]: ${message.content}\n\n` +
         taskNotice +
         `[KANBAN BOARD]\n${board.summary}\n[/KANBAN BOARD]\n\n` +
         waitInstructions;
@@ -890,7 +890,7 @@ export class TeamLead extends BaseAgent {
     }
 
     const summary =
-      `[Worker ${message.fromAgentId} report]: ${message.content}\n\n` +
+      `[Worker ${(message.fromAgentId && this.workers.get(message.fromAgentId)?.name) ?? message.fromAgentId} report]: ${message.content}\n\n` +
       taskNotice +
       `[KANBAN BOARD]\n${board.summary}\n[/KANBAN BOARD]\n\n` +
       instructions;
@@ -1246,7 +1246,7 @@ export class TeamLead extends BaseAgent {
   }
 
   override getStatusSummary(): string {
-    return `TeamLead ${this.id} [${this.status}] — ${this.workers.size} worker(s)`;
+    return `TeamLead ${this.name ?? this.id} [${this.status}] — ${this.workers.size} worker(s)`;
   }
 
   protected getTools(): Record<string, unknown> {
@@ -1709,7 +1709,7 @@ export class TeamLead extends BaseAgent {
         assignedMsg = kanbanT ? ` ${this.taskLabel(kanbanT)} moved to in_progress.` : ` Task ${taskId} moved to in_progress.`;
       }
       console.log(`[TeamLead ${this.id}] Worker ${workerId} spawned and directive sent`);
-      return `Spawned ${entry.name} worker (${worker.id}) and assigned task.${assignedMsg}`;
+      return `Spawned ${entry.name} worker "${workerName}" and assigned task.${assignedMsg}`;
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       console.error(`[TeamLead ${this.id}] Failed to spawn worker: ${errMsg}`, err);

--- a/packages/server/src/agents/worker.ts
+++ b/packages/server/src/agents/worker.ts
@@ -161,7 +161,7 @@ export class Worker extends BaseAgent {
   }
 
   override getStatusSummary(): string {
-    return `Worker ${this.id} [${this.status}]`;
+    return `Worker ${this.name ?? this.id} [${this.status}]`;
   }
 
   protected getTools(): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- Replace raw nanoid-style IDs with human-readable agent names in worker reports, status summaries, and spawn messages
- Add `getAgentName()` helper to COO for resolving team lead names
- Use `this.name ?? this.id` fallback pattern in `getStatusSummary()` for TeamLead and Worker

## Test plan
- [x] `npx pnpm build` — no new type errors
- [x] `npx pnpm test` — all 946 tests pass
- [ ] Manual test: spawn a worker and verify chat updates show human names instead of IDs