### PR TITLE
docs: add YouTube demo video script

### DIFF
--- a/docs/demo/otterbot-demo-script.md
+++ b/docs/demo/otterbot-demo-script.md
@@ -1,0 +1,21 @@
+# Otterbot Demo Video Script
+
+## Opening Hook
+
+What if your AI assistant lived on *your* machine, talked to *all* your messaging platforms, and never sent your data to the cloud? Meet **Otterbot** — the open-source personal AI agent you actually own.
+
+## Key Features
+
+- **Multi-platform messaging**: Connect WhatsApp, Telegram, Slack, Discord, and more through dedicated channel adapters
+- **Local-first privacy**: Your data stays on your machine — no third-party servers, no telemetry
+- **WebSocket control plane**: A central hub manages sessions, channels, tools, and events in real time
+- **Extensible skills**: Add capabilities like calendar management, email, and browser automation via a modular plugin system
+- **File-based configuration**: Simple, transparent config files — no hidden databases
+
+## How It Differs from OpenClaw
+
+Otterbot is fully open-source under the MIT license with a focus on simplicity and self-hosting. While inspired by OpenClaw's gateway architecture, Otterbot strips away complexity and keeps everything local and hackable.
+
+## Call to Action
+
+Star the repo on GitHub, spin up your own instance, and join the community. Your AI assistant should work for *you* — not the other way around.


### PR DESCRIPTION
## Summary
- Adds `docs/demo/otterbot-demo-script.md` with a concise ~180-word script for a YouTube demo video
- Highlights key features, privacy-first design, differences from OpenClaw, and a closing call to action

## Test plan
- [ ] Verify the markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)