### PR TITLE
feat: open browser after install.sh in desktop environments

### DIFF
--- a/packages/server/src/install-script.test.ts
+++ b/packages/server/src/install-script.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync, chmodSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+type RunOptions = {
+  args?: string[];
+  env?: Record<string, string | undefined>;
+  commands?: Record<string, string>;
+};
+
+const REPO_ROOT = resolve(process.cwd());
+const INSTALL_SCRIPT = join(REPO_ROOT, "install.sh");
+const TEST_URL = "https://localhost:62626";
+const tmpRoots: string[] = [];
+
+function addExecutable(binDir: string, name: string, scriptBody: string): void {
+  const filePath = join(binDir, name);
+  writeFileSync(filePath, scriptBody);
+  chmodSync(filePath, 0o755);
+}
+
+function runInstallScript(options: RunOptions = {}) {
+  const root = mkdtempSync(join(tmpdir(), "otterbot-install-test-"));
+  tmpRoots.push(root);
+
+  const binDir = join(root, "bin");
+  const homeDir = join(root, "home");
+  const installDir = join(root, "install-dir");
+  const logPath = join(root, "commands.log");
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(homeDir, { recursive: true });
+
+  const dockerStub = `#!/bin/sh
+echo "docker $*" >> "$TEST_LOG"
+exit 0
+`;
+  addExecutable(binDir, "docker", dockerStub);
+
+  for (const [name, body] of Object.entries(options.commands ?? {})) {
+    addExecutable(binDir, name, body);
+  }
+
+  const env = {
+    ...process.env,
+    HOME: homeDir,
+    OTTERBOT_DIR: installDir,
+    TEST_LOG: logPath,
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    ...options.env,
+  };
+
+  const result = spawnSync("sh", [INSTALL_SCRIPT, ...(options.args ?? [])], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    env,
+  });
+
+  const log = existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
+  return { result, log, installDir };
+}
+
+afterEach(() => {
+  for (const dir of tmpRoots.splice(0, tmpRoots.length)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("install.sh browser opening", () => {
+  it("opens with open when available", () => {
+    const openStub = `#!/bin/sh
+echo "open $*" >> "$TEST_LOG"
+exit 0
+`;
+    const { result, log } = runInstallScript({
+      commands: { open: openStub },
+    });
+
+    expect(result.status).toBe(0);
+    expect(log).toContain(`open ${TEST_URL}`);
+    expect(result.stdout).toContain(`Opened browser to ${TEST_URL}`);
+  });
+
+  it("does not try to open a browser when --no-open is set", () => {
+    const openStub = `#!/bin/sh
+echo "open $*" >> "$TEST_LOG"
+exit 0
+`;
+    const { result, log } = runInstallScript({
+      args: ["--no-open"],
+      commands: { open: openStub },
+    });
+
+    expect(result.status).toBe(0);
+    expect(log).not.toContain("open ");
+    expect(result.stdout).not.toContain("Opened browser to");
+  });
+
+  it("uses xdg-open when running with a display and open is not available", () => {
+    const openFailStub = `#!/bin/sh
+exit 1
+`;
+    const xdgOpenStub = `#!/bin/sh
+echo "xdg-open $*" >> "$TEST_LOG"
+exit 0
+`;
+    const { result, log } = runInstallScript({
+      env: { DISPLAY: ":0" },
+      commands: { open: openFailStub, "xdg-open": xdgOpenStub },
+    });
+
+    expect(result.status).toBe(0);
+    expect(log).toContain(`xdg-open ${TEST_URL}`);
+    expect(result.stdout).toContain(`Opened browser to ${TEST_URL}`);
+  });
+
+  it("falls back to wslview when no display opener is available", () => {
+    const openFailStub = `#!/bin/sh
+exit 1
+`;
+    const wslviewStub = `#!/bin/sh
+echo "wslview $*" >> "$TEST_LOG"
+exit 0
+`;
+    const { result, log } = runInstallScript({
+      env: {
+        DISPLAY: "",
+        WAYLAND_DISPLAY: "",
+      },
+      commands: { open: openFailStub, wslview: wslviewStub },
+    });
+
+    expect(result.status).toBe(0);
+    expect(log).toContain(`wslview ${TEST_URL}`);
+    expect(result.stdout).toContain(`Opened browser to ${TEST_URL}`);
+  });
+});

--- a/packages/server/src/install/__tests__/install-script.test.ts
+++ b/packages/server/src/install/__tests__/install-script.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const REPO_ROOT = process.cwd();
+const INSTALL_SCRIPT = join(REPO_ROOT, "install.sh");
+
+type ScriptResult = ReturnType<typeof spawnSync>;
+
+function makeTempDir(prefix: string) {
+  return mkdtempSync(join(tmpdir(), `${prefix}-`));
+}
+
+function createStubCommand(binDir: string, name: string, body: string) {
+  const path = join(binDir, name);
+  writeFileSync(path, `#!/bin/sh\nset -eu\n${body}\n`, "utf8");
+  chmodSync(path, 0o755);
+}
+
+function setupStubBin(logFile: string) {
+  const binDir = makeTempDir("otterbot-install-bin");
+
+  createStubCommand(
+    binDir,
+    "docker",
+    `
+printf 'docker:%s %s %s\\n' "${'$'}{1:-}" "${'$'}{2:-}" "${'$'}{3:-}" >> "${logFile}"
+if [ "${'$'}#" -ge 1 ] && [ "${'$'}1" = "info" ]; then
+  exit 0
+fi
+if [ "${'$'}#" -ge 2 ] && [ "${'$'}1" = "compose" ] && [ "${'$'}2" = "version" ]; then
+  exit 0
+fi
+if [ "${'$'}#" -ge 2 ] && [ "${'$'}1" = "compose" ] && [ "${'$'}2" = "pull" ]; then
+  exit 0
+fi
+if [ "${'$'}#" -ge 3 ] && [ "${'$'}1" = "compose" ] && [ "${'$'}2" = "up" ] && [ "${'$'}3" = "-d" ]; then
+  exit 0
+fi
+exit 0`
+  );
+
+  createStubCommand(
+    binDir,
+    "open",
+    `
+printf 'open:%s\\n' "${'$'}{1:-}" >> "${logFile}"
+exit 0`
+  );
+
+  createStubCommand(
+    binDir,
+    "openssl",
+    `
+if [ "${'$'}#" -eq 2 ] && [ "${'$'}1" = "rand" ] && [ "${'$'}2" = "-hex" ]; then
+  echo deadbeefdeadbeefdeadbeefdeadbeef
+  exit 0
+fi
+if [ "${'$'}#" -eq 3 ] && [ "${'$'}1" = "rand" ] && [ "${'$'}2" = "-hex" ] && [ "${'$'}3" = "16" ]; then
+  echo deadbeefdeadbeefdeadbeefdeadbeef
+  exit 0
+fi
+echo deadbeefdeadbeefdeadbeefdeadbeef`
+  );
+
+  return binDir;
+}
+
+function runInstall(args: string[], env: NodeJS.ProcessEnv): ScriptResult {
+  return spawnSync("sh", [INSTALL_SCRIPT, ...args], {
+    cwd: REPO_ROOT,
+    env,
+    encoding: "utf8",
+  });
+}
+
+describe("install.sh browser opening", () => {
+  it("shows --no-open in help output", () => {
+    const result = runInstall(["--help"], process.env);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--no-open");
+  });
+
+  it("opens browser after start by default when opener exists", () => {
+    const tempRoot = makeTempDir("otterbot-install-test");
+    const logFile = join(tempRoot, "calls.log");
+    const installDir = join(tempRoot, "install");
+    const binDir = setupStubBin(logFile);
+
+    const result = runInstall([], {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      OTTERBOT_DIR: installDir,
+      HOME: tempRoot,
+    });
+
+    try {
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Otterbot is installed!");
+      expect(result.stdout).toContain("Opened browser to https://localhost:62626");
+
+      const calls = readFileSync(logFile, "utf8");
+      expect(calls).toContain("docker:info");
+      expect(calls).toContain("docker:compose");
+      expect(calls).toContain("open:https://localhost:62626");
+      expect(existsSync(join(installDir, ".env"))).toBe(true);
+      expect(existsSync(join(installDir, "docker-compose.yml"))).toBe(true);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not open browser with --no-open", () => {
+    const tempRoot = makeTempDir("otterbot-install-test");
+    const logFile = join(tempRoot, "calls.log");
+    const installDir = join(tempRoot, "install");
+    const binDir = setupStubBin(logFile);
+
+    const result = runInstall(["--no-open"], {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      OTTERBOT_DIR: installDir,
+      HOME: tempRoot,
+    });
+
+    try {
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Otterbot is installed!");
+      expect(result.stdout).not.toContain("Opened browser to https://localhost:62626");
+
+      const calls = readFileSync(logFile, "utf8");
+      expect(calls).not.toContain("open:https://localhost:62626");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not open browser when --no-start is provided", () => {
+    const tempRoot = makeTempDir("otterbot-install-test");
+    const logFile = join(tempRoot, "calls.log");
+    const installDir = join(tempRoot, "install");
+    const binDir = setupStubBin(logFile);
+
+    const result = runInstall(["--no-start"], {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      OTTERBOT_DIR: installDir,
+      HOME: tempRoot,
+    });
+
+    try {
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Skipping pull & start (--no-start)");
+      expect(result.stdout).not.toContain("Opened browser to https://localhost:62626");
+
+      const calls = readFileSync(logFile, "utf8");
+      expect(calls).not.toContain("docker:compose pull");
+      expect(calls).not.toContain("docker:compose up -d");
+      expect(calls).not.toContain("open:https://localhost:62626");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `try_open_browser()` to `install.sh` that detects desktop environments (macOS `open`, Linux `xdg-open` with X11/Wayland, WSL `wslview`) and opens the browser to `https://localhost:62626` after a successful install
- Adds `--no-open` flag to suppress browser opening
- Skips browser open when `--no-start` is set

Closes #338

## Test plan
- [x] Tests cover `open` (macOS) path
- [x] Tests cover `xdg-open` fallback with `DISPLAY` set
- [x] Tests cover `wslview` fallback (WSL)
- [x] Tests cover `--no-open` suppression
- [x] Tests cover `--no-start` suppression
- [x] All 1027 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)