### PR TITLE
feat: add WASD camera movement controls to 3D live view

### DIFF
--- a/packages/web/src/components/live-view/LiveViewScene.tsx
+++ b/packages/web/src/components/live-view/LiveViewScene.tsx
@@ -10,6 +10,7 @@ import { AgentCharacter } from "./AgentCharacter";
 import { FallbackAgent } from "./FallbackAgent";
 import { EnvironmentScene } from "./EnvironmentScene";
 import { ZoneGroundMarkers } from "./ZoneGroundMarkers";
+import { WASDControls } from "./WASDControls";
 import { EditableEnvironmentScene } from "../room-builder/EditableEnvironmentScene";
 import type { Agent } from "@otterbot/shared";
 import { findWaypointsByZoneAndTag } from "../../lib/pathfinding";
@@ -500,6 +501,7 @@ export function LiveViewScene({ userProfile }: LiveViewSceneProps) {
         minPolarAngle={0.3}
         maxPolarAngle={Math.PI / 2.1}
       />
+      <WASDControls disabled={builderActive} />
     </>
   );
 }

--- a/packages/web/src/components/live-view/WASDControls.test.tsx
+++ b/packages/web/src/components/live-view/WASDControls.test.tsx
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import * as THREE from "three";
+
+const mockState = vi.hoisted(() => ({
+  refs: [] as Array<{ current: unknown }>,
+  refIndex: 0,
+  cleanups: [] as Array<() => void>,
+  frameCallback: undefined as undefined | ((state: unknown, dt: number) => void),
+  camera: undefined as
+    | undefined
+    | {
+        position: THREE.Vector3;
+        up: THREE.Vector3;
+        getWorldDirection: (target: THREE.Vector3) => THREE.Vector3;
+      },
+  listeners: new Map<string, Set<(event: unknown) => void>>(),
+}));
+
+vi.mock("react", () => ({
+  useRef: (initialValue: unknown) => {
+    const i = mockState.refIndex++;
+    if (!mockState.refs[i]) {
+      mockState.refs[i] = { current: initialValue };
+    }
+    return mockState.refs[i];
+  },
+  useEffect: (effect: () => void | (() => void)) => {
+    const cleanup = effect();
+    if (typeof cleanup === "function") {
+      mockState.cleanups.push(cleanup);
+    }
+  },
+}));
+
+vi.mock("@react-three/fiber", () => ({
+  useThree: () => ({ camera: mockState.camera }),
+  useFrame: (cb: (state: unknown, dt: number) => void) => {
+    mockState.frameCallback = cb;
+  },
+}));
+
+import { WASDControls } from "./WASDControls";
+
+function dispatchWindowEvent(type: string, event: unknown) {
+  const handlers = mockState.listeners.get(type);
+  if (!handlers) return;
+  for (const handler of handlers) {
+    handler(event);
+  }
+}
+
+function mountWASDControls(props?: { speed?: number; disabled?: boolean }) {
+  mockState.refIndex = 0;
+  WASDControls(props ?? {});
+  expect(mockState.frameCallback).toBeDefined();
+}
+
+describe("WASDControls", () => {
+  beforeEach(() => {
+    mockState.refs = [];
+    mockState.refIndex = 0;
+    mockState.cleanups = [];
+    mockState.frameCallback = undefined;
+    mockState.listeners.clear();
+    mockState.camera = {
+      position: new THREE.Vector3(0, 1, 0),
+      up: new THREE.Vector3(0, 1, 0),
+      getWorldDirection: (target: THREE.Vector3) => target.set(0, 0, -1),
+    };
+
+    (globalThis as { window?: unknown }).window = {
+      addEventListener: (type: string, handler: (event: unknown) => void) => {
+        const existing = mockState.listeners.get(type);
+        if (existing) {
+          existing.add(handler);
+          return;
+        }
+        mockState.listeners.set(type, new Set([handler]));
+      },
+      removeEventListener: (type: string, handler: (event: unknown) => void) => {
+        mockState.listeners.get(type)?.delete(handler);
+      },
+    };
+  });
+
+  it("moves camera and controls target forward when W is pressed", () => {
+    mountWASDControls({ speed: 10 });
+
+    const target = new THREE.Vector3(2, 0, 2);
+    dispatchWindowEvent("keydown", { key: "w", target: { tagName: "DIV" } });
+    mockState.frameCallback?.({ controls: { target } }, 0.5);
+
+    expect(mockState.camera?.position.x).toBeCloseTo(0, 6);
+    expect(mockState.camera?.position.y).toBeCloseTo(1, 6);
+    expect(mockState.camera?.position.z).toBeCloseTo(-5, 6);
+    expect(target.x).toBeCloseTo(2, 6);
+    expect(target.z).toBeCloseTo(-3, 6);
+  });
+
+  it("normalizes diagonal movement for W + D", () => {
+    mountWASDControls({ speed: 10 });
+
+    dispatchWindowEvent("keydown", { key: "w", target: { tagName: "DIV" } });
+    dispatchWindowEvent("keydown", { key: "d", target: { tagName: "DIV" } });
+    mockState.frameCallback?.({ controls: { target: new THREE.Vector3() } }, 1);
+
+    expect(mockState.camera?.position.x).toBeCloseTo(7.07106781, 5);
+    expect(mockState.camera?.position.z).toBeCloseTo(-7.07106781, 5);
+  });
+
+  it("ignores movement keys when focus is in input controls", () => {
+    mountWASDControls({ speed: 10 });
+
+    dispatchWindowEvent("keydown", { key: "w", target: { tagName: "INPUT" } });
+    mockState.frameCallback?.({ controls: { target: new THREE.Vector3() } }, 1);
+
+    expect(mockState.camera?.position.x).toBeCloseTo(0, 6);
+    expect(mockState.camera?.position.z).toBeCloseTo(0, 6);
+  });
+
+  it("clears pressed keys on window blur", () => {
+    mountWASDControls({ speed: 10 });
+
+    dispatchWindowEvent("keydown", { key: "ArrowUp", target: { tagName: "DIV" } });
+    dispatchWindowEvent("blur", {});
+    mockState.frameCallback?.({ controls: { target: new THREE.Vector3() } }, 1);
+
+    expect(mockState.camera?.position.z).toBeCloseTo(0, 6);
+  });
+
+  it("does not register listeners or move when disabled", () => {
+    mountWASDControls({ speed: 10, disabled: true });
+
+    expect(mockState.listeners.get("keydown")?.size ?? 0).toBe(0);
+    expect(mockState.listeners.get("keyup")?.size ?? 0).toBe(0);
+    expect(mockState.listeners.get("blur")?.size ?? 0).toBe(0);
+
+    mockState.frameCallback?.({ controls: { target: new THREE.Vector3() } }, 1);
+    expect(mockState.camera?.position.z).toBeCloseTo(0, 6);
+  });
+
+  it("removes listeners during effect cleanup", () => {
+    mountWASDControls();
+    expect(mockState.listeners.get("keydown")?.size ?? 0).toBe(1);
+    expect(mockState.listeners.get("keyup")?.size ?? 0).toBe(1);
+    expect(mockState.listeners.get("blur")?.size ?? 0).toBe(1);
+
+    for (const cleanup of mockState.cleanups) {
+      cleanup();
+    }
+
+    expect(mockState.listeners.get("keydown")?.size ?? 0).toBe(0);
+    expect(mockState.listeners.get("keyup")?.size ?? 0).toBe(0);
+    expect(mockState.listeners.get("blur")?.size ?? 0).toBe(0);
+  });
+});
+
+describe("LiveViewScene wiring", () => {
+  it("passes builder state to WASDControls disabled prop", () => {
+    const source = readFileSync(resolve(__dirname, "./LiveViewScene.tsx"), "utf-8");
+
+    expect(source).toContain('import { WASDControls } from "./WASDControls";');
+    expect(source).toContain("<WASDControls disabled={builderActive} />");
+  });
+});

--- a/packages/web/src/components/live-view/WASDControls.tsx
+++ b/packages/web/src/components/live-view/WASDControls.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+
+interface WASDControlsProps {
+  /** Movement speed in units per second */
+  speed?: number;
+  /** When true, controls are disabled (e.g. during room builder editing) */
+  disabled?: boolean;
+}
+
+/**
+ * WASD camera movement for the 3D live view.
+ *
+ * Moves the camera and its OrbitControls target together on the XZ plane,
+ * relative to the camera's current horizontal facing direction.
+ *
+ * - W / ArrowUp    → forward
+ * - S / ArrowDown  → backward
+ * - A / ArrowLeft  → strafe left
+ * - D / ArrowRight → strafe right
+ */
+export function WASDControls({ speed = 10, disabled = false }: WASDControlsProps) {
+  const { camera } = useThree();
+  const keys = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (disabled) {
+      keys.current.clear();
+      return;
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      // Ignore when focus is in form controls
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+
+      const key = e.key.toLowerCase();
+      if (key === "w" || key === "a" || key === "s" || key === "d" ||
+          key === "arrowup" || key === "arrowdown" || key === "arrowleft" || key === "arrowright") {
+        keys.current.add(key);
+      }
+    };
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      keys.current.delete(key);
+    };
+
+    // Clear keys when window loses focus
+    const onBlur = () => keys.current.clear();
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    window.addEventListener("blur", onBlur);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", onBlur);
+      keys.current.clear();
+    };
+  }, [disabled]);
+
+  // Reusable vectors (allocated once, reused per frame)
+  const forward = useRef(new THREE.Vector3());
+  const right = useRef(new THREE.Vector3());
+  const delta = useRef(new THREE.Vector3());
+
+  useFrame((state, dt) => {
+    if (disabled || keys.current.size === 0) return;
+
+    // Build horizontal forward vector from camera direction
+    camera.getWorldDirection(forward.current);
+    forward.current.y = 0;
+    forward.current.normalize();
+
+    // Right vector is perpendicular on XZ plane
+    right.current.crossVectors(forward.current, camera.up).normalize();
+
+    delta.current.set(0, 0, 0);
+
+    const pressed = keys.current;
+    if (pressed.has("w") || pressed.has("arrowup")) delta.current.add(forward.current);
+    if (pressed.has("s") || pressed.has("arrowdown")) delta.current.sub(forward.current);
+    if (pressed.has("a") || pressed.has("arrowleft")) delta.current.sub(right.current);
+    if (pressed.has("d") || pressed.has("arrowright")) delta.current.add(right.current);
+
+    if (delta.current.lengthSq() === 0) return;
+    delta.current.normalize().multiplyScalar(speed * dt);
+
+    // Move camera position
+    camera.position.add(delta.current);
+
+    // Move OrbitControls target so it stays in sync
+    const controls = state.controls as unknown as { target?: THREE.Vector3 };
+    if (controls?.target) {
+      controls.target.add(delta.current);
+    }
+  });
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Adds `WASDControls` component that enables WASD and arrow key camera movement in the 3D live view
- Moves both the camera position and OrbitControls target together on the XZ plane, relative to the camera's current facing direction
- Diagonal movement is normalized to prevent faster speeds
- Controls are disabled during room builder editing and when focus is in form inputs
- Window blur clears pressed keys to prevent stuck-key issues

Closes #332

## Test plan
- [x] Unit tests cover forward movement, diagonal normalization, input focus filtering, blur clearing, disabled state, and listener cleanup
- [x] Integration test verifies `WASDControls` is wired into `LiveViewScene` with `builderActive` disabled prop
- [x] All 1016 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)