### PR TITLE
fix: unify project branch resolution to prevent PRs targeting wrong branch

### DIFF
--- a/packages/server/src/agents/coo.ts
+++ b/packages/server/src/agents/coo.ts
@@ -53,6 +53,7 @@ import { getConfiguredSearchProvider } from "../tools/search/providers.js";
 import { getRandomModelPackId } from "../models3d/model-packs.js";
 import { pickWorkerName } from "../utils/worker-names.js";
 import { isDesktopEnabled } from "../desktop/desktop.js";
+import { resolveProjectBranch } from "../github/github-service.js";
 import { execSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 
@@ -1850,12 +1851,12 @@ The user can see everything on the desktop in real-time.`;
 
     // Include GitHub context if available
     const ghRepo = getConfig(`project:${project.id}:github:repo`);
-    const ghBranch = getConfig(`project:${project.id}:github:branch`) ?? project.githubBranch;
+    const ghBranch = resolveProjectBranch(project.id);
     const ghRulesRaw = getConfig(`project:${project.id}:github:rules`);
     if (ghRepo) {
       lines.push(`GITHUB REPO: ${ghRepo}`);
-      lines.push(`TARGET BRANCH: ${ghBranch ?? "main"}`);
-      lines.push(`PR WORKFLOW: Workers must create feature branches from \`${ghBranch ?? "main"}\`, commit, push, and open a PR targeting \`${ghBranch ?? "main"}\`.`);
+      lines.push(`TARGET BRANCH: ${ghBranch}`);
+      lines.push(`PR WORKFLOW: Workers must create feature branches from \`${ghBranch}\`, commit, push, and open a PR targeting \`${ghBranch}\`.`);
       if (ghRulesRaw) {
         try {
           const rules = JSON.parse(ghRulesRaw) as string[];

--- a/packages/server/src/merge-queue/__tests__/merge-queue.test.ts
+++ b/packages/server/src/merge-queue/__tests__/merge-queue.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../github/github-service.js", () => ({
   fetchPullRequest: (...args: unknown[]) => mockFetchPullRequest(...args),
   mergePullRequest: (...args: unknown[]) => mockMergePullRequest(...args),
   createIssueComment: (...args: unknown[]) => mockCreateIssueComment(...args),
+  resolveProjectBranch: vi.fn(() => "main"),
   gitEnvWithPAT: vi.fn(() => ({})),
   gitCredentialArgs: vi.fn(() => []),
 }));

--- a/packages/server/src/merge-queue/merge-queue.ts
+++ b/packages/server/src/merge-queue/merge-queue.ts
@@ -10,6 +10,7 @@ import type {
 } from "@otterbot/shared";
 import { getDb, schema } from "../db/index.js";
 import { getConfig } from "../auth/auth.js";
+import { resolveProjectBranch } from "../github/github-service.js";
 import {
   fetchPullRequest,
   mergePullRequest,
@@ -81,10 +82,7 @@ export class MergeQueue implements Scheduler {
     if (existing) return existing as unknown as MergeQueueEntry;
 
     // Get project info for base branch
-    const project = db.select().from(schema.projects).where(eq(schema.projects.id, task.projectId)).get();
-    const baseBranch = project?.githubBranch
-      ?? getConfig(`project:${task.projectId}:github:branch`)
-      ?? "main";
+    const baseBranch = resolveProjectBranch(task.projectId);
 
     // Determine position (append to end)
     const allEntries = db.select().from(schema.mergeQueue).all();

--- a/packages/server/src/pipeline/__tests__/pipeline-manager.test.ts
+++ b/packages/server/src/pipeline/__tests__/pipeline-manager.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../github/github-service.js", () => ({
   addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
   fetchCompareCommitsDiff: vi.fn().mockResolvedValue([]),
   fetchPullRequests: vi.fn().mockResolvedValue([]),
+  resolveProjectBranch: vi.fn(() => "main"),
 }));
 
 vi.mock("../../settings/settings.js", () => ({

--- a/packages/server/src/pipeline/pipeline-manager.ts
+++ b/packages/server/src/pipeline/pipeline-manager.ts
@@ -21,7 +21,7 @@ import {
   fetchPullRequests,
 } from "../github/github-service.js";
 import type { COO } from "../agents/coo.js";
-import type { GitHubIssue } from "../github/github-service.js";
+import { resolveProjectBranch, type GitHubIssue } from "../github/github-service.js";
 import { SECURITY_PREAMBLE } from "../agents/prompts/security-preamble.js";
 import { cleanTerminalOutput } from "../utils/terminal.js";
 import { formatBotComment, formatBotCommentWithDetails } from "../utils/github-comments.js";
@@ -222,7 +222,7 @@ export class PipelineManager {
         stageReports: new Map(Object.entries((task.stageReports as Record<string, string>) ?? {})),
         prBranch: task.prBranch ?? null,
         prNumber: task.prNumber ?? null,
-        targetBranch: project?.githubBranch ?? getConfig(`project:${task.projectId}:github:branch`) ?? "main",
+        targetBranch: resolveProjectBranch(task.projectId),
       };
 
       this.pipelines.set(task.id, state);
@@ -278,7 +278,7 @@ export class PipelineManager {
       stageReports: new Map(Object.entries((task.stageReports as Record<string, string>) ?? {})),
       prBranch: task.prBranch ?? null,
       prNumber: task.prNumber ?? null,
-      targetBranch: project?.githubBranch ?? getConfig(`project:${task.projectId}:github:branch`) ?? "main",
+      targetBranch: resolveProjectBranch(task.projectId),
     };
 
     this.pipelines.set(taskId, state);
@@ -534,7 +534,7 @@ export class PipelineManager {
       stageReports: new Map(),
       prBranch: null,
       prNumber: null,
-      targetBranch: project?.githubBranch ?? getConfig(`project:${projectId}:github:branch`) ?? "main",
+      targetBranch: resolveProjectBranch(projectId),
     };
     this.pipelines.set(taskId, state);
 
@@ -966,7 +966,7 @@ export class PipelineManager {
       stageReports: new Map(),
       prBranch: branchName,
       prNumber: task.prNumber ?? null,
-      targetBranch: project?.githubBranch ?? getConfig(`project:${task.projectId}:github:branch`) ?? "main",
+      targetBranch: resolveProjectBranch(task.projectId),
     };
 
     // Store review feedback context
@@ -1050,7 +1050,7 @@ export class PipelineManager {
       stageReports: new Map(),
       prBranch: branchName,
       prNumber: task.prNumber ?? null,
-      targetBranch: project?.githubBranch ?? getConfig(`project:${task.projectId}:github:branch`) ?? "main",
+      targetBranch: resolveProjectBranch(task.projectId),
     };
 
     // Store CI failure context
@@ -1143,7 +1143,7 @@ export class PipelineManager {
       stageReports: new Map(),
       prBranch: branchName,
       prNumber: task.prNumber ?? null,
-      targetBranch: project?.githubBranch ?? getConfig(`project:${task.projectId}:github:branch`) ?? "main",
+      targetBranch: resolveProjectBranch(task.projectId),
       isReReview: true,
     };
 


### PR DESCRIPTION
## Summary

- Extracts a shared `resolveProjectBranch()` helper in `github-service.ts` that consistently resolves the target branch: runtime config → DB → `"main"`
- Fixes worker branch resolution missing the DB fallback (was config-only, causing workers to default to `main` when branch is only stored in DB)
- Removes the LLM-controllable `base` parameter from the PR creation tool, preventing the LLM from overriding the configured branch with `"main"`
- Normalizes branch lookup order across all code paths (TeamLead, Worker, COO, PipelineManager, MergeQueue)

Closes #301

## Test plan
- [x] All 996 existing tests pass
- [x] PR tool no longer accepts `base` as an LLM-controllable parameter
- [x] Worker system prompts use the same resolution logic as TeamLead (config + DB fallback)
- [x] Test mocks updated for merge-queue and pipeline-manager