### PR TITLE
feat: add AI chat box to SSH terminal for live interaction

### DIFF
--- a/packages/server/src/socket/__tests__/ssh-chat-socket.test.ts
+++ b/packages/server/src/socket/__tests__/ssh-chat-socket.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockHandleSshChat = vi.fn();
+
+vi.mock("../../ssh/ssh-chat.js", () => ({
+  handleSshChat: (...args: any[]) => mockHandleSshChat(...args),
+  clearSshChatHistory: vi.fn(),
+}));
+
+import {
+  setupSocketHandlers,
+  registerPtySession,
+  unregisterPtySession,
+} from "../handlers.js";
+
+type SocketHandler = (...args: any[]) => void | Promise<void>;
+
+const socketHandlers = new Map<string, SocketHandler>();
+
+function createMockSocket() {
+  return {
+    id: "socket-1",
+    on: vi.fn((event: string, handler: SocketHandler) => {
+      socketHandlers.set(event, handler);
+    }),
+    emit: vi.fn(),
+  };
+}
+
+function createMockIo() {
+  const sockets: any[] = [];
+  return {
+    emit: vi.fn(),
+    on: vi.fn((event: string, handler: (socket: any) => void) => {
+      if (event === "connection") {
+        for (const socket of sockets) {
+          handler(socket);
+        }
+      }
+    }),
+    _addSocket: (s: any) => sockets.push(s),
+  };
+}
+
+function createMockBus() {
+  return {
+    onBroadcast: vi.fn(),
+    offBroadcast: vi.fn(),
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    send: vi.fn(),
+    getHistory: vi.fn(),
+    request: vi.fn(),
+  };
+}
+
+function createMockCoo() {
+  return {
+    getCurrentConversationId: vi.fn(() => null),
+    resetConversation: vi.fn(),
+    startNewConversation: vi.fn(),
+    toData: vi.fn(() => ({ model: "test", provider: "test" })),
+    getTeamLeads: vi.fn(() => new Map()),
+    destroy: vi.fn(),
+  };
+}
+
+function createMockRegistry() {
+  return {
+    list: vi.fn(() => []),
+    get: vi.fn(() => null),
+  };
+}
+
+describe("SSH chat socket handlers", () => {
+  beforeEach(() => {
+    socketHandlers.clear();
+    mockHandleSshChat.mockReset();
+  });
+
+  afterEach(() => {
+    unregisterPtySession("ssh-sess-1");
+  });
+
+  function setupHandler() {
+    const mockSocket = createMockSocket();
+    const mockIo = createMockIo();
+    mockIo._addSocket(mockSocket);
+
+    setupSocketHandlers(
+      mockIo as any,
+      createMockBus() as any,
+      createMockCoo() as any,
+      createMockRegistry() as any,
+    );
+
+    return { mockIo };
+  }
+
+  it("handles ssh:chat by passing terminal buffer and emitting stream + response", async () => {
+    const { mockIo } = setupHandler();
+    const ptyClient = {
+      getReplayBuffer: vi.fn(() => "recent terminal output"),
+      writeInput: vi.fn(),
+      gracefulExit: vi.fn(),
+    };
+    registerPtySession("ssh-sess-1", ptyClient as any);
+
+    mockHandleSshChat.mockImplementation(async (_req, callbacks) => {
+      callbacks.onStream("token-a", "msg-1");
+      callbacks.onComplete("msg-1", "Disk is 40% free", "df -h");
+      return "msg-1";
+    });
+
+    const handler = socketHandlers.get("ssh:chat");
+    expect(handler).toBeDefined();
+
+    const callback = vi.fn();
+    await handler!({ sessionId: "sess-1", message: "show free disk" }, callback);
+
+    expect(mockHandleSshChat).toHaveBeenCalledWith(
+      {
+        sessionId: "sess-1",
+        message: "show free disk",
+        terminalBuffer: "recent terminal output",
+      },
+      expect.objectContaining({
+        onStream: expect.any(Function),
+        onComplete: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+    expect(mockIo.emit).toHaveBeenCalledWith("ssh:chat-stream", {
+      sessionId: "sess-1",
+      token: "token-a",
+      messageId: "msg-1",
+    });
+    expect(mockIo.emit).toHaveBeenCalledWith("ssh:chat-response", {
+      sessionId: "sess-1",
+      messageId: "msg-1",
+      content: "Disk is 40% free",
+      command: "df -h",
+    });
+    expect(callback).toHaveBeenCalledWith({ ok: true, messageId: "msg-1" });
+  });
+
+  it("returns error ack when ssh:chat throws", async () => {
+    setupHandler();
+    mockHandleSshChat.mockRejectedValue(new Error("upstream failed"));
+    const handler = socketHandlers.get("ssh:chat");
+    const callback = vi.fn();
+
+    await handler!({ sessionId: "sess-1", message: "hi" }, callback);
+
+    expect(callback).toHaveBeenCalledWith({ ok: false, error: "upstream failed" });
+  });
+
+  it("does not send success ack after onError callback", async () => {
+    setupHandler();
+    mockHandleSshChat.mockImplementation(async (_req, callbacks) => {
+      callbacks.onError("No LLM provider configured");
+      return "msg-err";
+    });
+    const handler = socketHandlers.get("ssh:chat");
+    const callback = vi.fn();
+
+    await handler!({ sessionId: "sess-1", message: "show disk" }, callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith({ ok: false, error: "No LLM provider configured" });
+  });
+
+  it("rejects ssh:chat-confirm when no active SSH session exists", async () => {
+    setupHandler();
+    const handler = socketHandlers.get("ssh:chat-confirm");
+    const callback = vi.fn();
+
+    await handler!({ sessionId: "sess-1", messageId: "m1", command: "df -h" }, callback);
+
+    expect(callback).toHaveBeenCalledWith({ ok: false, error: "No active SSH session" });
+  });
+
+  it("writes confirmed command to active PTY", async () => {
+    setupHandler();
+    const ptyClient = {
+      getReplayBuffer: vi.fn(() => ""),
+      writeInput: vi.fn(),
+      gracefulExit: vi.fn(),
+    };
+    registerPtySession("ssh-sess-1", ptyClient as any);
+    const handler = socketHandlers.get("ssh:chat-confirm");
+    const callback = vi.fn();
+
+    await handler!({ sessionId: "sess-1", messageId: "m1", command: "df -h" }, callback);
+
+    expect(ptyClient.writeInput).toHaveBeenCalledWith("df -h\n");
+    expect(callback).toHaveBeenCalledWith({ ok: true });
+  });
+});

--- a/packages/server/src/socket/handlers.ts
+++ b/packages/server/src/socket/handlers.ts
@@ -998,6 +998,7 @@ export function setupSocketHandlers(
         const ptyClient = activePtySessions.get(agentId);
         const terminalBuffer = ptyClient?.getReplayBuffer() ?? "";
 
+        let errored = false;
         const messageId = await handleSshChat(
           {
             sessionId: data.sessionId,
@@ -1012,12 +1013,15 @@ export function setupSocketHandlers(
               io.emit("ssh:chat-response", { sessionId: data.sessionId, messageId: msgId, content, command });
             },
             onError: (error) => {
+              errored = true;
               callback?.({ ok: false, error });
             },
           },
         );
 
-        callback?.({ ok: true, messageId });
+        if (!errored) {
+          callback?.({ ok: true, messageId });
+        }
       } catch (err) {
         callback?.({ ok: false, error: err instanceof Error ? err.message : "SSH chat failed" });
       }

--- a/packages/server/src/ssh/ssh-chat.ts
+++ b/packages/server/src/ssh/ssh-chat.ts
@@ -1,0 +1,143 @@
+/**
+ * SSH Chat — AI-assisted terminal interaction.
+ *
+ * Reads the current terminal buffer from an active SSH PTY session,
+ * sends the user's natural-language request + terminal context to an LLM,
+ * and streams the response back. The LLM may suggest a command to run
+ * in the terminal, which the user can confirm before execution.
+ */
+
+import { nanoid } from "nanoid";
+import { streamText, type CoreMessage } from "ai";
+import { resolveModel, type LLMConfig } from "../llm/adapter.js";
+import { getConfig } from "../auth/auth.js";
+import { stripAnsi } from "../utils/terminal.js";
+
+const SSH_CHAT_SYSTEM_PROMPT = `You are an AI assistant helping a user interact with a remote server via SSH terminal.
+
+You can see the recent terminal output and the user's request. Your job is to:
+1. Understand what the user wants to accomplish
+2. If a command needs to be run, include it in a <command> tag like: <command>df -h</command>
+3. Provide a brief, helpful explanation of what you're doing or what the output means
+
+Rules:
+- Only suggest ONE command at a time
+- Never suggest destructive commands (rm -rf /, mkfs, dd if=/dev/zero, etc.) without explicit confirmation context
+- For multi-step tasks, handle one step at a time
+- When interpreting command output, be concise and highlight the important parts
+- If the terminal shows an error, help diagnose it
+- If you don't need to run a command (e.g. the user just asked a question about existing output), just respond with your analysis`;
+
+/** Per-session conversation history */
+const sessionHistories = new Map<string, CoreMessage[]>();
+
+/** Max terminal context to include (characters) */
+const MAX_TERMINAL_CONTEXT = 4000;
+
+/** Extract a command from the LLM response */
+function extractCommand(text: string): string | undefined {
+  const match = text.match(/<command>([\s\S]*?)<\/command>/);
+  return match?.[1]?.trim();
+}
+
+/** Strip command tags from display text */
+function stripCommandTags(text: string): string {
+  return text.replace(/<command>[\s\S]*?<\/command>/g, "").trim();
+}
+
+/** Resolve LLM config for SSH chat (reuses COO tier settings) */
+function getChatLLMConfig(): LLMConfig {
+  const provider = getConfig("coo_provider") ?? "";
+  const model = getConfig("coo_model") ?? "claude-sonnet-4-5-20250929";
+  return { provider, model };
+}
+
+export interface SshChatRequest {
+  sessionId: string;
+  message: string;
+  terminalBuffer: string;
+}
+
+export interface SshChatCallbacks {
+  onStream: (token: string, messageId: string) => void;
+  onComplete: (messageId: string, content: string, command?: string) => void;
+  onError: (error: string) => void;
+}
+
+export async function handleSshChat(
+  req: SshChatRequest,
+  callbacks: SshChatCallbacks,
+): Promise<string> {
+  const messageId = nanoid();
+
+  try {
+    const llmConfig = getChatLLMConfig();
+    if (!llmConfig.provider) {
+      callbacks.onError("No LLM provider configured. Go to Settings to configure one.");
+      return messageId;
+    }
+
+    const model = resolveModel(llmConfig);
+
+    // Get or create session history
+    let history = sessionHistories.get(req.sessionId);
+    if (!history) {
+      history = [];
+      sessionHistories.set(req.sessionId, history);
+    }
+
+    // Prepare terminal context (strip ANSI, trim to last N chars)
+    const cleanBuffer = stripAnsi(req.terminalBuffer);
+    const terminalContext = cleanBuffer.length > MAX_TERMINAL_CONTEXT
+      ? cleanBuffer.slice(-MAX_TERMINAL_CONTEXT)
+      : cleanBuffer;
+
+    // Build the user message with terminal context
+    const userContent = terminalContext
+      ? `[Current terminal output (last ${terminalContext.length} chars)]\n\`\`\`\n${terminalContext}\n\`\`\`\n\nUser request: ${req.message}`
+      : `User request: ${req.message}`;
+
+    history.push({ role: "user", content: userContent });
+
+    // Keep history manageable (last 20 exchanges)
+    if (history.length > 40) {
+      history.splice(0, history.length - 40);
+    }
+
+    const messages: CoreMessage[] = [
+      { role: "system", content: SSH_CHAT_SYSTEM_PROMPT },
+      ...history,
+    ];
+
+    const result = streamText({
+      model,
+      messages,
+      maxTokens: 1024,
+    });
+
+    let fullContent = "";
+
+    for await (const chunk of result.textStream) {
+      fullContent += chunk;
+      callbacks.onStream(chunk, messageId);
+    }
+
+    // Extract command if present
+    const command = extractCommand(fullContent);
+    const displayContent = stripCommandTags(fullContent);
+
+    // Store assistant response in history
+    history.push({ role: "assistant", content: fullContent });
+
+    callbacks.onComplete(messageId, displayContent, command);
+    return messageId;
+  } catch (err) {
+    callbacks.onError(err instanceof Error ? err.message : "SSH chat failed");
+    return messageId;
+  }
+}
+
+/** Clear conversation history for a session */
+export function clearSshChatHistory(sessionId: string): void {
+  sessionHistories.delete(sessionId);
+}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -76,6 +76,8 @@ export interface ServerToClientEvents {
   "mcp:status": (runtime: McpServerRuntime) => void;
   "ssh:session-start": (data: { sessionId: string; keyId: string; host: string; username: string; agentId: string }) => void;
   "ssh:session-end": (data: { sessionId: string; agentId: string; status: SshSessionStatus }) => void;
+  "ssh:chat-stream": (data: { sessionId: string; token: string; messageId: string }) => void;
+  "ssh:chat-response": (data: { sessionId: string; messageId: string; content: string; command?: string }) => void;
 }
 
 /** Events emitted from client to server */
@@ -268,6 +270,14 @@ export interface ClientToServerEvents {
   ) => void;
   "ssh:disconnect": (
     data: { sessionId: string },
+    callback?: (ack: { ok: boolean; error?: string }) => void,
+  ) => void;
+  "ssh:chat": (
+    data: { sessionId: string; message: string },
+    callback?: (ack: { ok: boolean; messageId?: string; error?: string }) => void,
+  ) => void;
+  "ssh:chat-confirm": (
+    data: { sessionId: string; messageId: string; command: string },
     callback?: (ack: { ok: boolean; error?: string }) => void,
   ) => void;
 }

--- a/packages/web/src/components/ssh/SshChat.tsx
+++ b/packages/web/src/components/ssh/SshChat.tsx
@@ -1,0 +1,291 @@
+import { useState, useRef, useEffect, useCallback, type KeyboardEvent } from "react";
+import { getSocket } from "../../lib/socket";
+import { MarkdownContent } from "../chat/MarkdownContent";
+
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  command?: string;
+  timestamp: number;
+}
+
+interface SshChatProps {
+  sessionId: string;
+}
+
+export function SshChat({ sessionId }: SshChatProps) {
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [streamingContent, setStreamingContent] = useState("");
+  const [streamingMessageId, setStreamingMessageId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, streamingContent]);
+
+  useEffect(() => {
+    const socket = getSocket();
+
+    const handleStream = (data: { sessionId: string; token: string; messageId: string }) => {
+      if (data.sessionId !== sessionId) return;
+      setStreamingMessageId(data.messageId);
+      setStreamingContent((prev) => prev + data.token);
+    };
+
+    const handleResponse = (data: { sessionId: string; messageId: string; content: string; command?: string }) => {
+      if (data.sessionId !== sessionId) return;
+      setStreamingContent("");
+      setStreamingMessageId(null);
+      setIsLoading(false);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: data.messageId,
+          role: "assistant",
+          content: data.content,
+          command: data.command,
+          timestamp: Date.now(),
+        },
+      ]);
+    };
+
+    socket.on("ssh:chat-stream", handleStream);
+    socket.on("ssh:chat-response", handleResponse);
+
+    return () => {
+      socket.off("ssh:chat-stream", handleStream);
+      socket.off("ssh:chat-response", handleResponse);
+    };
+  }, [sessionId]);
+
+  // Clear messages when session changes
+  useEffect(() => {
+    setMessages([]);
+    setStreamingContent("");
+    setStreamingMessageId(null);
+    setIsLoading(false);
+  }, [sessionId]);
+
+  const sendMessage = useCallback(() => {
+    const content = input.trim();
+    if (!content || isLoading) return;
+
+    const socket = getSocket();
+
+    // Add user message
+    setMessages((prev) => [
+      ...prev,
+      { id: `user-${Date.now()}`, role: "user", content, timestamp: Date.now() },
+    ]);
+    setInput("");
+    setIsLoading(true);
+
+    socket.emit("ssh:chat", { sessionId, message: content }, (ack) => {
+      if (ack && !ack.ok) {
+        setIsLoading(false);
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `error-${Date.now()}`,
+            role: "assistant",
+            content: `Error: ${ack.error ?? "Failed to send message"}`,
+            timestamp: Date.now(),
+          },
+        ]);
+      }
+    });
+
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+  }, [input, isLoading, sessionId]);
+
+  const handleRunCommand = useCallback(
+    (messageId: string, command: string) => {
+      const socket = getSocket();
+      socket.emit("ssh:chat-confirm", { sessionId, messageId, command }, (ack) => {
+        if (ack && !ack.ok) {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `error-${Date.now()}`,
+              role: "assistant",
+              content: `Failed to run command: ${ack.error}`,
+              timestamp: Date.now(),
+            },
+          ]);
+        }
+      });
+      // Mark command as executed in the message
+      setMessages((prev) =>
+        prev.map((msg) =>
+          msg.id === messageId ? { ...msg, command: undefined } : msg,
+        ),
+      );
+    },
+    [sessionId],
+  );
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  };
+
+  const resizeTextarea = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = Math.min(el.scrollHeight, 120) + "px";
+  }, []);
+
+  return (
+    <div className="flex flex-col border-t border-border bg-card" style={{ height: "260px" }}>
+      {/* Chat header */}
+      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border">
+        <div className="flex items-center gap-1.5">
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-muted-foreground"
+          >
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+          </svg>
+          <span className="text-xs font-medium text-muted-foreground">Terminal Assistant</span>
+        </div>
+        {messages.length > 0 && (
+          <button
+            onClick={() => setMessages([])}
+            className="text-[10px] text-muted-foreground hover:text-foreground"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Messages area */}
+      <div className="flex-1 overflow-y-auto px-3 py-2 space-y-2 min-h-0">
+        {messages.length === 0 && !streamingContent && (
+          <div className="flex items-center justify-center h-full">
+            <p className="text-xs text-muted-foreground text-center max-w-[280px]">
+              Ask questions about the terminal or request commands to run. E.g. "Show me disk space" or "Check for errors in syslog"
+            </p>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            className={`max-w-[90%] ${msg.role === "user" ? "ml-auto" : "mr-auto"}`}
+          >
+            <div
+              className={`rounded-lg px-3 py-1.5 text-xs leading-relaxed ${
+                msg.role === "user"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-secondary text-secondary-foreground"
+              }`}
+            >
+              {msg.role === "user" ? (
+                msg.content
+              ) : (
+                <MarkdownContent content={msg.content} />
+              )}
+            </div>
+            {msg.command && (
+              <div className="mt-1 flex items-center gap-1.5">
+                <code className="text-[11px] bg-zinc-800 text-green-400 px-2 py-1 rounded font-mono">
+                  {msg.command}
+                </code>
+                <button
+                  onClick={() => handleRunCommand(msg.id, msg.command!)}
+                  className="text-[10px] px-2 py-0.5 bg-green-600 text-white rounded hover:bg-green-500 transition-colors"
+                >
+                  Run
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+
+        {/* Streaming indicator */}
+        {streamingContent && (
+          <div className="max-w-[90%] mr-auto">
+            <div className="bg-secondary text-secondary-foreground rounded-lg px-3 py-1.5 text-xs leading-relaxed">
+              <MarkdownContent content={streamingContent} />
+              <span className="inline-block w-1 h-3 bg-muted-foreground/50 ml-0.5 animate-pulse" />
+            </div>
+          </div>
+        )}
+
+        {/* Loading indicator (before streaming starts) */}
+        {isLoading && !streamingContent && (
+          <div className="max-w-[90%] mr-auto">
+            <div className="bg-secondary text-secondary-foreground rounded-lg px-3 py-1.5 text-xs">
+              <div className="flex items-center gap-1.5 text-muted-foreground">
+                <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                <span>Thinking...</span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input area */}
+      <div className="px-3 py-2 border-t border-border">
+        <div className="flex items-end gap-1.5 bg-secondary rounded-lg px-2.5 py-1.5">
+          <textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value);
+              resizeTextarea();
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about the terminal or request a command..."
+            rows={1}
+            className="flex-1 bg-transparent text-xs resize-none outline-none placeholder:text-muted-foreground max-h-[120px]"
+          />
+          <button
+            onClick={sendMessage}
+            disabled={!input.trim() || isLoading}
+            className={`shrink-0 w-6 h-6 rounded flex items-center justify-center transition-colors ${
+              input.trim() && !isLoading
+                ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                : "bg-muted text-muted-foreground"
+            }`}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="22" y1="2" x2="11" y2="13" />
+              <polygon points="22 2 15 22 11 13 2 9 22 2" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/ssh/SshView.tsx
+++ b/packages/web/src/components/ssh/SshView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSshStore } from "../../stores/ssh-store";
 import { TerminalView } from "../code/TerminalView";
+import { SshChat } from "./SshChat";
 import { getSocket } from "../../lib/socket";
 import type { SshKeyInfo, SshSessionStatus } from "@otterbot/shared";
 
@@ -156,23 +157,28 @@ export function SshView() {
               </div>
             </div>
 
-            {/* Terminal */}
-            <div className="flex-1 min-h-0 relative">
-              {agentId && (
-                <TerminalView
-                  agentId={agentId}
-                  readOnly={selectedSession.status !== "active"}
-                />
-              )}
-              {selectedSession.status !== "active" && (
-                <div className="absolute bottom-0 left-0 right-0 bg-zinc-900/90 border-t border-border px-4 py-2 text-center">
-                  <span className="text-xs text-muted-foreground">
-                    Session ended
-                    {selectedSession.completedAt && (
-                      <> &middot; {new Date(selectedSession.completedAt).toLocaleString()}</>
-                    )}
-                  </span>
-                </div>
+            {/* Terminal + Chat */}
+            <div className="flex-1 min-h-0 flex flex-col">
+              <div className="flex-1 min-h-0 relative">
+                {agentId && (
+                  <TerminalView
+                    agentId={agentId}
+                    readOnly={selectedSession.status !== "active"}
+                  />
+                )}
+                {selectedSession.status !== "active" && (
+                  <div className="absolute bottom-0 left-0 right-0 bg-zinc-900/90 border-t border-border px-4 py-2 text-center">
+                    <span className="text-xs text-muted-foreground">
+                      Session ended
+                      {selectedSession.completedAt && (
+                        <> &middot; {new Date(selectedSession.completedAt).toLocaleString()}</>
+                      )}
+                    </span>
+                  </div>
+                )}
+              </div>
+              {selectedSession.status === "active" && (
+                <SshChat sessionId={selectedSession.id} />
               )}
             </div>
           </>


### PR DESCRIPTION
## Summary
- Adds an AI-powered chat panel below the SSH terminal that lets users ask questions about terminal output and request commands in natural language
- LLM reads the terminal buffer, streams a response, and can suggest commands which the user confirms before execution via a "Run" button
- Includes server-side `ssh-chat.ts` module with streaming LLM integration, conversation history, and command extraction from `<command>` tags
- Fixes a double-callback bug in the `ssh:chat` socket handler where both `onError` and the success ack could fire

Closes #295

## Test plan
- [x] All 982 existing tests pass
- [x] New `ssh-chat-socket.test.ts` covers: stream + response flow, error ack on throw, no double callback on `onError`, confirm rejects without active session, confirm writes command to PTY
- [ ] Manual: open SSH session, type a question in the chat box, verify streaming response appears
- [ ] Manual: verify suggested commands show "Run" button and execute in PTY on confirm
- [ ] Manual: verify chat clears when session ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)