### PR TITLE
fix: allow cancelling TTS playback by toggling speaker off

### DIFF
--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -87,6 +87,9 @@ export interface ClientToServerEvents {
   "ceo:new-chat": (
     callback?: (ack: { ok: boolean }) => void,
   ) => void;
+  "ceo:cancel-tts": (
+    callback?: (ack: { ok: boolean }) => void,
+  ) => void;
   "ceo:list-conversations": (
     data: { projectId?: string } | undefined,
     callback: (conversations: Conversation[]) => void,

--- a/packages/web/src/components/chat/CeoChat.tsx
+++ b/packages/web/src/components/chat/CeoChat.tsx
@@ -4,6 +4,7 @@ import { useSettingsStore } from "../../stores/settings-store";
 import { useProjectStore } from "../../stores/project-store";
 import { useSpeechToText } from "../../hooks/use-speech-to-text";
 import { getSocket } from "../../lib/socket";
+import { cancelTts } from "../../hooks/use-socket";
 import { cn } from "../../lib/utils";
 import { MarkdownContent } from "./MarkdownContent";
 
@@ -156,6 +157,10 @@ export function CeoChat({ cooName, detached }: { cooName?: string; detached?: bo
     setSpeakerOn((prev) => {
       const next = !prev;
       localStorage.setItem("otterbot:speaker", String(next));
+      // When turning speaker off, immediately stop all TTS playback
+      if (!next) {
+        cancelTts();
+      }
       return next;
     });
   }, []);


### PR DESCRIPTION
## Summary
- Adds a `ceo:cancel-tts` socket event and server-side generation counter to discard in-flight TTS synthesis results when the user cancels
- Moves client-side TTS queue/player to module-level state so `cancelTts()` can be called from outside the hook
- Toggling the speaker off in the UI immediately stops playback, clears the queue, revokes blob URLs, and notifies the server

Closes #290

## Test plan
- [ ] Toggle speaker on, send a message that triggers TTS, verify audio plays
- [ ] While TTS is playing, toggle speaker off — audio should stop immediately
- [ ] Send multiple messages with TTS, toggle speaker off mid-queue — all queued audio should be discarded
- [ ] Toggle speaker back on and send a new message — TTS should work normally again

🤖 Generated with [Claude Code](https://claude.com/claude-code)