### PR TITLE
fix: spawn backlog workers when tasks move to done via PR merge

### DIFF
--- a/packages/server/src/agents/prompts/team-lead.ts
+++ b/packages/server/src/agents/prompts/team-lead.ts
@@ -69,8 +69,9 @@ Task F: "Final verification and report"      → blockedBy: [E]
 - **Always pass \`taskId\` when calling \`spawn_worker\`** — this automatically moves the task to "in_progress" and assigns the worker. You do NOT need to call \`update_task\` for this.
 - **Only spawn workers for UNBLOCKED tasks.** Do NOT spawn workers for \`[BLOCKED]\` tasks — the system will refuse the assignment. Blocked tasks automatically become available when their blockers complete.
 - When a worker reports back, **you must evaluate the report** and use \`update_task\` to move the task:
-  - To "done" if the worker succeeded
+  - To "done" if the worker succeeded (but **NEVER move a task with a PR to "done"** — the PR Monitor handles that automatically when the PR is merged)
   - To "backlog" (with \`assigneeAgentId: ""\`) if the worker failed, so it can be retried
+- **Tasks with PRs:** When a worker creates a PR, the task moves to "in_review". Do NOT try to move it to "done" yourself. The PR Monitor will automatically move it to "done" once the PR is merged on GitHub.
 - **Replacing a failed task:** If you need to create a new task to replace a failed one, \`delete_task\` the old task first. This automatically removes it from other tasks' \`blockedBy\` lists so they don't stay stuck. Then create the new task and update any dependencies.
 - Use \`list_tasks\` only when you first receive a directive and need to see existing state. Do NOT use it to poll for changes.
 

--- a/packages/server/src/agents/team-lead.ts
+++ b/packages/server/src/agents/team-lead.ts
@@ -752,6 +752,7 @@ export class TeamLead extends BaseAgent {
     if (reportingTaskId && this._pipelineManager?.isPipelineTask(reportingTaskId)) {
       console.log(`[TeamLead ${this.id}] Pipeline-managed task ${reportingTaskId} — routing to PipelineManager`);
       await this._pipelineManager.advancePipeline(reportingTaskId, message.content, detectedBranch);
+      await this.autoSpawnUnblockedTasks();
       return;
     }
 
@@ -2195,6 +2196,12 @@ export class TeamLead extends BaseAgent {
     const delLabel = this.taskLabel(existing);
     const unblockedMsg = unblockedCount > 0 ? ` ${unblockedCount} task(s) unblocked.` : "";
     return `${delLabel} deleted.${unblockedMsg}`;
+  }
+
+  /** Called by external callers (PR Monitor, Merge Queue) when a task moves to "done" to trigger backlog spawning. */
+  async notifyTaskDone(taskId: string): Promise<void> {
+    this.checkUnblockedTasks(taskId);
+    await this.autoSpawnUnblockedTasks();
   }
 
   /** Log which tasks become unblocked when a task completes. No auto-spawning — the continuation loop picks them up. */

--- a/packages/server/src/agents/team-lead.ts
+++ b/packages/server/src/agents/team-lead.ts
@@ -2016,7 +2016,7 @@ export class TeamLead extends BaseAgent {
 
     // Guard: tasks with an open PR should go to in_review, not done.
     // Only the PR monitor should move them to done (when the PR is actually merged).
-    if (updates.column === "done" && existing.column === "in_progress" && (existing as any).prNumber) {
+    if (updates.column === "done" && (existing as any).prNumber) {
       console.warn(
         `[TeamLead ${this.id}] Auto-correcting update_task: task "${existing.title}" (${taskId}) has PR #${(existing as any).prNumber} — ` +
         `routing to "in_review" instead of "done". The PR monitor will move it to done when the PR is merged.`,

--- a/packages/server/src/github/__tests__/pr-monitor.test.ts
+++ b/packages/server/src/github/__tests__/pr-monitor.test.ts
@@ -34,7 +34,7 @@ import { GitHubPRMonitor } from "../pr-monitor.js";
 
 // Create mock COO
 function createMockCoo() {
-  const teamLeads = new Map<string, { id: string }>();
+  const teamLeads = new Map<string, { id: string; notifyTaskDone?: ReturnType<typeof vi.fn> }>();
   return {
     getTeamLeads: vi.fn(() => teamLeads),
     bus: {
@@ -162,6 +162,35 @@ describe("GitHubPRMonitor", () => {
         "kanban:task-updated",
         expect.objectContaining({ id: "task-1", column: "done" }),
       );
+    });
+
+    it("calls notifyTaskDone on TeamLead when PR is merged", async () => {
+      const db = getDb();
+      insertProject(db, "proj-1", "owner/repo");
+      insertTask(db, {
+        id: "task-notify-1",
+        projectId: "proj-1",
+        title: "#99: Notify test",
+        column: "in_review",
+        prNumber: 99,
+        prBranch: "feat/notify-99",
+      });
+
+      const mockNotify = vi.fn().mockResolvedValue(undefined);
+      mockCoo._teamLeads.set("proj-1", { id: "tl-1", notifyTaskDone: mockNotify });
+
+      configStore.set("github:token", "ghp_test");
+      mockFetchPullRequest.mockResolvedValue({
+        number: 99,
+        state: "closed",
+        merged: true,
+        head: { ref: "feat/notify-99", sha: "notify123" },
+        base: { ref: "main" },
+      });
+
+      await (monitor as any).poll();
+
+      expect(mockNotify).toHaveBeenCalledWith("task-notify-1");
     });
   });
 

--- a/packages/server/src/github/pr-monitor.ts
+++ b/packages/server/src/github/pr-monitor.ts
@@ -150,6 +150,12 @@ export class GitHubPRMonitor {
       }
 
       console.log(`[PRMonitor] PR #${prNumber} merged — task ${task.id} → done`);
+
+      // Notify TeamLead to spawn backlog workers
+      const teamLead = this.coo.getTeamLeads().get(task.projectId);
+      if (teamLead) {
+        await teamLead.notifyTaskDone(task.id);
+      }
       return;
     }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -942,6 +942,7 @@ async function main() {
       prMonitor.setMergeQueue(mergeQueue);
       pipelineManager.setMergeQueue(mergeQueue);
       mergeQueue.setPipelineManager(pipelineManager);
+      mergeQueue.setCoo(coo);
       coo.setPipelineManager(pipelineManager);
 
       setupSocketHandlers(io, bus, coo, registry, {

--- a/packages/server/src/merge-queue/__tests__/merge-queue.test.ts
+++ b/packages/server/src/merge-queue/__tests__/merge-queue.test.ts
@@ -52,6 +52,19 @@ function createMockWorkspace() {
   } as any;
 }
 
+function createMockCoo(teamLeadOverrides?: Record<string, { notifyTaskDone: ReturnType<typeof vi.fn> }>) {
+  const teamLeads = new Map<string, { notifyTaskDone: ReturnType<typeof vi.fn> }>();
+  if (teamLeadOverrides) {
+    for (const [key, val] of Object.entries(teamLeadOverrides)) {
+      teamLeads.set(key, val);
+    }
+  }
+  return {
+    getTeamLeads: vi.fn(() => teamLeads),
+    _teamLeads: teamLeads,
+  } as any;
+}
+
 function createMockPipelineManager(overrides?: {
   isEnabled?: boolean;
   startReReview?: (...args: unknown[]) => Promise<void>;
@@ -384,6 +397,32 @@ describe("MergeQueue", () => {
       expect(dbTask?.column).toBe("done");
     });
 
+    it("calls notifyTaskDone on TeamLead after direct merge", async () => {
+      const task = insertTask({ id: "task-pe-notify", prNumber: 33, prBranch: "feat/notify" });
+      insertProject();
+      const entry = insertMergeQueueEntry({
+        id: "entry-pe-notify",
+        taskId: task.id,
+        prNumber: 33,
+        prBranch: "feat/notify",
+      });
+      configStore.set("github:token", "test-token");
+      mockRebaseBranch.mockReturnValue(true);
+      mockForcePushBranch.mockReturnValue(undefined);
+      mockMergePullRequest.mockResolvedValue(undefined);
+
+      const mockPM = createMockPipelineManager({ isEnabled: false });
+      mq.setPipelineManager(mockPM);
+
+      const mockNotify = vi.fn().mockResolvedValue(undefined);
+      const mockCoo = createMockCoo({ [PROJECT_ID]: { notifyTaskDone: mockNotify } });
+      mq.setCoo(mockCoo);
+
+      await (mq as any).processEntry(entry.id);
+
+      expect(mockNotify).toHaveBeenCalledWith(task.id);
+    });
+
     it("rebase conflict → status conflict", async () => {
       const task = insertTask({ id: "task-pe-conflict", prNumber: 32, prBranch: "feat/conflict" });
       insertProject();
@@ -499,6 +538,27 @@ describe("MergeQueue", () => {
       const dbTask = getTask(task.id);
       expect(dbTask?.column).toBe("done");
       expect(dbTask?.completionReport).toContain("merged");
+    });
+
+    it("calls notifyTaskDone on TeamLead when PR merged externally", async () => {
+      const task = insertTask({ id: "task-sync-notify", prNumber: 65 });
+      insertProject();
+      insertMergeQueueEntry({
+        id: "entry-sync-notify",
+        taskId: task.id,
+        prNumber: 65,
+        status: "queued",
+      });
+      configStore.set("github:token", "test-token");
+      mockFetchPullRequest.mockResolvedValue({ merged: true, state: "closed" });
+
+      const mockNotify = vi.fn().mockResolvedValue(undefined);
+      const mockCoo = createMockCoo({ [PROJECT_ID]: { notifyTaskDone: mockNotify } });
+      mq.setCoo(mockCoo);
+
+      await (mq as any).syncExternalState();
+
+      expect(mockNotify).toHaveBeenCalledWith(task.id);
     });
 
     it("removes entry when PR closed without merge", async () => {

--- a/packages/server/src/merge-queue/merge-queue.ts
+++ b/packages/server/src/merge-queue/merge-queue.ts
@@ -23,6 +23,7 @@ import { formatBotComment } from "../utils/github-comments.js";
 import type { Scheduler } from "../schedulers/scheduler-registry.js";
 import type { PipelineManager } from "../pipeline/pipeline-manager.js";
 import type { WorkspaceManager } from "../workspace/workspace.js";
+import type { COO } from "../agents/coo.js";
 
 type TypedServer = Server<ClientToServerEvents, ServerToClientEvents>;
 
@@ -31,6 +32,7 @@ export class MergeQueue implements Scheduler {
   private workspace: WorkspaceManager;
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private pipelineManager: PipelineManager | null = null;
+  private coo: COO | null = null;
   private processing = false;
 
   constructor(io: TypedServer, workspace: WorkspaceManager) {
@@ -40,6 +42,10 @@ export class MergeQueue implements Scheduler {
 
   setPipelineManager(pm: PipelineManager): void {
     this.pipelineManager = pm;
+  }
+
+  setCoo(coo: COO): void {
+    this.coo = coo;
   }
 
   // ─── Scheduler interface ──────────────────────────────────────────
@@ -306,6 +312,14 @@ export class MergeQueue implements Scheduler {
           }
 
           console.log(`[MergeQueue] PR #${entry.prNumber} merged externally — task ${entry.taskId} → done`);
+
+          // Notify TeamLead to spawn backlog workers
+          if (this.coo) {
+            const teamLead = this.coo.getTeamLeads().get(entry.projectId);
+            if (teamLead) {
+              await teamLead.notifyTaskDone(entry.taskId);
+            }
+          }
         } else if (pr.state === "closed") {
           // Closed without merge — remove from queue, task → backlog
           db.delete(schema.mergeQueue).where(eq(schema.mergeQueue.id, entry.id)).run();
@@ -504,6 +518,14 @@ export class MergeQueue implements Scheduler {
       this.emitQueueUpdated();
 
       console.log(`[MergeQueue] PR #${entry.prNumber} merged successfully`);
+
+      // Notify TeamLead to spawn backlog workers
+      if (this.coo) {
+        const teamLead = this.coo.getTeamLeads().get(entry.projectId);
+        if (teamLead) {
+          await teamLead.notifyTaskDone(entry.taskId);
+        }
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
 


### PR DESCRIPTION
## Summary

- **Backlog tasks were never spawned** when tasks moved to "done" through PR Monitor (merge detected) or Merge Queue (external merge / queue merge), because those code paths didn't notify the TeamLead
- **Pipeline early return** in `handleWorkerReport` skipped `autoSpawnUnblockedTasks()` after routing to `advancePipeline()`

### Changes
- Add `notifyTaskDone()` public method on TeamLead that calls `checkUnblockedTasks()` + `autoSpawnUnblockedTasks()`
- PR Monitor calls `teamLead.notifyTaskDone()` after moving a merged PR's task to done
- Merge Queue gains a COO reference (`setCoo()`) and calls `notifyTaskDone()` in both `syncExternalState` and `doMerge`
- Wire `mergeQueue.setCoo(coo)` in `index.ts`
- Add `autoSpawnUnblockedTasks()` after pipeline early return in `handleWorkerReport`

## Test plan
- [x] PR Monitor test: verify `notifyTaskDone` called on TeamLead when PR is merged
- [x] Merge Queue test: verify `notifyTaskDone` called in `syncExternalState` (external merge)
- [x] Merge Queue test: verify `notifyTaskDone` called in `doMerge` (queue merge)
- [x] All 1111 existing tests pass
- [x] Type-check passes