### PR TITLE
feat: add module agent query UI with inline ask box and chat panel

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5163,6 +5163,11 @@ Respond with ONLY a JSON object (no markdown, no explanation) with these fields:
             if (replyMsg) {
               return { ok: true, answer: replyMsg.content };
             }
+            // Agent timed out — fall through to simpler handlers
+            // but if there's no fallback, return a timeout message
+            if (!loaded.definition.onQuery) {
+              return { ok: true, answer: "The agent did not respond in time. It may be busy or unavailable." };
+            }
           }
         }
 

--- a/packages/web/src/components/settings/ModuleAgentChat.tsx
+++ b/packages/web/src/components/settings/ModuleAgentChat.tsx
@@ -57,7 +57,7 @@ export function ModuleAgentChat({ modules, onClose }: ModuleAgentChatProps) {
         ]);
       } else {
         const data = await res.json();
-        setMessages((prev) => [...prev, { role: "agent", content: data.answer }]);
+        setMessages((prev) => [...prev, { role: "agent", content: data.answer || "(empty response)" }]);
       }
     } catch (err) {
       setMessages((prev) => [

--- a/packages/web/src/components/settings/ModulesSection.tsx
+++ b/packages/web/src/components/settings/ModulesSection.tsx
@@ -137,15 +137,18 @@ function ModuleQueryBox({ moduleId }: { moduleId: string }) {
         </button>
       </div>
       {error && <div className="text-xs text-red-500">{error}</div>}
-      {lastQ && lastA && (
+      {lastQ && asking && (
         <div className="bg-secondary/50 rounded-md p-3 space-y-2">
           <div className="text-[10px] text-muted-foreground">Q: {lastQ}</div>
-          <div className="text-xs text-foreground whitespace-pre-wrap">{lastA}</div>
+          <div className="text-xs text-muted-foreground animate-pulse">
+            Thinking... this may take a minute while the agent reasons.
+          </div>
         </div>
       )}
-      {lastQ && !lastA && asking && (
-        <div className="text-[10px] text-muted-foreground animate-pulse">
-          Thinking...
+      {lastQ && !asking && lastA !== null && (
+        <div className="bg-secondary/50 rounded-md p-3 space-y-2">
+          <div className="text-[10px] text-muted-foreground">Q: {lastQ}</div>
+          <div className="text-xs text-foreground whitespace-pre-wrap">{lastA || "(empty response)"}</div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Add `POST /api/modules/:id/query` REST endpoint that routes questions through module agents (via MessageBus), with fallback to `onQuery` handlers and raw knowledge search
- Add inline "Ask Agent" box on loaded module cards in Settings (visible when module has an agent or query handler)
- Add unified "Agent Chat" modal with agent selector dropdown for longer conversations with module agents
- Improved loading/feedback states and edge case handling (empty responses, agent timeouts)

## Test plan
- [ ] Open Settings > Modules on a loaded module with an agent — verify "Ask Agent" box appears
- [ ] Type a question in the inline box, verify "Thinking..." appears and response displays
- [ ] Click "Agent Chat" button — verify modal opens with agent selector and chat interface
- [ ] Send multiple messages in chat — verify conversation flows naturally
- [ ] Ask the COO "ask the discussions module about X" — verify no regression