### PR TITLE
feat: module config UI and full historical sync

### DIFF
--- a/packages/shared/src/types/module.ts
+++ b/packages/shared/src/types/module.ts
@@ -112,6 +112,7 @@ export interface ModuleContext {
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
 export type PollHandler = (ctx: ModuleContext) => Promise<PollResult>;
+export type FullSyncHandler = (ctx: ModuleContext) => Promise<PollResult>;
 export type WebhookHandler = (req: WebhookRequest, ctx: ModuleContext) => Promise<WebhookResult>;
 export type QueryHandler = (query: string, ctx: ModuleContext) => Promise<string>;
 
@@ -150,6 +151,7 @@ export interface ModuleDefinition {
   tools?: ModuleToolDefinition[];
   agent?: ModuleAgentConfig;
   onPoll?: PollHandler;
+  onFullSync?: FullSyncHandler;
   onWebhook?: WebhookHandler;
   onQuery?: QueryHandler;
   onLoad?(ctx: ModuleContext): Promise<void>;


### PR DESCRIPTION
## Summary

- Add module configuration UI with config panel, provider/model dropdowns, posting mode controls, and database info display
- Add `onFullSync` handler to module types for paginated historical data fetching
- Implement paginated `fetchAllDiscussions` in github-discussions module with rate limiting
- Add `POST /api/modules/:id/poll` endpoint to trigger polls or full syncs
- Add "Sync Now" button to the modules settings UI

## Test plan

- [ ] Open Settings > Modules, verify config panel renders for installed modules
- [ ] Click "Sync Now" on a loaded github-discussions module — verify spinner, success message with item count
- [ ] Check DB row counts before/after sync to confirm all historical discussions are captured
- [ ] Verify regular 5-minute polling still works (no regression)
- [ ] Type-check: `npx tsc --noEmit -p packages/server/tsconfig.json` and `npx tsc --noEmit -p packages/shared/tsconfig.json`