### PR TITLE
feat: add module agent query UI and main chat agent selector

### DIFF
--- a/packages/server/src/socket/handlers.ts
+++ b/packages/server/src/socket/handlers.ts
@@ -218,10 +218,11 @@ export function setupSocketHandlers(
           .run();
       }
 
+      const targetAgent = data.toAgentId ?? "coo";
       const message = bus.send({
         fromAgentId: null, // CEO
-        toAgentId: "coo",
-        type: MessageType.Chat,
+        toAgentId: targetAgent,
+        type: targetAgent === "coo" ? MessageType.Chat : MessageType.Directive,
         content: data.content,
         conversationId,
         metadata: projectId ? { projectId } : undefined,

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -84,7 +84,7 @@ export interface ServerToClientEvents {
 /** Events emitted from client to server */
 export interface ClientToServerEvents {
   "ceo:message": (
-    data: { content: string; conversationId?: string; projectId?: string },
+    data: { content: string; conversationId?: string; projectId?: string; toAgentId?: string },
     callback?: (ack: { messageId: string; conversationId: string }) => void,
   ) => void;
   "ceo:new-chat": (

--- a/packages/web/src/stores/message-store.ts
+++ b/packages/web/src/stores/message-store.ts
@@ -55,20 +55,26 @@ export const useMessageStore = create<MessageState>((set) => ({
     set((state) => {
       const newMessages = [...state.messages, message];
 
-      // If it's a CEO↔COO chat message, also add to chat
+      // If it's a CEO↔COO or CEO↔module-agent chat/report message, also add to chat
+      const isModuleAgent =
+        message.fromAgentId?.startsWith("module-agent-") ||
+        message.toAgentId?.startsWith("module-agent-");
       const isCeoChat =
-        message.type === "chat" &&
+        (message.type === "chat" || (message.type === "report" && isModuleAgent)) &&
         (message.fromAgentId === null ||
-          message.fromAgentId === "coo") &&
-        (message.toAgentId === null || message.toAgentId === "coo");
+          message.fromAgentId === "coo" ||
+          message.fromAgentId?.startsWith("module-agent-")) &&
+        (message.toAgentId === null ||
+          message.toAgentId === "coo" ||
+          message.toAgentId?.startsWith("module-agent-"));
 
       const newChat = isCeoChat
         ? [...state.chatMessages, message]
         : state.chatMessages;
 
-      // Clear streaming if this is the final COO response for the current conversation
+      // Clear streaming if this is the final agent response for the current conversation
       const clearStream =
-        message.fromAgentId === "coo" &&
+        (message.fromAgentId === "coo" || message.fromAgentId?.startsWith("module-agent-")) &&
         message.toAgentId === null &&
         (!message.conversationId || message.conversationId === state.currentConversationId);
 


### PR DESCRIPTION
## Summary
- Add `POST /api/modules/:id/query` REST endpoint that routes questions through module agents (via MessageBus), with fallback to `onQuery` handlers and raw knowledge search
- Add inline "Ask Agent" box on loaded module cards in Settings
- Add unified "Agent Chat" modal with agent selector dropdown for longer conversations
- Add module agent selector dropdown to the main chat input — allows direct messaging module agents bypassing the COO
- Add `toAgentId` to `ceo:message` socket event and update server handler to route accordingly
- Update message store to display module agent responses in the main chat view

## Test plan
- [ ] Open Settings > Modules on a loaded module with an agent — verify "Ask Agent" box appears
- [ ] Type a question in the inline box, verify "Thinking..." appears and response displays
- [ ] Click "Agent Chat" button — verify modal opens with chat interface
- [ ] In main chat, use the agent selector dropdown to pick a module agent
- [ ] Send a message — verify it routes to the module agent and response appears in chat
- [ ] Switch back to COO — verify normal chat still works
- [ ] Ask the COO "ask the discussions module about X" — verify no regression