### PR TITLE
fix: expose issue monitor toggle in project settings

### DIFF
--- a/packages/server/src/github/__tests__/issue-monitor.test.ts
+++ b/packages/server/src/github/__tests__/issue-monitor.test.ts
@@ -165,7 +165,7 @@ describe("GitHubIssueMonitor", () => {
   });
 
   describe("loadFromDb", () => {
-    it("loads all projects with a githubRepo regardless of githubIssueMonitor flag", async () => {
+    it("only loads projects with githubIssueMonitor enabled", async () => {
       const db = getDb();
       configStore.set("github:username", "testuser");
 
@@ -184,7 +184,7 @@ describe("GitHubIssueMonitor", () => {
         })
         .run();
 
-      // Insert a project without issue monitoring — should still be watched
+      // Insert a project without issue monitoring — should NOT be watched
       db.insert(schema.projects)
         .values({
           id: "proj-no-monitor",
@@ -201,18 +201,12 @@ describe("GitHubIssueMonitor", () => {
 
       monitor.loadFromDb();
 
-      // Verify both projects are watched for assigned issues
+      // Verify only the project with issue monitoring enabled is watched
       configStore.set("github:token", "ghp_test");
       await (monitor as any).poll();
-      expect(mockFetchAssignedIssues).toHaveBeenCalledTimes(2);
+      expect(mockFetchAssignedIssues).toHaveBeenCalledTimes(1);
       expect(mockFetchAssignedIssues).toHaveBeenCalledWith(
         "owner/repo",
-        "ghp_test",
-        "testuser",
-        undefined,
-      );
-      expect(mockFetchAssignedIssues).toHaveBeenCalledWith(
-        "owner/other",
         "ghp_test",
         "testuser",
         undefined,

--- a/packages/server/src/github/issue-monitor.ts
+++ b/packages/server/src/github/issue-monitor.ts
@@ -71,7 +71,7 @@ export class GitHubIssueMonitor {
     if (!assignee) return;
 
     for (const project of projects) {
-      if (project.githubRepo) {
+      if (project.githubRepo && project.githubIssueMonitor) {
         this.watchProject(project.id, project.githubRepo, assignee);
       }
     }

--- a/packages/server/src/socket/__tests__/project-set-issue-monitor.test.ts
+++ b/packages/server/src/socket/__tests__/project-set-issue-monitor.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrateDb, resetDb, getDb, schema } from "../../db/index.js";
+import { eq } from "drizzle-orm";
+
+// Mock auth
+const configStore = new Map<string, string>();
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn((key: string) => configStore.get(key)),
+  setConfig: vi.fn((key: string, value: string) => configStore.set(key, value)),
+  deleteConfig: vi.fn((key: string) => configStore.delete(key)),
+}));
+
+// Mock github-service
+vi.mock("../../github/github-service.js", () => ({
+  cloneRepo: vi.fn(),
+  getRepoDefaultBranch: vi.fn().mockResolvedValue("main"),
+}));
+
+// Mock TTS
+vi.mock("../../tts/tts.js", () => ({
+  isTTSEnabled: vi.fn(() => false),
+  getConfiguredTTSProvider: vi.fn(() => null),
+  stripMarkdown: vi.fn((s: string) => s),
+}));
+
+// Mock search providers
+vi.mock("../../tools/search/providers.js", () => ({
+  getConfiguredSearchProvider: vi.fn(() => null),
+}));
+
+// Mock desktop module
+vi.mock("../../desktop/desktop.js", () => ({
+  isDesktopEnabled: vi.fn(() => false),
+  getDesktopConfig: vi.fn(() => ({})),
+}));
+
+// Mock model-packs
+vi.mock("../../models3d/model-packs.js", () => ({
+  getRandomModelPackId: vi.fn(() => "pack-1"),
+}));
+
+// Mock LLM adapter
+vi.mock("../../llm/adapter.js", () => ({
+  stream: vi.fn(),
+  resolveProviderCredentials: vi.fn(() => ({ type: "anthropic" })),
+}));
+
+// Mock circuit breaker
+vi.mock("../../llm/circuit-breaker.js", () => ({
+  isProviderAvailable: vi.fn(() => true),
+  getCircuitBreaker: vi.fn(() => ({ recordSuccess: vi.fn(), recordFailure: vi.fn(), remainingCooldownMs: 0 })),
+}));
+
+// Mock settings/model-pricing
+vi.mock("../../settings/model-pricing.js", () => ({
+  calculateCost: vi.fn(() => 0),
+}));
+
+// Mock kimi-tool-parser
+vi.mock("../../llm/kimi-tool-parser.js", () => ({
+  containsKimiToolMarkup: vi.fn(() => false),
+  findToolMarkupStart: vi.fn(() => -1),
+  formatToolsForPrompt: vi.fn(() => ""),
+  parseKimiToolCalls: vi.fn(() => ({ cleanText: "", toolCalls: [] })),
+  usesTextToolCalling: vi.fn(() => false),
+}));
+
+// Mock tool-factory
+vi.mock("../../tools/tool-factory.js", () => ({
+  createTools: vi.fn(() => ({})),
+}));
+
+// Mock git utils
+vi.mock("../../utils/git.js", () => ({
+  initGitRepo: vi.fn(),
+  createInitialCommit: vi.fn(),
+}));
+
+// Mock opencode-client
+vi.mock("../../tools/opencode-client.js", () => ({
+  TASK_COMPLETE_SENTINEL: "◊◊TASK_COMPLETE_9f8e7d◊◊",
+  OpenCodeClient: vi.fn().mockImplementation(() => ({
+    executeTask: vi.fn().mockResolvedValue({ success: true, sessionId: "s", summary: "Done", diff: null }),
+  })),
+}));
+
+import { setupSocketHandlers } from "../handlers.js";
+import type { WorkspaceManager } from "../../workspace/workspace.js";
+
+// Track socket event handlers
+type SocketHandler = (...args: any[]) => void;
+const socketHandlers = new Map<string, SocketHandler>();
+
+function createMockSocket() {
+  return {
+    on: vi.fn((event: string, handler: SocketHandler) => {
+      socketHandlers.set(event, handler);
+    }),
+  };
+}
+
+function createMockIo() {
+  const sockets: any[] = [];
+  return {
+    emit: vi.fn(),
+    on: vi.fn((event: string, handler: (socket: any) => void) => {
+      if (event === "connection") {
+        for (const s of sockets) {
+          handler(s);
+        }
+      }
+    }),
+    _addSocket: (s: any) => sockets.push(s),
+  };
+}
+
+function createMockBus() {
+  return {
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    send: vi.fn(() => ({
+      id: "msg-1",
+      fromAgentId: "",
+      toAgentId: "",
+      type: "report",
+      content: "",
+      timestamp: new Date().toISOString(),
+    })),
+    getHistory: vi.fn(() => ({ messages: [], hasMore: false })),
+    request: vi.fn(),
+    onBroadcast: vi.fn(),
+    offBroadcast: vi.fn(),
+  };
+}
+
+function createMockCoo() {
+  return {
+    spawnTeamLeadForManualProject: vi.fn(),
+    getTeamLeads: vi.fn(() => new Map()),
+    toData: vi.fn(() => ({ model: "test", provider: "test" })),
+    getCurrentConversationId: vi.fn(() => null),
+    destroy: vi.fn(),
+  };
+}
+
+function createMockRegistry() {
+  return {
+    list: vi.fn(() => []),
+    get: vi.fn(() => null),
+  };
+}
+
+function createMockWorkspace(): WorkspaceManager {
+  return {
+    createProject: vi.fn(),
+    repoPath: vi.fn((projectId: string) => `/tmp/test-workspace/projects/${projectId}/repo`),
+    projectPath: vi.fn((projectId: string) => `/tmp/test-workspace/projects/${projectId}`),
+    getRoot: vi.fn(() => "/tmp/test-workspace"),
+    validateAccess: vi.fn(() => true),
+  } as unknown as WorkspaceManager;
+}
+
+function createMockIssueMonitor() {
+  return {
+    watchProject: vi.fn(),
+    unwatchProject: vi.fn(),
+    loadFromDb: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    setPipelineManager: vi.fn(),
+  };
+}
+
+function insertProject(overrides: { id: string; githubRepo?: string | null; githubIssueMonitor?: boolean }) {
+  const db = getDb();
+  db.insert(schema.projects)
+    .values({
+      id: overrides.id,
+      name: "Test Project",
+      description: "desc",
+      status: "active",
+      githubRepo: overrides.githubRepo === null ? null : (overrides.githubRepo ?? "owner/repo"),
+      githubBranch: overrides.githubRepo === null ? null : "main",
+      githubIssueMonitor: overrides.githubIssueMonitor ?? false,
+      rules: [],
+      createdAt: new Date().toISOString(),
+    })
+    .run();
+}
+
+describe("project:set-issue-monitor socket handler", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-issue-monitor-test-"));
+    resetDb();
+    configStore.clear();
+    socketHandlers.clear();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+  });
+
+  afterEach(() => {
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function setupHandler(issueMonitor?: any) {
+    const mockSocket = createMockSocket();
+    const mockIo = createMockIo();
+    const mockBus = createMockBus();
+    const mockCoo = createMockCoo();
+    const mockRegistry = createMockRegistry();
+    const mockWorkspace = createMockWorkspace();
+    const mockIssueMonitor = issueMonitor ?? createMockIssueMonitor();
+
+    mockIo._addSocket(mockSocket);
+
+    setupSocketHandlers(
+      mockIo as any,
+      mockBus as any,
+      mockCoo as any,
+      mockRegistry as any,
+      undefined,
+      { workspace: mockWorkspace, issueMonitor: mockIssueMonitor as any },
+    );
+
+    return { mockSocket, mockIo, mockBus, mockCoo, mockWorkspace, mockIssueMonitor };
+  }
+
+  it("enables issue monitor for a GitHub project", async () => {
+    insertProject({ id: "proj-1", githubRepo: "owner/repo", githubIssueMonitor: false });
+    configStore.set("github:username", "testuser");
+
+    const { mockIo, mockIssueMonitor } = setupHandler();
+    const handler = socketHandlers.get("project:set-issue-monitor");
+    expect(handler).toBeDefined();
+
+    const callback = vi.fn();
+    await handler!({ projectId: "proj-1", enabled: true }, callback);
+
+    expect(callback).toHaveBeenCalledWith({ ok: true });
+
+    // Verify DB was updated
+    const db = getDb();
+    const project = db.select().from(schema.projects).where(eq(schema.projects.id, "proj-1")).get();
+    expect(project!.githubIssueMonitor).toBe(true);
+
+    // Verify issue monitor was started
+    expect(mockIssueMonitor.watchProject).toHaveBeenCalledWith("proj-1", "owner/repo", "testuser");
+
+    // Verify project:updated was emitted
+    expect(mockIo.emit).toHaveBeenCalledWith(
+      "project:updated",
+      expect.objectContaining({ id: "proj-1", githubIssueMonitor: true }),
+    );
+  });
+
+  it("disables issue monitor for a GitHub project", async () => {
+    insertProject({ id: "proj-2", githubRepo: "owner/repo", githubIssueMonitor: true });
+
+    const { mockIssueMonitor } = setupHandler();
+    const handler = socketHandlers.get("project:set-issue-monitor");
+    const callback = vi.fn();
+
+    await handler!({ projectId: "proj-2", enabled: false }, callback);
+
+    expect(callback).toHaveBeenCalledWith({ ok: true });
+
+    // Verify DB was updated
+    const db = getDb();
+    const project = db.select().from(schema.projects).where(eq(schema.projects.id, "proj-2")).get();
+    expect(project!.githubIssueMonitor).toBe(false);
+
+    // Verify issue monitor was stopped
+    expect(mockIssueMonitor.unwatchProject).toHaveBeenCalledWith("proj-2");
+  });
+
+  it("rejects when project not found", async () => {
+    setupHandler();
+    const handler = socketHandlers.get("project:set-issue-monitor");
+    const callback = vi.fn();
+
+    await handler!({ projectId: "nonexistent", enabled: true }, callback);
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, error: "Project not found" }),
+    );
+  });
+
+  it("rejects for non-GitHub project", async () => {
+    insertProject({ id: "proj-local", githubRepo: null });
+
+    setupHandler();
+    const handler = socketHandlers.get("project:set-issue-monitor");
+    const callback = vi.fn();
+
+    await handler!({ projectId: "proj-local", enabled: true }, callback);
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, error: "Issue monitoring requires a GitHub repository" }),
+    );
+  });
+
+  it("works without issue monitor dependency", async () => {
+    insertProject({ id: "proj-3", githubRepo: "owner/repo", githubIssueMonitor: false });
+
+    const mockSocket = createMockSocket();
+    const mockIo = createMockIo();
+    const mockBus = createMockBus();
+    const mockCoo = createMockCoo();
+    const mockRegistry = createMockRegistry();
+    const mockWorkspace = createMockWorkspace();
+
+    mockIo._addSocket(mockSocket);
+
+    setupSocketHandlers(
+      mockIo as any,
+      mockBus as any,
+      mockCoo as any,
+      mockRegistry as any,
+      undefined,
+      { workspace: mockWorkspace, issueMonitor: undefined },
+    );
+
+    const handler = socketHandlers.get("project:set-issue-monitor");
+    const callback = vi.fn();
+
+    await handler!({ projectId: "proj-3", enabled: true }, callback);
+
+    expect(callback).toHaveBeenCalledWith({ ok: true });
+
+    // DB should still be updated even without issue monitor
+    const db = getDb();
+    const project = db.select().from(schema.projects).where(eq(schema.projects.id, "proj-3")).get();
+    expect(project!.githubIssueMonitor).toBe(true);
+  });
+});

--- a/packages/server/src/socket/handlers.ts
+++ b/packages/server/src/socket/handlers.ts
@@ -755,6 +755,59 @@ export function setupSocketHandlers(
       }
     });
 
+    // Toggle issue monitor for a project
+    socket.on("project:set-issue-monitor", (data, callback) => {
+      try {
+        const db = getDb();
+        const project = db
+          .select()
+          .from(schema.projects)
+          .where(eq(schema.projects.id, data.projectId))
+          .get();
+
+        if (!project) {
+          callback?.({ ok: false, error: "Project not found" });
+          return;
+        }
+
+        if (!project.githubRepo) {
+          callback?.({ ok: false, error: "Issue monitoring requires a GitHub repository" });
+          return;
+        }
+
+        db.update(schema.projects)
+          .set({ githubIssueMonitor: data.enabled })
+          .where(eq(schema.projects.id, data.projectId))
+          .run();
+
+        // Start or stop monitoring
+        if (deps?.issueMonitor) {
+          if (data.enabled) {
+            const ghUsername = getConfig("github:username");
+            if (ghUsername && project.githubRepo) {
+              deps.issueMonitor.watchProject(data.projectId, project.githubRepo, ghUsername);
+            }
+          } else {
+            deps.issueMonitor.unwatchProject(data.projectId);
+          }
+        }
+
+        // Emit project:updated so UI refreshes
+        const updated = db
+          .select()
+          .from(schema.projects)
+          .where(eq(schema.projects.id, data.projectId))
+          .get();
+        if (updated) {
+          io.emit("project:updated", updated as any);
+        }
+
+        callback?.({ ok: true });
+      } catch (err) {
+        callback?.({ ok: false, error: err instanceof Error ? err.message : "Failed to update issue monitor setting" });
+      }
+    });
+
     // Retrieve agent activity (bus messages + persisted activity records)
     socket.on("agent:activity", (data, callback) => {
       const db = getDb();

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -258,6 +258,12 @@ export interface ClientToServerEvents {
     callback?: (ack: { ok: boolean; error?: string }) => void,
   ) => void;
 
+  // Issue monitor toggle
+  "project:set-issue-monitor": (
+    data: { projectId: string; enabled: boolean },
+    callback?: (ack: { ok: boolean; error?: string }) => void,
+  ) => void;
+
   // Target branch
   "project:get-branch": (
     data: { projectId: string },

--- a/packages/web/src/components/project/ProjectSettings.tsx
+++ b/packages/web/src/components/project/ProjectSettings.tsx
@@ -37,6 +37,7 @@ export function ProjectSettings({ projectId }: { projectId: string }) {
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isGitHubProject, setIsGitHubProject] = useState(false);
+  const [issueMonitor, setIssueMonitor] = useState(false);
   const [targetBranch, setTargetBranch] = useState("");
 
   const openCodeEnabled = useSettingsStore((s) => s.openCodeEnabled);
@@ -48,9 +49,10 @@ export function ProjectSettings({ projectId }: { projectId: string }) {
   useEffect(() => {
     const socket = getSocket();
 
-    // Check if project has GitHub integration
+    // Check if project has GitHub integration and load issue monitor state
     socket.emit("project:get", { projectId }, (project) => {
       setIsGitHubProject(!!project?.githubRepo);
+      setIssueMonitor(!!project?.githubIssueMonitor);
     });
 
     // Load target branch
@@ -162,6 +164,11 @@ export function ProjectSettings({ projectId }: { projectId: string }) {
         socket.emit("project:set-branch", { projectId, branch: targetBranch.trim() });
       }
 
+      // Save issue monitor setting
+      if (isGitHubProject) {
+        socket.emit("project:set-issue-monitor", { projectId, enabled: issueMonitor });
+      }
+
       // Also save agent assignments (for non-pipeline mode)
       socket.emit("project:set-agent-assignments", { projectId, assignments }, (ack2) => {
         setSaving(false);
@@ -198,6 +205,29 @@ export function ProjectSettings({ projectId }: { projectId: string }) {
               placeholder="main"
               className="mt-2 text-sm bg-secondary border border-border rounded px-3 py-1.5 w-full max-w-xs focus:outline-none focus:ring-1 focus:ring-primary"
             />
+          </div>
+        )}
+
+        {/* Issue Monitor toggle (GitHub projects only) */}
+        {isGitHubProject && (
+          <div>
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-sm font-semibold">Issue Monitor</h2>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Automatically create tasks from GitHub issues assigned to your bot
+                </p>
+              </div>
+              <label className="relative inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={issueMonitor}
+                  onChange={(e) => { setIssueMonitor(e.target.checked); setSaved(false); }}
+                  className="sr-only peer"
+                />
+                <div className="w-9 h-5 bg-muted rounded-full peer peer-checked:bg-primary transition-colors after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full" />
+              </label>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Adds a **project:set-issue-monitor** socket event so the issue monitor setting can be toggled after project creation
- Adds an **Issue Monitor** toggle switch to the Project Settings UI (visible for GitHub projects only)
- Fixes `loadFromDb` in `GitHubIssueMonitor` to only watch projects that have `githubIssueMonitor` enabled (previously watched all projects with a GitHub repo)
- When toggled on, immediately starts watching for assigned issues; when toggled off, immediately stops

Closes #361

## Test plan
- [x] New test file `project-set-issue-monitor.test.ts` with 5 tests covering:
  - Enabling issue monitor for a GitHub project
  - Disabling issue monitor for a GitHub project
  - Rejecting when project not found
  - Rejecting for non-GitHub projects
  - Working without issue monitor dependency
- [x] Updated existing `issue-monitor.test.ts` to verify `loadFromDb` respects the `githubIssueMonitor` flag
- [x] All 1068 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)