### PR TITLE
fix: provider deletion now shows errors and requires confirmation

### DIFF
--- a/packages/server/src/settings/__tests__/providers-delete.test.ts
+++ b/packages/server/src/settings/__tests__/providers-delete.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const configStore = new Map<string, string>();
+
+  const customModelsTable = { providerId: Symbol("customModels.providerId") };
+  const providersTable = { id: Symbol("providers.id") };
+
+  const runCustomModelsDelete = vi.fn();
+  const runProvidersDelete = vi.fn();
+
+  const whereCustomModelsDelete = vi.fn(() => ({ run: runCustomModelsDelete }));
+  const whereProvidersDelete = vi.fn(() => ({ run: runProvidersDelete }));
+
+  const dbDelete = vi.fn((table: unknown) => {
+    if (table === customModelsTable) {
+      return { where: whereCustomModelsDelete };
+    }
+    if (table === providersTable) {
+      return { where: whereProvidersDelete };
+    }
+    throw new Error("Unexpected table passed to db.delete");
+  });
+
+  return {
+    configStore,
+    customModelsTable,
+    providersTable,
+    runCustomModelsDelete,
+    runProvidersDelete,
+    whereCustomModelsDelete,
+    whereProvidersDelete,
+    dbDelete,
+    eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+  };
+});
+
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn((key: string) => mocks.configStore.get(key)),
+  setConfig: vi.fn(),
+  deleteConfig: vi.fn(),
+}));
+
+vi.mock("../../db/index.js", () => ({
+  getDb: vi.fn(() => ({
+    delete: mocks.dbDelete,
+  })),
+  schema: {
+    providers: mocks.providersTable,
+    customModels: mocks.customModelsTable,
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: mocks.eq,
+}));
+
+vi.mock("../../llm/adapter.js", () => ({
+  resolveModel: vi.fn(),
+}));
+
+vi.mock("../../tools/search/providers.js", () => ({
+  getConfiguredSearchProvider: vi.fn(() => null),
+}));
+
+vi.mock("../../tts/tts.js", () => ({
+  getConfiguredTTSProvider: vi.fn(() => null),
+}));
+
+vi.mock("../../stt/stt.js", () => ({
+  getConfiguredSTTProvider: vi.fn(() => null),
+}));
+
+vi.mock("../../tools/opencode-client.js", () => ({
+  OpenCodeClient: vi.fn(),
+}));
+
+vi.mock("../../opencode/opencode-manager.js", () => ({
+  ensureOpenCodeConfig: vi.fn(),
+  writeOpenCodeConfig: vi.fn(),
+}));
+
+vi.mock("../../coding-agents/claude-code-manager.js", () => ({
+  isClaudeCodeInstalled: vi.fn(() => false),
+  isClaudeCodeReady: vi.fn(() => false),
+}));
+
+vi.mock("../../coding-agents/codex-manager.js", () => ({
+  isCodexInstalled: vi.fn(() => false),
+  isCodexReady: vi.fn(() => false),
+}));
+
+vi.mock("nanoid", () => ({
+  nanoid: vi.fn(() => "test-id"),
+}));
+
+import { deleteProvider } from "../settings.js";
+
+describe("deleteProvider", () => {
+  beforeEach(() => {
+    mocks.configStore.clear();
+    mocks.runCustomModelsDelete.mockClear();
+    mocks.runProvidersDelete.mockClear();
+    mocks.whereCustomModelsDelete.mockClear();
+    mocks.whereProvidersDelete.mockClear();
+    mocks.dbDelete.mockClear();
+    mocks.eq.mockClear();
+  });
+
+  it("returns an error and does not delete when provider is in use as default", () => {
+    mocks.configStore.set("coo_provider", "provider-1");
+
+    const result = deleteProvider("provider-1");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Provider is in use as a tier default");
+    expect(mocks.dbDelete).not.toHaveBeenCalled();
+  });
+
+  it("deletes referencing custom models before deleting provider", () => {
+    const result = deleteProvider("provider-2");
+
+    expect(result).toEqual({ ok: true });
+    expect(mocks.dbDelete).toHaveBeenCalledTimes(2);
+    expect(mocks.dbDelete).toHaveBeenNthCalledWith(1, mocks.customModelsTable);
+    expect(mocks.dbDelete).toHaveBeenNthCalledWith(2, mocks.providersTable);
+
+    expect(mocks.eq).toHaveBeenNthCalledWith(1, mocks.customModelsTable.providerId, "provider-2");
+    expect(mocks.eq).toHaveBeenNthCalledWith(2, mocks.providersTable.id, "provider-2");
+
+    expect(mocks.runCustomModelsDelete).toHaveBeenCalledTimes(1);
+    expect(mocks.runProvidersDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -268,6 +268,8 @@ export function deleteProvider(id: string): { ok: boolean; error?: string } {
     }
   }
   const db = getDb();
+  // Remove custom models that reference this provider
+  db.delete(schema.customModels).where(eq(schema.customModels.providerId, id)).run();
   db.delete(schema.providers).where(eq(schema.providers.id, id)).run();
   return { ok: true };
 }

--- a/packages/web/src/components/settings/ProvidersTab.tsx
+++ b/packages/web/src/components/settings/ProvidersTab.tsx
@@ -180,6 +180,8 @@ function ProviderCard({ provider }: { provider: NamedProvider }) {
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState(provider.baseUrl ?? "");
   const [saving, setSaving] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   const updateProvider = useSettingsStore((s) => s.updateProvider);
   const deleteProviderFn = useSettingsStore((s) => s.deleteProvider);
@@ -207,9 +209,11 @@ function ProviderCard({ provider }: { provider: NamedProvider }) {
   };
 
   const handleDelete = async () => {
+    setDeleteError(null);
     const result = await deleteProviderFn(provider.id);
     if (!result.ok) {
-      // Error is set in the store
+      setDeleteError(result.error || "Failed to delete provider");
+      setConfirmingDelete(false);
     }
   };
 
@@ -315,12 +319,29 @@ function ProviderCard({ provider }: { provider: NamedProvider }) {
             >
               {testResult?.testing ? "Testing..." : "Test"}
             </button>
-            <button
-              onClick={handleDelete}
-              className="text-xs bg-secondary text-red-400 px-3 py-1.5 rounded-md hover:bg-red-500/20"
-            >
-              Delete
-            </button>
+            {!confirmingDelete ? (
+              <button
+                onClick={() => { setDeleteError(null); setConfirmingDelete(true); }}
+                className="text-xs bg-secondary text-red-400 px-3 py-1.5 rounded-md hover:bg-red-500/20"
+              >
+                Delete
+              </button>
+            ) : (
+              <>
+                <button
+                  onClick={handleDelete}
+                  className="text-xs bg-red-600 text-white px-3 py-1.5 rounded-md hover:bg-red-700"
+                >
+                  Confirm Delete
+                </button>
+                <button
+                  onClick={() => setConfirmingDelete(false)}
+                  className="text-xs bg-secondary text-foreground px-3 py-1.5 rounded-md hover:bg-secondary/80"
+                >
+                  Cancel
+                </button>
+              </>
+            )}
 
             {testResult && !testResult.testing && (
               <span
@@ -335,6 +356,10 @@ function ProviderCard({ provider }: { provider: NamedProvider }) {
               </span>
             )}
           </div>
+
+          {deleteError && (
+            <p className="text-xs text-red-500">{deleteError}</p>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Fix provider deletion failing silently by deleting referencing custom models before the provider row
- Add a two-click confirmation flow (Delete → Confirm Delete / Cancel) to prevent accidental deletions
- Display error messages when deletion fails (e.g., provider is in use as a tier default)

Closes #311

## Test plan
- [x] All 998 existing tests pass
- [x] New `providers-delete.test.ts` covers cascade delete ordering and in-use guard
- [ ] Manual: create a provider, expand it, click Delete → Confirm Delete → provider is removed
- [ ] Manual: set a provider as a tier default, try to delete it → error message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>