### PR TITLE
feat: module config UI dropdowns, posting modes & DB info

### DIFF
--- a/packages/server/src/modules/module-loader.ts
+++ b/packages/server/src/modules/module-loader.ts
@@ -141,6 +141,20 @@ export class ModuleLoader {
           required: false,
         };
       }
+      if (!definition.configSchema.agent_posting_mode) {
+        definition.configSchema.agent_posting_mode = {
+          type: "select",
+          description: "Controls when the module agent responds to queries",
+          required: false,
+          default: "respond",
+          options: [
+            { value: "respond", label: "Always respond" },
+            { value: "lurk", label: "Lurk (index only, never respond)" },
+            { value: "new_chats", label: "New conversations only" },
+            { value: "permission", label: "Ask COO for permission" },
+          ],
+        };
+      }
     }
 
     // Create knowledge store (data dir is always in ./data/modules/<id>/)

--- a/packages/shared/src/types/module.ts
+++ b/packages/shared/src/types/module.ts
@@ -27,10 +27,11 @@ export interface ModuleManifest {
 // ─── Config schema ───────────────────────────────────────────────────────────
 
 export interface ModuleConfigField {
-  type: "string" | "number" | "boolean" | "secret";
+  type: "string" | "number" | "boolean" | "secret" | "select";
   description: string;
   required: boolean;
   default?: string | number | boolean;
+  options?: { value: string; label: string }[];
 }
 
 export type ModuleConfigSchema = Record<string, ModuleConfigField>;


### PR DESCRIPTION
## Summary

- **Select field type**: Added `"select"` to `ModuleConfigField` with `options` array support
- **Posting mode**: New `agent_posting_mode` config (respond/lurk/new_chats/permission) auto-injected for module agents, enforced before `think()` in `ModuleAgent`
- **Provider/model dropdowns**: `agent_provider` renders as a `<select>` from configured providers; `agent_model` renders as a `ModelCombobox` with models fetched for the selected provider
- **Database info**: New `GET /api/modules/:id/db-info` endpoint returns table names and row counts; shown in the config panel when the module is loaded

Closes #318

## Test plan

- [ ] Open Settings > Modules > Config on a module with an agent
- [ ] Verify `agent_provider` shows a dropdown of configured providers
- [ ] Verify `agent_model` shows a combobox with models for the selected provider
- [ ] Verify `agent_posting_mode` shows a select dropdown with four options
- [ ] Set mode to "lurk", query module — verify it declines
- [ ] Set mode to "respond" — verify normal behavior
- [ ] Enable module, verify Database section shows tables with row counts
- [ ] Type-check: `npx tsc --noEmit -p packages/server/tsconfig.json`