### PR TITLE
fix: break circular import preventing module system init

### DIFF
--- a/packages/server/src/modules/module-tools.ts
+++ b/packages/server/src/modules/module-tools.ts
@@ -14,7 +14,6 @@ import {
   uninstallModule,
 } from "./module-installer.js";
 import { getConfig } from "../auth/auth.js";
-import { getModuleAgent } from "./index.js";
 
 export function createModuleTools(
   loader: ModuleLoader,
@@ -28,6 +27,7 @@ export function createModuleTools(
       execute: async () => {
         const modules = loader.getAll();
         const { listModules } = await import("./module-manifest.js");
+        const { getModuleAgent } = await import("./index.js");
         const installed = listModules();
 
         const items = installed.map((m) => {
@@ -74,9 +74,9 @@ export function createModuleTools(
 
         try {
           // If the module has an active agent, route through it for reasoned answers
+          const { getModuleAgent, getModuleBus } = await import("./index.js");
           const moduleAgent = getModuleAgent(moduleId);
           if (moduleAgent) {
-            const { getModuleBus } = await import("./index.js");
             const bus = getModuleBus();
             if (bus) {
               const agentId = `module-agent-${moduleId}`;


### PR DESCRIPTION
## Summary

- `module-tools.ts` had a static import of `getModuleAgent` from `./index.js`, while `index.ts` imports `createModuleTools` from `./module-tools.js` — creating a circular dependency that prevents the module system from initializing
- Switches to dynamic `await import("./index.js")` inside the tool `execute` functions, breaking the cycle
- This fixes the "Module System not Initialized" error when trying to enable modules in the UI

## Test plan
- [ ] Enable a module in the UI → no longer shows "Module System not Initialized"
- [ ] `npx pnpm test` — 998 tests pass
- [ ] `npx tsc --noEmit -p packages/server/tsconfig.json` — clean