### PR TITLE
fix: make SSH chat window resizable with drag handle

### DIFF
--- a/packages/web/src/components/ssh/SshChat.test.tsx
+++ b/packages/web/src/components/ssh/SshChat.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SshChat } from "./SshChat";
+
+vi.mock("../../lib/socket", () => ({
+  getSocket: () => ({ on: vi.fn(), off: vi.fn(), emit: vi.fn() }),
+}));
+
+vi.mock("../chat/MarkdownContent", () => ({
+  MarkdownContent: ({ content }: { content: string }) => <span>{content}</span>,
+}));
+
+describe("SshChat layout", () => {
+  it("uses full-height container instead of fixed inline height", () => {
+    const html = renderToStaticMarkup(<SshChat sessionId="session-1" />);
+
+    expect(html).toContain('class="flex flex-col border-t border-border bg-card h-full"');
+    expect(html).not.toContain('style="height:260px"');
+  });
+});

--- a/packages/web/src/components/ssh/SshChat.tsx
+++ b/packages/web/src/components/ssh/SshChat.tsx
@@ -156,7 +156,7 @@ export function SshChat({ sessionId }: SshChatProps) {
   }, []);
 
   return (
-    <div className="flex flex-col border-t border-border bg-card" style={{ height: "260px" }}>
+    <div className="flex flex-col border-t border-border bg-card h-full">
       {/* Chat header */}
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border">
         <div className="flex items-center gap-1.5">

--- a/packages/web/src/components/ssh/SshView.test.tsx
+++ b/packages/web/src/components/ssh/SshView.test.tsx
@@ -55,8 +55,8 @@ vi.mock("react-resizable-panels", () => ({
   ),
 }));
 
-function makeStore(status: "active" | "completed") {
-  const completedAt = status === "completed" ? "2026-02-26T12:30:00.000Z" : undefined;
+function makeStore(status: "active" | "completed" | "error") {
+  const completedAt = status !== "active" ? "2026-02-26T12:30:00.000Z" : undefined;
 
   return {
     sessions: [
@@ -115,5 +115,16 @@ describe("SshView resize layout", () => {
     expect(html).not.toContain('data-testid="ssh-chat"');
     expect(html).toContain('data-testid="terminal-view" data-agent-id="ssh-session-1" data-read-only="true"');
     expect(html).toContain("Session ended");
+  });
+
+  it("keeps only the terminal panel for error sessions", () => {
+    useSshStoreMock.mockReturnValue(makeStore("error"));
+
+    const html = renderToStaticMarkup(<SshView />);
+
+    expect(html).toContain('data-testid="panel" data-min-size="20" data-default-size="100"');
+    expect(html).not.toContain('data-testid="separator"');
+    expect(html).not.toContain('data-testid="ssh-chat"');
+    expect(html).toContain('data-testid="terminal-view" data-agent-id="ssh-session-1" data-read-only="true"');
   });
 });

--- a/packages/web/src/components/ssh/SshView.test.tsx
+++ b/packages/web/src/components/ssh/SshView.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ReactNode } from "react";
+import { SshView } from "./SshView";
+
+const useSshStoreMock = vi.fn();
+
+vi.mock("../../stores/ssh-store", () => ({
+  useSshStore: () => useSshStoreMock(),
+}));
+
+vi.mock("../../lib/socket", () => ({
+  getSocket: () => ({ on: vi.fn(), off: vi.fn() }),
+}));
+
+vi.mock("../code/TerminalView", () => ({
+  TerminalView: ({ agentId, readOnly }: { agentId: string; readOnly: boolean }) => (
+    <div data-testid="terminal-view" data-agent-id={agentId} data-read-only={String(readOnly)} />
+  ),
+}));
+
+vi.mock("./SshChat", () => ({
+  SshChat: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="ssh-chat" data-session-id={sessionId} />
+  ),
+}));
+
+vi.mock("react-resizable-panels", () => ({
+  Group: ({ direction, autoSaveId, className, children }: {
+    direction: string;
+    autoSaveId: string;
+    className?: string;
+    children: ReactNode;
+  }) => (
+    <div
+      data-testid="panel-group"
+      data-direction={direction}
+      data-autosave-id={autoSaveId}
+      className={className}
+    >
+      {children}
+    </div>
+  ),
+  Panel: ({ minSize, defaultSize, children }: {
+    minSize: number;
+    defaultSize: number;
+    children: ReactNode;
+  }) => (
+    <div data-testid="panel" data-min-size={String(minSize)} data-default-size={String(defaultSize)}>
+      {children}
+    </div>
+  ),
+  Separator: ({ className }: { className?: string }) => (
+    <div data-testid="separator" className={className} />
+  ),
+}));
+
+function makeStore(status: "active" | "completed") {
+  const completedAt = status === "completed" ? "2026-02-26T12:30:00.000Z" : undefined;
+
+  return {
+    sessions: [
+      {
+        id: "session-1",
+        keyId: "key-1",
+        host: "example.com",
+        username: "ubuntu",
+        startedAt: "2026-02-26T12:00:00.000Z",
+        completedAt,
+        status,
+      },
+    ],
+    selectedSessionId: "session-1",
+    sshKeys: [],
+    loadSessions: vi.fn(),
+    loadKeys: vi.fn(),
+    selectSession: vi.fn(),
+    deleteSession: vi.fn(),
+    connectToHost: vi.fn(),
+    disconnectSession: vi.fn(),
+    handleSessionStart: vi.fn(),
+    handleSessionEnd: vi.fn(),
+  };
+}
+
+describe("SshView resize layout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders resizable terminal/chat panels with a separator for active sessions", () => {
+    useSshStoreMock.mockReturnValue(makeStore("active"));
+
+    const html = renderToStaticMarkup(<SshView />);
+
+    expect(html).toContain('data-testid="panel-group"');
+    expect(html).toContain('data-direction="vertical"');
+    expect(html).toContain('data-autosave-id="ssh-terminal-chat"');
+
+    expect(html).toContain('data-testid="panel" data-min-size="20" data-default-size="65"');
+    expect(html).toContain('data-testid="separator" class="panel-resize-handle-horizontal"');
+    expect(html).toContain('data-testid="panel" data-min-size="15" data-default-size="35"');
+
+    expect(html).toContain('data-testid="ssh-chat" data-session-id="session-1"');
+    expect(html).toContain('data-testid="terminal-view" data-agent-id="ssh-session-1" data-read-only="false"');
+  });
+
+  it("hides chat panel and uses full terminal panel for completed sessions", () => {
+    useSshStoreMock.mockReturnValue(makeStore("completed"));
+
+    const html = renderToStaticMarkup(<SshView />);
+
+    expect(html).toContain('data-testid="panel" data-min-size="20" data-default-size="100"');
+    expect(html).not.toContain('data-testid="separator"');
+    expect(html).not.toContain('data-testid="ssh-chat"');
+    expect(html).toContain('data-testid="terminal-view" data-agent-id="ssh-session-1" data-read-only="true"');
+    expect(html).toContain("Session ended");
+  });
+});

--- a/packages/web/src/components/ssh/SshView.tsx
+++ b/packages/web/src/components/ssh/SshView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Group, Panel, Separator } from "react-resizable-panels";
 import { useSshStore } from "../../stores/ssh-store";
 import { TerminalView } from "../code/TerminalView";
 import { SshChat } from "./SshChat";
@@ -158,29 +159,36 @@ export function SshView() {
             </div>
 
             {/* Terminal + Chat */}
-            <div className="flex-1 min-h-0 flex flex-col">
-              <div className="flex-1 min-h-0 relative">
-                {agentId && (
-                  <TerminalView
-                    agentId={agentId}
-                    readOnly={selectedSession.status !== "active"}
-                  />
-                )}
-                {selectedSession.status !== "active" && (
-                  <div className="absolute bottom-0 left-0 right-0 bg-zinc-900/90 border-t border-border px-4 py-2 text-center">
-                    <span className="text-xs text-muted-foreground">
-                      Session ended
-                      {selectedSession.completedAt && (
-                        <> &middot; {new Date(selectedSession.completedAt).toLocaleString()}</>
-                      )}
-                    </span>
-                  </div>
-                )}
-              </div>
+            <Group direction="vertical" className="flex-1 min-h-0" autoSaveId="ssh-terminal-chat">
+              <Panel minSize={20} defaultSize={selectedSession.status === "active" ? 65 : 100}>
+                <div className="h-full relative">
+                  {agentId && (
+                    <TerminalView
+                      agentId={agentId}
+                      readOnly={selectedSession.status !== "active"}
+                    />
+                  )}
+                  {selectedSession.status !== "active" && (
+                    <div className="absolute bottom-0 left-0 right-0 bg-zinc-900/90 border-t border-border px-4 py-2 text-center">
+                      <span className="text-xs text-muted-foreground">
+                        Session ended
+                        {selectedSession.completedAt && (
+                          <> &middot; {new Date(selectedSession.completedAt).toLocaleString()}</>
+                        )}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </Panel>
               {selectedSession.status === "active" && (
-                <SshChat sessionId={selectedSession.id} />
+                <>
+                  <Separator className="panel-resize-handle-horizontal" />
+                  <Panel minSize={15} defaultSize={35}>
+                    <SshChat sessionId={selectedSession.id} />
+                  </Panel>
+                </>
               )}
-            </div>
+            </Group>
           </>
         ) : (
           <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground">

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -131,6 +131,30 @@
   cursor: col-resize;
 }
 
+/* Horizontal resize handle (for vertical panel groups) */
+.panel-resize-handle-horizontal {
+  height: 1px;
+  background: hsl(var(--border));
+  transition: background 150ms, height 150ms;
+  position: relative;
+}
+
+.panel-resize-handle-horizontal::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -3px;
+  bottom: -3px;
+}
+
+.panel-resize-handle-horizontal[data-separator="hover"],
+.panel-resize-handle-horizontal[data-separator="active"] {
+  height: 3px;
+  background: hsl(var(--primary));
+  cursor: row-resize;
+}
+
 /* Prose overrides for chat bubbles — tighten spacing */
 .prose {
   font-size: inherit;


### PR DESCRIPTION
## Summary
- Replaces the fixed 260px height on the SSH chat panel with a resizable `react-resizable-panels` layout
- Terminal panel defaults to 65% and chat to 35%, with a draggable horizontal separator
- Layout preference is persisted to localStorage via `autoSaveId`
- When the session is completed, the chat panel hides and the terminal takes 100%

Closes #300

## Test plan
- [x] New test verifies resizable panel structure for active sessions
- [x] New test verifies full-terminal layout for completed sessions
- [x] New test verifies SshChat uses `h-full` instead of fixed height
- [x] All 995 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)