### PR TITLE
feat: support multi-provider selection in setup wizard

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1363,6 +1363,7 @@ async function main() {
       openCodeApiKey?: string;
       openCodeBaseUrl?: string;
       openCodeInteractive?: boolean;
+      additionalProviders?: Array<{ type: string; name: string; apiKey?: string; baseUrl?: string }>;
     };
   }>("/api/setup/complete", async (req, reply) => {
     if (isSetupComplete()) {
@@ -1375,7 +1376,7 @@ async function main() {
       return { error: "Passphrase not set. Start setup from the beginning." };
     }
 
-    const { provider, providerName, model, apiKey, baseUrl, userName, userAvatar, userBio, userTimezone, ttsVoice, ttsProvider, userModelPackId, userGearConfig, cooName, cooModelPackId, cooGearConfig, searchProvider, searchApiKey, searchBaseUrl, adminName, adminModelPackId, adminGearConfig, openCodeEnabled, openCodeProvider, openCodeModel, openCodeApiKey, openCodeBaseUrl, openCodeInteractive } = req.body;
+    const { provider, providerName, model, apiKey, baseUrl, userName, userAvatar, userBio, userTimezone, ttsVoice, ttsProvider, userModelPackId, userGearConfig, cooName, cooModelPackId, cooGearConfig, searchProvider, searchApiKey, searchBaseUrl, adminName, adminModelPackId, adminGearConfig, openCodeEnabled, openCodeProvider, openCodeModel, openCodeApiKey, openCodeBaseUrl, openCodeInteractive, additionalProviders } = req.body;
 
     if (!provider || !model) {
       reply.code(400);
@@ -1405,6 +1406,20 @@ async function main() {
       apiKey: apiKey,
       baseUrl: baseUrl,
     });
+
+    // Create additional providers selected in the wizard
+    if (additionalProviders && Array.isArray(additionalProviders)) {
+      for (const ap of additionalProviders) {
+        if (ap.type && ap.name) {
+          createProvider({
+            name: ap.name,
+            type: ap.type as ProviderType,
+            apiKey: ap.apiKey,
+            baseUrl: ap.baseUrl,
+          });
+        }
+      }
+    }
 
     setConfig("coo_provider", namedProvider.id);
     setConfig("coo_model", model);

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -31,6 +31,14 @@ export interface ModelOption {
   source: "discovered" | "custom";
 }
 
+/** Provider entry submitted during setup wizard (multi-provider). */
+export interface SetupProviderEntry {
+  type: string;
+  name: string;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
 /** Per-agent-type model/provider override (stored in config table) */
 export interface AgentModelOverride {
   registryEntryId: string;

--- a/packages/web/src/components/setup/SetupWizard.tsx
+++ b/packages/web/src/components/setup/SetupWizard.tsx
@@ -3,7 +3,7 @@ import { useAuthStore } from "../../stores/auth-store";
 import { useModelPackStore } from "../../stores/model-pack-store";
 import { CharacterSelect } from "../character-select/CharacterSelect";
 import { DEFAULT_AVATARS } from "./default-avatars";
-import type { GearConfig } from "@otterbot/shared";
+import type { GearConfig, SetupProviderEntry } from "@otterbot/shared";
 import { ModelPricingPrompt } from "../settings/ModelPricingPrompt";
 import { saveWizardState, loadWizardState, clearWizardState } from "../../hooks/use-setup-persistence";
 import { PasswordInput } from "../ui/PasswordInput";
@@ -125,6 +125,9 @@ export function SetupWizard() {
   const [model, setModel] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
+
+  // Additional (non-primary) providers selected in the wizard
+  const [additionalProviders, setAdditionalProviders] = useState<SetupProviderEntry[]>([]);
   const [passphrase, setPassphrase] = useState("");
   const [confirmPassphrase, setConfirmPassphrase] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -230,12 +233,14 @@ export function SetupWizard() {
     if (typeof saved.openCodeModel === "string") setOpenCodeModel(saved.openCodeModel);
     if (typeof saved.openCodeApiKey === "string") setOpenCodeApiKey(saved.openCodeApiKey);
     if (typeof saved.openCodeBaseUrl === "string") setOpenCodeBaseUrl(saved.openCodeBaseUrl);
+    if (Array.isArray(saved.additionalProviders)) setAdditionalProviders(saved.additionalProviders as SetupProviderEntry[]);
   }, []);
 
   // Persist wizard state to sessionStorage on change
   useEffect(() => {
     saveWizardState({
       step, provider, providerName, model, apiKey, baseUrl,
+      additionalProviders,
       displayName, avatar, bio, timezone,
       characterPackId, characterGearConfig,
       cooName, cooModelPackId, cooGearConfig,
@@ -247,6 +252,7 @@ export function SetupWizard() {
     });
   }, [
     step, provider, providerName, model, apiKey, baseUrl,
+    additionalProviders,
     displayName, avatar, bio, timezone,
     characterPackId, characterGearConfig,
     cooName, cooModelPackId, cooGearConfig,
@@ -391,7 +397,34 @@ export function SetupWizard() {
     } else if (id === "lmstudio" && !baseUrl) {
       setBaseUrl("http://localhost:1234/v1");
     }
+    // Remove from additional if it was there
+    setAdditionalProviders((prev) => prev.filter((p) => p.type !== id));
     setError(null);
+  };
+
+  const handleToggleAdditionalProvider = (id: string) => {
+    if (id === provider) return; // Can't toggle the primary provider here
+    setAdditionalProviders((prev) => {
+      const exists = prev.find((p) => p.type === id);
+      if (exists) {
+        return prev.filter((p) => p.type !== id);
+      }
+      const typeMeta = providerTypes.find((pt) => pt.type === id);
+      const entry: SetupProviderEntry = {
+        type: id,
+        name: typeMeta?.label || id,
+      };
+      if (id === "ollama") entry.baseUrl = "http://localhost:11434/api";
+      if (id === "lmstudio") entry.baseUrl = "http://localhost:1234/v1";
+      return [...prev, entry];
+    });
+    setError(null);
+  };
+
+  const updateAdditionalProvider = (type: string, updates: Partial<SetupProviderEntry>) => {
+    setAdditionalProviders((prev) =>
+      prev.map((p) => (p.type === type ? { ...p, ...updates } : p)),
+    );
   };
 
   const handleNextFromPassphrase = async () => {
@@ -426,6 +459,18 @@ export function SetupWizard() {
     if (NEEDS_BASE_URL.has(provider) && !baseUrl) {
       setError("A base URL is required for this provider");
       return;
+    }
+    // Validate additional providers
+    for (const ap of additionalProviders) {
+      const meta = providerTypes.find((pt) => pt.type === ap.type);
+      if (meta?.needsApiKey && !ap.apiKey) {
+        setError(`An API key is required for ${meta.label}`);
+        return;
+      }
+      if (meta?.needsBaseUrl && !ap.baseUrl) {
+        setError(`A base URL is required for ${meta?.label || ap.type}`);
+        return;
+      }
     }
     setError(null);
     setStep(4);
@@ -507,6 +552,7 @@ export function SetupWizard() {
       model,
       apiKey: apiKey || undefined,
       baseUrl: baseUrl || undefined,
+      additionalProviders: additionalProviders.length > 0 ? additionalProviders : undefined,
       userName: displayName.trim(),
       userAvatar: avatar || undefined,
       userBio: bio.trim() || undefined,
@@ -726,27 +772,60 @@ export function SetupWizard() {
           {step === 3 && (
             <div className="space-y-4">
               <h2 className="text-sm font-medium">
-                3. Configure your LLM provider
+                3. Configure your LLM providers
               </h2>
               <p className="text-xs text-muted-foreground">
+                Select a <strong>primary</strong> provider (click once), then optionally add more providers (click others).
                 Only <strong>OpenAI Compatible</strong> and <strong>OpenRouter</strong> have been tested.
               </p>
 
-              {/* Provider type cards */}
-              <div className="grid grid-cols-2 gap-2">
-                {providerTypes.map((pt) => (
-                  <button
-                    key={pt.type}
-                    onClick={() => handleSelectProvider(pt.type)}
-                    className={`p-3 rounded-md border text-left text-sm transition-colors ${
-                      provider === pt.type
-                        ? "border-primary bg-primary/10 text-foreground"
-                        : "border-border bg-background text-muted-foreground hover:border-muted-foreground"
-                    }`}
-                  >
-                    <div className="font-medium">{pt.label}</div>
-                  </button>
-                ))}
+              {/* Provider type cards — multi-select */}
+              <div className="grid grid-cols-2 gap-2" data-testid="provider-grid">
+                {providerTypes.map((pt) => {
+                  const isPrimary = provider === pt.type;
+                  const isAdditional = additionalProviders.some((p) => p.type === pt.type);
+                  const isSelected = isPrimary || isAdditional;
+
+                  return (
+                    <button
+                      key={pt.type}
+                      data-testid={`provider-btn-${pt.type}`}
+                      onClick={() => {
+                        if (!provider || isPrimary) {
+                          // No primary yet, or clicking the already-primary — select as primary
+                          handleSelectProvider(pt.type);
+                        } else if (isAdditional) {
+                          // Already additional — deselect it
+                          handleToggleAdditionalProvider(pt.type);
+                        } else {
+                          // Add as additional provider
+                          handleToggleAdditionalProvider(pt.type);
+                        }
+                      }}
+                      className={`p-3 rounded-md border text-left text-sm transition-colors relative ${
+                        isPrimary
+                          ? "border-primary bg-primary/10 text-foreground ring-2 ring-primary/30"
+                          : isAdditional
+                            ? "border-primary bg-primary/5 text-foreground"
+                            : "border-border bg-background text-muted-foreground hover:border-muted-foreground"
+                      }`}
+                    >
+                      <div className="font-medium flex items-center justify-between">
+                        {pt.label}
+                        {isPrimary && (
+                          <span className="text-[10px] font-normal text-primary bg-primary/10 px-1.5 py-0.5 rounded" data-testid={`primary-badge-${pt.type}`}>
+                            Primary
+                          </span>
+                        )}
+                        {isAdditional && (
+                          <span className="text-[10px] font-normal text-muted-foreground" data-testid={`selected-indicator-${pt.type}`}>
+                            &#10003;
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
               </div>
 
               {provider && (
@@ -918,6 +997,70 @@ export function SetupWizard() {
                   a reasoning model (like Claude Opus or Sonnet 4.5) to the Team Lead for better
                   planning. Workers can use cheaper/faster models since they execute the Team Lead's
                   detailed plans.
+                </div>
+              )}
+
+              {/* Additional provider configurations */}
+              {additionalProviders.length > 0 && (
+                <div className="space-y-3" data-testid="additional-providers-section">
+                  <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Additional Providers
+                  </h3>
+                  {additionalProviders.map((ap) => {
+                    const meta = providerTypes.find((pt) => pt.type === ap.type);
+                    return (
+                      <div
+                        key={ap.type}
+                        data-testid={`additional-provider-${ap.type}`}
+                        className="border border-border rounded-md p-3 space-y-2"
+                      >
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm font-medium">{meta?.label || ap.type}</span>
+                          <button
+                            onClick={() => handleToggleAdditionalProvider(ap.type)}
+                            className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+                            data-testid={`remove-additional-${ap.type}`}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                        <div>
+                          <label className="block text-xs text-muted-foreground mb-1">Name</label>
+                          <input
+                            type="text"
+                            value={ap.name}
+                            onChange={(e) => updateAdditionalProvider(ap.type, { name: e.target.value })}
+                            placeholder={`e.g. My ${meta?.label || ap.type}`}
+                            className="w-full px-3 py-1.5 bg-background border border-input rounded-md text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                          />
+                        </div>
+                        {meta?.needsApiKey && (
+                          <div>
+                            <label className="block text-xs text-muted-foreground mb-1">API Key</label>
+                            <input
+                              type="password"
+                              value={ap.apiKey || ""}
+                              onChange={(e) => updateAdditionalProvider(ap.type, { apiKey: e.target.value })}
+                              placeholder="sk-..."
+                              className="w-full px-3 py-1.5 bg-background border border-input rounded-md text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                            />
+                          </div>
+                        )}
+                        {meta?.needsBaseUrl && (
+                          <div>
+                            <label className="block text-xs text-muted-foreground mb-1">Base URL</label>
+                            <input
+                              type="text"
+                              value={ap.baseUrl || ""}
+                              onChange={(e) => updateAdditionalProvider(ap.type, { baseUrl: e.target.value })}
+                              placeholder="http://localhost:..."
+                              className="w-full px-3 py-1.5 bg-background border border-input rounded-md text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                            />
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
               )}
 

--- a/packages/web/src/components/setup/__tests__/multi-provider-selection.test.ts
+++ b/packages/web/src/components/setup/__tests__/multi-provider-selection.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const wizardSource = readFileSync(
+  resolve(__dirname, "../SetupWizard.tsx"),
+  "utf-8",
+);
+
+describe("SetupWizard multi-provider selection", () => {
+  it("renders a provider grid with data-testid", () => {
+    expect(wizardSource).toContain('data-testid="provider-grid"');
+  });
+
+  it("renders per-provider buttons with data-testid pattern", () => {
+    expect(wizardSource).toContain("data-testid={`provider-btn-${pt.type}`}");
+  });
+
+  it("shows a Primary badge on the primary provider", () => {
+    expect(wizardSource).toContain("primary-badge-");
+    // Badge text content
+    expect(wizardSource).toMatch(/Primary\s*<\/span>/);
+    // Only displayed when isPrimary is true
+    expect(wizardSource).toContain("{isPrimary && (");
+  });
+
+  it("shows a checkmark indicator for additional (non-primary) providers", () => {
+    expect(wizardSource).toContain("selected-indicator-");
+    expect(wizardSource).toContain("{isAdditional && (");
+    expect(wizardSource).toContain("&#10003;");
+  });
+
+  it("tracks additionalProviders state as an array", () => {
+    expect(wizardSource).toContain(
+      "useState<SetupProviderEntry[]>([])",
+    );
+  });
+
+  it("renders an additional-providers configuration section", () => {
+    expect(wizardSource).toContain('data-testid="additional-providers-section"');
+    expect(wizardSource).toContain("Additional Providers");
+  });
+
+  it("renders per-additional-provider config blocks with remove buttons", () => {
+    expect(wizardSource).toContain("data-testid={`additional-provider-${ap.type}`}");
+    expect(wizardSource).toContain("data-testid={`remove-additional-${ap.type}`}");
+    expect(wizardSource).toMatch(/Remove\s*<\/button>/);
+  });
+
+  it("shows name, API key, and base URL fields per additional provider", () => {
+    // Name field always present for additional providers
+    expect(wizardSource).toContain(
+      'updateAdditionalProvider(ap.type, { name: e.target.value })',
+    );
+    // API key shown conditionally
+    expect(wizardSource).toContain(
+      'updateAdditionalProvider(ap.type, { apiKey: e.target.value })',
+    );
+    // Base URL shown conditionally
+    expect(wizardSource).toContain(
+      'updateAdditionalProvider(ap.type, { baseUrl: e.target.value })',
+    );
+  });
+
+  it("sends additionalProviders in the completeSetup call", () => {
+    expect(wizardSource).toContain(
+      "additionalProviders: additionalProviders.length > 0 ? additionalProviders : undefined",
+    );
+  });
+
+  it("persists additionalProviders in session storage", () => {
+    // Save call includes additionalProviders
+    expect(wizardSource).toContain("additionalProviders,");
+    // Restore logic handles the array
+    expect(wizardSource).toContain(
+      'if (Array.isArray(saved.additionalProviders))',
+    );
+  });
+
+  it("validates additional providers before advancing", () => {
+    expect(wizardSource).toContain("for (const ap of additionalProviders)");
+    expect(wizardSource).toContain("An API key is required for");
+    expect(wizardSource).toContain("A base URL is required for");
+  });
+
+  it("imports SetupProviderEntry from shared", () => {
+    expect(wizardSource).toContain("SetupProviderEntry");
+  });
+});

--- a/packages/web/src/components/setup/__tests__/setup-provider-entry.test.ts
+++ b/packages/web/src/components/setup/__tests__/setup-provider-entry.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import type { SetupProviderEntry } from "@otterbot/shared";
+
+describe("SetupProviderEntry type", () => {
+  it("accepts a minimal entry with type and name", () => {
+    const entry: SetupProviderEntry = { type: "anthropic", name: "My Anthropic" };
+    expect(entry.type).toBe("anthropic");
+    expect(entry.name).toBe("My Anthropic");
+    expect(entry.apiKey).toBeUndefined();
+    expect(entry.baseUrl).toBeUndefined();
+  });
+
+  it("accepts an entry with all optional fields", () => {
+    const entry: SetupProviderEntry = {
+      type: "openai-compatible",
+      name: "Local LLM",
+      apiKey: "sk-test",
+      baseUrl: "http://localhost:8080/v1",
+    };
+    expect(entry.type).toBe("openai-compatible");
+    expect(entry.apiKey).toBe("sk-test");
+    expect(entry.baseUrl).toBe("http://localhost:8080/v1");
+  });
+
+  it("can be stored in an array for multi-provider selection", () => {
+    const providers: SetupProviderEntry[] = [
+      { type: "anthropic", name: "Anthropic" },
+      { type: "openai", name: "OpenAI", apiKey: "sk-123" },
+      { type: "ollama", name: "Ollama", baseUrl: "http://localhost:11434/api" },
+    ];
+    expect(providers).toHaveLength(3);
+    expect(providers.map((p) => p.type)).toEqual(["anthropic", "openai", "ollama"]);
+  });
+});

--- a/packages/web/src/hooks/__tests__/use-setup-persistence-multi-provider.test.ts
+++ b/packages/web/src/hooks/__tests__/use-setup-persistence-multi-provider.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+
+const STORAGE_KEY = "otterbot-setup-wizard";
+
+const store = new Map<string, string>();
+const mockSessionStorage = {
+  getItem: vi.fn((key: string) => store.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => { store.set(key, value); }),
+  removeItem: vi.fn((key: string) => { store.delete(key); }),
+  clear: vi.fn(() => { store.clear(); }),
+};
+vi.stubGlobal("sessionStorage", mockSessionStorage);
+
+const { saveWizardState, loadWizardState } = await import(
+  "../use-setup-persistence"
+);
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("setup wizard persistence – multi-provider", () => {
+  beforeEach(() => {
+    store.clear();
+    vi.clearAllMocks();
+  });
+
+  it("persists additionalProviders array alongside scalar fields", () => {
+    const providers = [
+      { type: "openai", name: "My OpenAI", apiKey: "sk-test" },
+      { type: "ollama", name: "Local Ollama", baseUrl: "http://localhost:11434/api" },
+    ];
+    saveWizardState({
+      step: 3,
+      provider: "anthropic",
+      additionalProviders: providers,
+    });
+    const loaded = loadWizardState();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.provider).toBe("anthropic");
+    expect(loaded!.additionalProviders).toEqual(providers);
+  });
+
+  it("round-trips an empty additionalProviders array", () => {
+    saveWizardState({ step: 3, additionalProviders: [] });
+    const loaded = loadWizardState();
+    expect(loaded!.additionalProviders).toEqual([]);
+  });
+
+  it("handles state without additionalProviders (backward compat)", () => {
+    saveWizardState({ step: 3, provider: "anthropic" });
+    const loaded = loadWizardState();
+    expect(loaded!.additionalProviders).toBeUndefined();
+  });
+});

--- a/packages/web/src/stores/auth-store.ts
+++ b/packages/web/src/stores/auth-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { ProviderTypeMeta } from "@otterbot/shared";
+import type { ProviderTypeMeta, SetupProviderEntry } from "@otterbot/shared";
 
 export type AppScreen = "loading" | "setup" | "change-passphrase" | "login" | "app";
 
@@ -18,6 +18,7 @@ interface AuthState {
     model: string;
     apiKey?: string;
     baseUrl?: string;
+    additionalProviders?: SetupProviderEntry[];
     userName: string;
     userAvatar?: string;
     userBio?: string;


### PR DESCRIPTION
## Summary
- Allow users to select multiple LLM providers during initial setup (first is primary, others are additional)
- Add `SetupProviderEntry` shared type and `additionalProviders` array to the setup/complete API
- Multi-select provider grid in the wizard UI with "Primary" badge and checkmark indicators
- Per-provider config sections for name, API key, and base URL with validation
- Session storage persistence and restoration for additional providers
- Server creates all selected providers during setup completion

Closes #298

## Test plan
- [x] All 1146 existing + new unit tests pass (91 test files)
- [ ] Manual: walk through setup wizard, select a primary provider + 1-2 additional providers
- [ ] Verify additional providers appear in Settings after setup completes
- [ ] Verify primary provider is used for COO model assignment
- [ ] Verify session storage recovery restores additional provider selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)