### PR TITLE
feat: add module agents — subordinate AI agents for modules

### DIFF
--- a/packages/server/src/agents/module-agent.ts
+++ b/packages/server/src/agents/module-agent.ts
@@ -1,0 +1,193 @@
+import { tool } from "ai";
+import { z } from "zod";
+import {
+  AgentRole,
+  AgentStatus,
+  MessageType,
+  type BusMessage,
+  type ModuleAgentConfig,
+  type ModuleToolDefinition,
+  type ModuleContext,
+} from "@otterbot/shared";
+import { BaseAgent, type AgentOptions } from "./agent.js";
+import type { MessageBus } from "../bus/message-bus.js";
+import type { ModuleKnowledgeStore } from "../modules/module-knowledge-store.js";
+import { getConfig } from "../auth/auth.js";
+
+export interface ModuleAgentDeps {
+  moduleId: string;
+  agentConfig: ModuleAgentConfig;
+  knowledgeStore: ModuleKnowledgeStore;
+  moduleContext: ModuleContext;
+  moduleTools?: ModuleToolDefinition[];
+  bus: MessageBus;
+  onStatusChange?: (agentId: string, status: AgentStatus) => void;
+  onStream?: (agentId: string, token: string, messageId: string) => void;
+  onThinking?: (agentId: string, token: string, messageId: string) => void;
+  onThinkingEnd?: (agentId: string, messageId: string) => void;
+}
+
+export class ModuleAgent extends BaseAgent {
+  readonly moduleId: string;
+  private knowledgeStore: ModuleKnowledgeStore;
+  private moduleContext: ModuleContext;
+  private moduleToolDefs: ModuleToolDefinition[];
+  private onStream?: (agentId: string, token: string, messageId: string) => void;
+  private onThinking?: (agentId: string, token: string, messageId: string) => void;
+  private onThinkingEnd?: (agentId: string, messageId: string) => void;
+
+  constructor(deps: ModuleAgentDeps) {
+    const moduleId = deps.moduleId;
+
+    // Read config overrides, falling back to module defaults
+    const agentName = getConfig(`module:${moduleId}:agent_name`) ?? deps.agentConfig.defaultName;
+    const systemPrompt = getConfig(`module:${moduleId}:agent_prompt`) ?? deps.agentConfig.defaultPrompt;
+    const model = getConfig(`module:${moduleId}:agent_model`)
+      ?? deps.agentConfig.defaultModel
+      ?? getConfig("worker_model")
+      ?? getConfig("coo_model")
+      ?? "claude-sonnet-4-5-20250929";
+    const provider = getConfig(`module:${moduleId}:agent_provider`)
+      ?? deps.agentConfig.defaultProvider
+      ?? getConfig("worker_provider")
+      ?? getConfig("coo_provider")
+      ?? "anthropic";
+
+    const options: AgentOptions = {
+      id: `module-agent-${moduleId}`,
+      name: agentName,
+      role: AgentRole.ModuleAgent,
+      parentId: "coo",
+      projectId: null,
+      model,
+      provider,
+      systemPrompt,
+      onStatusChange: deps.onStatusChange,
+    };
+
+    super(options, deps.bus);
+    this.llmConfig.maxSteps = 8;
+    this.moduleId = moduleId;
+    this.knowledgeStore = deps.knowledgeStore;
+    this.moduleContext = deps.moduleContext;
+    this.moduleToolDefs = deps.moduleTools ?? [];
+    this.onStream = deps.onStream;
+    this.onThinking = deps.onThinking;
+    this.onThinkingEnd = deps.onThinkingEnd;
+  }
+
+  protected getTools(): Record<string, unknown> {
+    const tools: Record<string, unknown> = {};
+
+    // knowledge_search — searches this module's knowledge store
+    tools.knowledge_search = tool({
+      description:
+        "Search this module's knowledge store for relevant documents. " +
+        "Uses hybrid full-text + vector search for best results.",
+      parameters: z.object({
+        query: z.string().describe("The search query"),
+        limit: z.number().optional().describe("Max results to return (default 10)"),
+      }),
+      execute: async ({ query, limit }) => {
+        const results = await this.knowledgeStore.search(query, limit ?? 10);
+        if (results.length === 0) {
+          return "No results found.";
+        }
+        return results
+          .map((doc) => {
+            const meta = doc.metadata;
+            const url = meta?.url ? ` (${meta.url})` : "";
+            return `---\n${doc.content}${url}\n`;
+          })
+          .join("\n");
+      },
+    });
+
+    // Expose any custom tools the module defines
+    for (const moduleTool of this.moduleToolDefs) {
+      const shape: Record<string, z.ZodTypeAny> = {};
+      const params = moduleTool.parameters as Record<string, { type?: string; description?: string; required?: boolean }>;
+      for (const [key, param] of Object.entries(params)) {
+        let fieldSchema: z.ZodTypeAny;
+        const desc = param.description ?? "";
+        switch (param.type) {
+          case "number":
+            fieldSchema = z.number().describe(desc);
+            break;
+          case "boolean":
+            fieldSchema = z.boolean().describe(desc);
+            break;
+          default:
+            fieldSchema = z.string().describe(desc);
+        }
+        shape[key] = param.required ? fieldSchema : fieldSchema.optional();
+      }
+
+      tools[moduleTool.name] = tool({
+        description: moduleTool.description,
+        parameters: z.object(shape),
+        execute: async (args: Record<string, unknown>) => {
+          return moduleTool.execute(args, this.moduleContext);
+        },
+      });
+    }
+
+    return tools;
+  }
+
+  async handleMessage(message: BusMessage): Promise<void> {
+    if (message.type === MessageType.Directive) {
+      await this.handleDirective(message);
+    } else if (message.type === MessageType.Chat) {
+      // Also handle chat messages (from scheduled tasks or direct queries)
+      await this.handleDirective(message);
+    }
+  }
+
+  private async handleDirective(message: BusMessage) {
+    const { text, thinking } = await this.think(
+      message.content,
+      (token, messageId) => {
+        this.onStream?.(this.id, token, messageId);
+      },
+      (token, messageId) => {
+        this.onThinking?.(this.id, token, messageId);
+      },
+      (messageId) => {
+        this.onThinkingEnd?.(this.id, messageId);
+      },
+    );
+
+    // If has correlationId, reply with it so request() resolves
+    if (message.correlationId && message.fromAgentId) {
+      this.sendMessage(
+        message.fromAgentId,
+        MessageType.Report,
+        text,
+        thinking ? { thinking, moduleId: this.moduleId } : { moduleId: this.moduleId },
+        undefined,
+        message.correlationId,
+      );
+    } else if (message.fromAgentId) {
+      this.sendMessage(
+        message.fromAgentId,
+        MessageType.Report,
+        text,
+        thinking ? { thinking, moduleId: this.moduleId } : { moduleId: this.moduleId },
+      );
+    }
+  }
+
+  /** Re-read model/provider from config before each think */
+  protected refreshLlmConfig(): void {
+    const model = getConfig(`module:${this.moduleId}:agent_model`)
+      ?? getConfig("worker_model")
+      ?? getConfig("coo_model");
+    const provider = getConfig(`module:${this.moduleId}:agent_provider`)
+      ?? getConfig("worker_provider")
+      ?? getConfig("coo_provider");
+
+    if (model) this.llmConfig.model = model;
+    if (provider) this.llmConfig.provider = provider;
+  }
+}

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -5,7 +5,7 @@ export const agents = sqliteTable("agents", {
   id: text("id").primaryKey(),
   name: text("name"),
   registryEntryId: text("registry_entry_id"),
-  role: text("role", { enum: ["coo", "team_lead", "worker", "admin_assistant", "scheduler"] }).notNull(),
+  role: text("role", { enum: ["coo", "team_lead", "worker", "admin_assistant", "scheduler", "module_agent"] }).notNull(),
   parentId: text("parent_id"),
   status: text("status", {
     enum: ["idle", "thinking", "acting", "awaiting_input", "done", "error"],
@@ -73,7 +73,7 @@ export const registryEntries = sqliteTable("registry_entries", {
     .notNull()
     .default([]),
   builtIn: integer("built_in", { mode: "boolean" }).notNull().default(false),
-  role: text("role", { enum: ["coo", "team_lead", "worker", "admin_assistant", "scheduler"] })
+  role: text("role", { enum: ["coo", "team_lead", "worker", "admin_assistant", "scheduler", "module_agent"] })
     .notNull()
     .default("worker"),
   modelPackId: text("model_pack_id"),
@@ -444,7 +444,8 @@ export const customScheduledTasks = sqliteTable("custom_scheduled_tasks", {
   name: text("name").notNull(),
   description: text("description").notNull().default(""),
   message: text("message").notNull(),
-  mode: text("mode", { enum: ["coo-prompt", "coo-background", "notification"] }).notNull().default("notification"),
+  mode: text("mode", { enum: ["coo-prompt", "coo-background", "notification", "module-agent"] }).notNull().default("notification"),
+  moduleAgentId: text("module_agent_id"),
   intervalMs: integer("interval_ms").notNull(),
   enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
   lastRunAt: text("last_run_at"),

--- a/packages/server/src/modules/index.ts
+++ b/packages/server/src/modules/index.ts
@@ -9,15 +9,25 @@ import { existsSync, readFileSync } from "node:fs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 import type { FastifyInstance } from "fastify";
+import type { Server } from "socket.io";
 import type { COO } from "../agents/coo.js";
+import type { MessageBus } from "../bus/message-bus.js";
 import { ModuleLoader } from "./module-loader.js";
 import { ModuleScheduler } from "./module-scheduler.js";
 import { registerModuleWebhooks } from "./module-webhook.js";
 import { createModuleTools } from "./module-tools.js";
 import { getModule, addModule } from "./module-manifest.js";
+import { ModuleAgent, type ModuleAgentDeps } from "../agents/module-agent.js";
+import { AgentStatus } from "@otterbot/shared";
+import { getConfig } from "../auth/auth.js";
+import { getRandomModelPackId } from "../models3d/model-packs.js";
 
 let _loader: ModuleLoader | null = null;
 let _scheduler: ModuleScheduler | null = null;
+let _bus: MessageBus | null = null;
+let _io: Server | null = null;
+/** Active module agents keyed by module instance ID */
+const _moduleAgents = new Map<string, ModuleAgent>();
 
 export function getModuleLoader(): ModuleLoader | null {
   return _loader;
@@ -25,6 +35,18 @@ export function getModuleLoader(): ModuleLoader | null {
 
 export function getModuleScheduler(): ModuleScheduler | null {
   return _scheduler;
+}
+
+export function getModuleAgent(moduleId: string): ModuleAgent | undefined {
+  return _moduleAgents.get(moduleId);
+}
+
+export function getActiveModuleAgents(): Map<string, ModuleAgent> {
+  return _moduleAgents;
+}
+
+export function getModuleBus(): MessageBus | null {
+  return _bus;
 }
 
 /** Known built-in module directories (checked in order). */
@@ -97,6 +119,8 @@ async function registerBuiltins(): Promise<void> {
 export async function initModules(
   coo: COO,
   app: FastifyInstance,
+  bus?: MessageBus,
+  io?: Server,
 ): Promise<void> {
   console.log("[Modules] Initializing module system...");
 
@@ -108,6 +132,8 @@ export async function initModules(
 
   _loader = loader;
   _scheduler = scheduler;
+  if (bus) _bus = bus;
+  if (io) _io = io;
 
   // 1. Load all modules from manifest
   const modules = await loader.loadAll();
@@ -122,10 +148,82 @@ export async function initModules(
   const tools = createModuleTools(loader, scheduler);
   coo.setModuleTools(tools);
 
+  // 5. Spawn module agents for modules that declare agent config
+  if (bus && io) {
+    for (const [id, loaded] of modules) {
+      await spawnModuleAgent(id, loaded, bus, io);
+    }
+  }
+
   console.log(`[Modules] Module system initialized with ${modules.size} modules`);
 }
 
+/** Spawn a module agent for a loaded module (if it declares agent config and is enabled). */
+async function spawnModuleAgent(
+  moduleId: string,
+  loaded: import("./module-loader.js").LoadedModule,
+  bus: MessageBus,
+  io: Server,
+): Promise<ModuleAgent | null> {
+  const agentConfig = loaded.definition.agent;
+  if (!agentConfig) return null;
+
+  // Check if agent is disabled via config
+  const enabledRaw = getConfig(`module:${moduleId}:agent_enabled`);
+  if (enabledRaw === "false") return null;
+
+  // Destroy existing agent for this module if any
+  destroyModuleAgent(moduleId, io);
+
+  try {
+    const agent = new ModuleAgent({
+      moduleId,
+      agentConfig,
+      knowledgeStore: loaded.knowledgeStore,
+      moduleContext: loaded.context,
+      moduleTools: loaded.definition.tools,
+      bus,
+      onStatusChange: (agentId, status) => {
+        io.emit("agent:status", { agentId, status });
+      },
+      onStream: (agentId, token, messageId) => {
+        io.emit("agent:stream", { agentId, token, messageId });
+      },
+    });
+
+    _moduleAgents.set(moduleId, agent);
+
+    // Emit pseudo-agent spawned event for 3D view
+    const agentData = agent.toData();
+    agentData.modelPackId = agentData.modelPackId ?? getRandomModelPackId();
+    io.emit("agent:spawned", agentData);
+
+    console.log(`[Modules] Spawned module agent: ${agent.id}`);
+    return agent;
+  } catch (err) {
+    console.error(`[Modules] Failed to spawn module agent for ${moduleId}:`, err);
+    return null;
+  }
+}
+
+/** Destroy a module agent and clean up. */
+function destroyModuleAgent(moduleId: string, io: Server): void {
+  const existing = _moduleAgents.get(moduleId);
+  if (existing) {
+    existing.destroy();
+    _moduleAgents.delete(moduleId);
+    io.emit("agent:destroyed", { agentId: existing.id });
+    console.log(`[Modules] Destroyed module agent: ${existing.id}`);
+  }
+}
+
 export async function shutdownModules(): Promise<void> {
+  // Destroy all module agents
+  for (const [, agent] of _moduleAgents) {
+    agent.destroy();
+  }
+  _moduleAgents.clear();
+
   if (_scheduler) {
     _scheduler.stopAll();
     _scheduler = null;

--- a/packages/server/src/modules/module-loader.ts
+++ b/packages/server/src/modules/module-loader.ts
@@ -98,6 +98,51 @@ export class ModuleLoader {
     const { loadModuleDefinition } = await import("./module-installer.js");
     const definition = await loadModuleDefinition(modulePath);
 
+    // Auto-inject agent config fields into config schema if module declares an agent
+    if (definition.agent) {
+      if (!definition.configSchema) {
+        definition.configSchema = {};
+      }
+      if (!definition.configSchema.agent_enabled) {
+        definition.configSchema.agent_enabled = {
+          type: "boolean",
+          description: "Enable the module's AI agent for reasoned queries",
+          required: false,
+          default: true,
+        };
+      }
+      if (!definition.configSchema.agent_name) {
+        definition.configSchema.agent_name = {
+          type: "string",
+          description: "Display name for the module agent",
+          required: false,
+          default: definition.agent.defaultName,
+        };
+      }
+      if (!definition.configSchema.agent_prompt) {
+        definition.configSchema.agent_prompt = {
+          type: "string",
+          description: "System prompt for the module agent",
+          required: false,
+          default: definition.agent.defaultPrompt,
+        };
+      }
+      if (!definition.configSchema.agent_model) {
+        definition.configSchema.agent_model = {
+          type: "string",
+          description: "LLM model for the module agent (leave empty for system default)",
+          required: false,
+        };
+      }
+      if (!definition.configSchema.agent_provider) {
+        definition.configSchema.agent_provider = {
+          type: "string",
+          description: "LLM provider for the module agent (leave empty for system default)",
+          required: false,
+        };
+      }
+    }
+
     // Create knowledge store (data dir is always in ./data/modules/<id>/)
     const dataDir = resolve(modulesDir(), id);
     const knowledgeStore = new ModuleKnowledgeStore(id, dataDir);

--- a/packages/server/src/schedulers/custom-task-scheduler.ts
+++ b/packages/server/src/schedulers/custom-task-scheduler.ts
@@ -208,6 +208,21 @@ export class CustomTaskScheduler {
         content: wrappedMessage,
         metadata: { ...baseMeta, backgroundTask: true },
       });
+    } else if (task.mode === "module-agent") {
+      // Send directive to a specific module agent
+      const moduleAgentId = (task as any).moduleAgentId;
+      if (moduleAgentId) {
+        // Send as a Directive; the module agent will process and send a Report back to COO
+        this.bus.send({
+          fromAgentId: "coo",
+          toAgentId: moduleAgentId,
+          type: MessageType.Directive,
+          content: task.message,
+          metadata: { ...baseMeta, moduleAgent: true },
+        });
+      } else {
+        console.warn(`[CustomTaskScheduler] Task "${task.name}" has mode=module-agent but no moduleAgentId`);
+      }
     } else {
       // notification mode: post as a COO message to the chat (no agent processing)
       this.bus.send({

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -6,6 +6,7 @@ export enum AgentRole {
   Worker = "worker",
   AdminAssistant = "admin_assistant",
   Scheduler = "scheduler",
+  ModuleAgent = "module_agent",
 }
 
 export enum AgentStatus {

--- a/packages/shared/src/types/module.ts
+++ b/packages/shared/src/types/module.ts
@@ -134,12 +134,20 @@ export interface ModuleToolDefinition {
 
 // ─── Module definition ───────────────────────────────────────────────────────
 
+export interface ModuleAgentConfig {
+  defaultName: string;
+  defaultPrompt: string;
+  defaultModel?: string;
+  defaultProvider?: string;
+}
+
 export interface ModuleDefinition {
   manifest: ModuleManifest;
   configSchema?: ModuleConfigSchema;
   triggers?: ModuleTrigger[];
   migrations?: ModuleMigration[];
   tools?: ModuleToolDefinition[];
+  agent?: ModuleAgentConfig;
   onPoll?: PollHandler;
   onWebhook?: WebhookHandler;
   onQuery?: QueryHandler;

--- a/packages/shared/src/types/registry.ts
+++ b/packages/shared/src/types/registry.ts
@@ -13,7 +13,7 @@ export interface RegistryEntry {
   /** Derived from assigned skills — not stored on the entry directly */
   tools: string[];
   builtIn: boolean;
-  role: "coo" | "team_lead" | "worker";
+  role: "coo" | "team_lead" | "worker" | "module_agent";
   modelPackId: string | null;
   gearConfig: GearConfig | null;
   clonedFromId: string | null;
@@ -27,7 +27,7 @@ export interface RegistryEntryCreate {
   promptAddendum?: string | null;
   defaultModel: string;
   defaultProvider: string;
-  role?: "coo" | "team_lead" | "worker";
+  role?: "coo" | "team_lead" | "worker" | "module_agent";
   clonedFromId?: string | null;
   modelPackId?: string | null;
   gearConfig?: GearConfig | null;

--- a/packages/web/src/components/live-view/LiveViewScene.tsx
+++ b/packages/web/src/components/live-view/LiveViewScene.tsx
@@ -43,6 +43,7 @@ export function LiveViewScene({ userProfile }: LiveViewSceneProps) {
     const workers = activeAgents.filter((a) => a.role === "worker");
     const adminAssistants = activeAgents.filter((a) => a.role === "admin_assistant");
     const schedulers = activeAgents.filter((a) => a.role === "scheduler");
+    const moduleAgents = activeAgents.filter((a) => a.role === "module_agent");
 
     // Helper: does a project have any actively-working non-lead agents?
     const hasActiveWorkersInProject = (projectId: string | null): boolean => {
@@ -222,6 +223,24 @@ export function LiveViewScene({ userProfile }: LiveViewSceneProps) {
           rotationY: pos.rotationY,
         });
       }
+
+      // Module agents — share break room with schedulers
+      for (let i = 0; i < moduleAgents.length; i++) {
+        const ma = moduleAgents[i];
+        const zoneId = breakRoomZone ? breakRoomZoneId : mainZoneId;
+        const deskIdx = breakRoomZone ? breakRoomIdx++ : nextDeskIndex++;
+        const pos = getStatusAwarePos(ma, zoneId, deskIdx);
+        positions.push({
+          agent: ma,
+          role: "module_agent",
+          x: pos.x,
+          z: pos.z,
+          label: ma.name ?? `Module Agent ${ma.id.slice(0, 6)}`,
+          modelPackId: ma.modelPackId ?? null,
+          gearConfig: ma.gearConfig ?? null,
+          rotationY: pos.rotationY,
+        });
+      }
     } else if (activeScene?.agentPositions) {
       const ap = activeScene.agentPositions;
 
@@ -296,6 +315,21 @@ export function LiveViewScene({ userProfile }: LiveViewSceneProps) {
           rotationY: slot.rotation ?? 0,
         });
       }
+
+      // Module agents — cycle through worker slots after schedulers
+      for (let i = 0; i < moduleAgents.length; i++) {
+        const slot = ap.worker[(workers.length + schedulers.length + i) % ap.worker.length];
+        positions.push({
+          agent: moduleAgents[i],
+          role: "module_agent",
+          x: slot.position[0],
+          z: slot.position[2],
+          label: moduleAgents[i].name ?? `Module Agent ${moduleAgents[i].id.slice(0, 6)}`,
+          modelPackId: moduleAgents[i].modelPackId ?? null,
+          gearConfig: moduleAgents[i].gearConfig ?? null,
+          rotationY: slot.rotation ?? 0,
+        });
+      }
     } else {
       // Fallback: original grid layout
       positions.push({
@@ -361,6 +395,20 @@ export function LiveViewScene({ userProfile }: LiveViewSceneProps) {
           label: schedulers[i].name ?? `Scheduler ${schedulers[i].id.slice(0, 6)}`,
           modelPackId: schedulers[i].modelPackId ?? null,
           gearConfig: schedulers[i].gearConfig ?? null,
+          rotationY: 0,
+        });
+      }
+
+      for (let i = 0; i < moduleAgents.length; i++) {
+        const spread = (i - (moduleAgents.length - 1) / 2) * 3;
+        positions.push({
+          agent: moduleAgents[i],
+          role: "module_agent",
+          x: spread,
+          z: -15,
+          label: moduleAgents[i].name ?? `Module Agent ${moduleAgents[i].id.slice(0, 6)}`,
+          modelPackId: moduleAgents[i].modelPackId ?? null,
+          gearConfig: moduleAgents[i].gearConfig ?? null,
           rotationY: 0,
         });
       }

--- a/packages/web/src/stores/settings-store.ts
+++ b/packages/web/src/stores/settings-store.ts
@@ -34,12 +34,19 @@ export interface CustomTaskInfo {
   name: string;
   description: string;
   message: string;
-  mode: "coo-prompt" | "coo-background" | "notification";
+  mode: "coo-prompt" | "coo-background" | "notification" | "module-agent";
+  moduleAgentId?: string | null;
   intervalMs: number;
   enabled: boolean;
   lastRunAt: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface ModuleAgentInfo {
+  moduleId: string;
+  agentId: string;
+  name: string | null;
 }
 
 export interface SearchProviderConfig {
@@ -262,7 +269,8 @@ interface SettingsState {
     name: string;
     description?: string;
     message: string;
-    mode?: "coo-prompt" | "coo-background" | "notification";
+    mode?: "coo-prompt" | "coo-background" | "notification" | "module-agent";
+    moduleAgentId?: string;
     intervalMs: number;
     enabled?: boolean;
   }) => Promise<void>;
@@ -270,11 +278,16 @@ interface SettingsState {
     name?: string;
     description?: string;
     message?: string;
-    mode?: "coo-prompt" | "coo-background" | "notification";
+    mode?: "coo-prompt" | "coo-background" | "notification" | "module-agent";
+    moduleAgentId?: string;
     intervalMs?: number;
     enabled?: boolean;
   }) => Promise<void>;
   deleteCustomTask: (id: string) => Promise<void>;
+
+  // Module agents
+  moduleAgents: ModuleAgentInfo[];
+  loadModuleAgents: () => Promise<void>;
 
   // Search actions
   loadSearchSettings: () => Promise<void>;
@@ -481,6 +494,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   scheduledTasksLoading: false,
   customTasks: [],
   customTasksLoading: false,
+  moduleAgents: [],
   searchProviders: [],
   activeSearchProvider: null,
   searchTestResults: {},
@@ -854,6 +868,17 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       // Silently fail
     } finally {
       set({ customTasksLoading: false });
+    }
+  },
+
+  loadModuleAgents: async () => {
+    try {
+      const res = await fetch("/api/settings/module-agents");
+      if (!res.ok) return;
+      const data = await res.json();
+      set({ moduleAgents: data.agents });
+    } catch {
+      // Silently fail
     }
   },
 


### PR DESCRIPTION
## Summary

- **ModuleAgent class**: New `BaseAgent` subclass that gives modules their own AI agent with a `knowledge_search` tool (hybrid FTS + vector search) scoped to the module's knowledge store, plus any custom tools the module defines
- **COO integration**: `module_query` now routes through the module agent when active, producing synthesized/reasoned answers instead of raw search results. Falls back to raw search if no agent or on timeout
- **Scheduled reports**: New `module-agent` mode in `CustomTaskScheduler` lets users schedule recurring directives to module agents (e.g., "Generate a daily digest of new Security Onion articles")
- **3D LiveView**: Module agents appear in the break room zone alongside schedulers with their own `module_agent` role
- **Auto-config**: Modules declaring `agent` config get settings fields auto-injected (`agent_enabled`, `agent_name`, `agent_prompt`, `agent_model`, `agent_provider`) in the module settings UI
- **Lifecycle management**: Module agents are spawned on module load, destroyed on unload/disable, with proper bus subscription cleanup

## Key files
| File | Change |
|------|--------|
| `packages/server/src/agents/module-agent.ts` | **New** — ModuleAgent class |
| `packages/shared/src/types/module.ts` | `ModuleAgentConfig` interface, `agent` field on `ModuleDefinition` |
| `packages/shared/src/types/agent.ts` | `ModuleAgent` added to `AgentRole` enum |
| `packages/server/src/modules/index.ts` | Spawn/destroy lifecycle, getters |
| `packages/server/src/modules/module-loader.ts` | Auto-inject agent config fields |
| `packages/server/src/modules/module-tools.ts` | Route `module_query` through agent |
| `packages/server/src/schedulers/custom-task-scheduler.ts` | `module-agent` mode |
| `packages/web/src/components/settings/ScheduledTasksSection.tsx` | Module agent mode UI |
| `packages/web/src/components/live-view/LiveViewScene.tsx` | 3D positioning |

## Test plan
- [ ] Install a module with `agent` config → verify agent spawns, appears in 3D view
- [ ] Ask COO a question that triggers `module_query` → verify routed through agent
- [ ] Create a scheduled task with `module-agent` mode → verify fires on schedule
- [ ] Disable module → verify agent destroyed, disappears from 3D view
- [ ] `npx pnpm test` passes (996/996 tests green)
- [ ] Type-check clean on shared and server packages