### PR TITLE
fix: convert static imports to dynamic in modules/index.ts

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2627,11 +2627,10 @@ async function main() {
     try {
       const { getActiveModuleAgents } = await import("./modules/index.js");
       const agents = getActiveModuleAgents();
-      const items = Array.from(agents.entries()).map(([moduleId, agent]) => ({
-        moduleId,
-        agentId: agent.id,
-        name: agent.name,
-      }));
+      const items = Array.from(agents.entries()).map(([moduleId, agent]) => {
+        const a = agent as { id: string; name: string };
+        return { moduleId, agentId: a.id, name: a.name };
+      });
       return { agents: items };
     } catch {
       return { agents: [] };


### PR DESCRIPTION
## Summary
- Converts static imports of `ModuleAgent`, `getConfig`, and `getRandomModelPackId` in `packages/server/src/modules/index.ts` to dynamic imports inside `spawnModuleAgent()`
- The static imports caused the entire module file to fail loading if any agent-related dependency couldn't resolve, silently preventing module system initialization (`_loader` stayed `null`)
- This was the root cause of the "Module System not Initialized" error when toggling modules

## Test plan
- [ ] Start the server and verify module system initializes (no "Module System not Initialized" error)
- [ ] Toggle a module on/off in the UI
- [ ] Verify module agents still spawn correctly for modules with agent config