### PR TITLE
fix: add missing migration for module_agent_id column

### DIFF
--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -626,6 +626,11 @@ export async function migrateDb() {
     updated_at TEXT NOT NULL
   )`);
 
+  // Idempotent migration: add module_agent_id to custom_scheduled_tasks
+  try {
+    db.run(sql`ALTER TABLE custom_scheduled_tasks ADD COLUMN module_agent_id TEXT`);
+  } catch { /* column already exists */ }
+
   // MCP servers table
   db.run(sql`CREATE TABLE IF NOT EXISTS mcp_servers (
     id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Adds idempotent `ALTER TABLE` migration to add `module_agent_id` column to `custom_scheduled_tasks` table
- The column was defined in the Drizzle schema but had no migration for existing databases, causing a `SqliteError: no such column: "module_agent_id"` crash at startup

## Test plan
- [ ] Start server against an existing database — no crash
- [ ] Verify custom scheduled tasks still load and run