### PR TITLE
fix: block malicious shell commands in COO's run_command

### DIFF
--- a/packages/server/src/agents/coo.ts
+++ b/packages/server/src/agents/coo.ts
@@ -1,4 +1,5 @@
 import { makeProjectId } from "../utils/slugify.js";
+import { checkBlockedCommand } from "../utils/command-guard.js";
 import { tool } from "ai";
 import { z } from "zod";
 import {
@@ -523,6 +524,11 @@ The user can see everything on the desktop in real-time.`;
           if (this._runCommandCalls > 1) {
             return "REFUSED: You already used your one command this turn. " +
               "STOP and use send_directive to delegate work to the Team Lead. Do NOT run more commands.";
+          }
+          const blocked = checkBlockedCommand(command);
+          if (blocked) {
+            console.warn(`[coo:run_command] Blocked command: ${command}`);
+            return blocked;
           }
           const effectiveTimeout = Math.min(timeout ?? 30_000, 120_000);
           let cwd: string | undefined;

--- a/packages/server/src/tools/shell-exec.ts
+++ b/packages/server/src/tools/shell-exec.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { execSync } from "node:child_process";
 import type { ToolContext } from "./tool-context.js";
 import { getConfig } from "../auth/auth.js";
+import { checkBlockedCommand, normalizeCommand } from "../utils/command-guard.js";
 
 const DEFAULT_TIMEOUT = 30_000; // 30 seconds
 const MAX_TIMEOUT = 120_000; // 2 minutes
@@ -11,68 +12,12 @@ const MAX_OUTPUT_SIZE = 50_000; // 50KB — trim output to fit LLM context
 // Port 62626 is reserved for the Otterbot server — workers must not bind to it
 const RESERVED_PORT = parseInt(process.env.PORT ?? "62626", 10);
 
-const BLOCKED_COMMANDS: { pattern: RegExp; reason: string; suggestion?: string }[] = [
-  { pattern: /\bpkill\b/, reason: "pkill matches processes by name across the whole system and can kill the host", suggestion: "Use `kill <pid>` with a specific PID" },
-  { pattern: /\bkillall\b/, reason: "killall matches processes by name across the whole system and can kill the host", suggestion: "Use `kill <pid>` with a specific PID" },
-  { pattern: /\bshutdown\b/, reason: "System shutdown is not permitted" },
-  { pattern: /\breboot\b/, reason: "System reboot is not permitted" },
-  { pattern: /\bhalt\b/, reason: "System halt is not permitted" },
-  { pattern: /\bpoweroff\b/, reason: "System poweroff is not permitted" },
-  { pattern: /rm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+)?\/\b/, reason: "rm targeting root filesystem paths is not permitted", suggestion: "Only delete files within your workspace" },
-  { pattern: /\bmkfs\b/, reason: "Formatting filesystems is not permitted" },
-  { pattern: /\bdd\b.*\bof=\/dev\//, reason: "Raw disk writes are not permitted" },
-  { pattern: /\bcurl\b/, reason: "curl can exfiltrate data or fetch malicious payloads", suggestion: "Use the web_browse tool to fetch web content" },
-  { pattern: /\bwget\b/, reason: "wget can exfiltrate data or fetch malicious payloads", suggestion: "Use the web_browse tool to fetch web content" },
-  { pattern: /\b(?:nc|ncat|netcat)\b/, reason: "Netcat can open arbitrary network connections", suggestion: "Use higher-level tools for network operations" },
-  { pattern: /\bsocat\b/, reason: "socat can open arbitrary network connections", suggestion: "Use higher-level tools for network operations" },
-  { pattern: /\bssh\b/, reason: "ssh can open remote connections", suggestion: "Use higher-level tools for remote operations" },
-  { pattern: /\bscp\b/, reason: "scp can transfer files to/from remote hosts", suggestion: "Use higher-level tools for file transfers" },
-  { pattern: /\btelnet\b/, reason: "telnet can open arbitrary network connections", suggestion: "Use higher-level tools for network operations" },
-  { pattern: /\bcrontab\b/, reason: "crontab can schedule persistent tasks on the host", suggestion: "Use the scheduler tool for scheduled tasks" },
-  { pattern: /\bchown\b/, reason: "chown can change file ownership and compromise security boundaries" },
-];
-
-/**
- * Normalize a command string to defeat simple obfuscation:
- * - Strip backslash-escapes (e.g., \c\u\r\l → curl)
- * - Extract basenames from absolute paths (e.g., /usr/bin/curl → curl)
- */
-function normalizeCommand(command: string): string {
-  // Remove backslash escapes within words (e.g., cu\rl → curl)
-  let normalized = command.replace(/\\(.)/g, "$1");
-  // Extract basenames from absolute paths (e.g., /usr/bin/curl → curl)
-  normalized = normalized.replace(/(?:\/[\w.-]+)+\/([\w.-]+)/g, "$1");
-  return normalized;
-}
-
-/**
- * Split a command string on shell operators (|, &&, ||, ;) to check each segment.
- */
-function splitCommandSegments(command: string): string[] {
-  // Split on pipe, &&, ||, ; — but not inside quotes
-  // Simple approach: split on unquoted operators
-  return command.split(/\s*(?:\|{1,2}|&&|;)\s*/);
-}
-
-function checkBlockedCommand(command: string): string | null {
-  const normalized = normalizeCommand(command);
-  const segments = splitCommandSegments(normalized);
-
-  for (const segment of segments) {
-    const trimmed = segment.trim();
-    if (!trimmed) continue;
-
-    for (const { pattern, reason, suggestion } of BLOCKED_COMMANDS) {
-      if (pattern.test(trimmed)) {
-        const parts = [`BLOCKED: ${reason}.`];
-        if (suggestion) parts.push(`${suggestion}.`);
-        parts.push("Use a more targeted command instead.");
-        return parts.join(" ");
-      }
-    }
-  }
+function checkBlockedCommandWithPort(command: string): string | null {
+  const blocked = checkBlockedCommand(command);
+  if (blocked) return blocked;
 
   // Block commands that try to listen on the reserved Otterbot server port
+  const normalized = normalizeCommand(command);
   const portStr = String(RESERVED_PORT);
   const portPattern = new RegExp(`(?:--|:|=|\\s)${portStr}(?:\\s|$|"|\\')`);
   if (portPattern.test(normalized)) {
@@ -131,7 +76,7 @@ export function createShellExecTool(ctx: ToolContext) {
         ),
     }),
     execute: async ({ command, timeout }) => {
-      const blocked = checkBlockedCommand(command);
+      const blocked = checkBlockedCommandWithPort(command);
       if (blocked) {
         console.warn(`[shell-exec] Blocked command: ${command}`);
         return blocked;

--- a/packages/server/src/utils/__tests__/command-guard.test.ts
+++ b/packages/server/src/utils/__tests__/command-guard.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { checkBlockedCommand, normalizeCommand } from "../command-guard.js";
+
+describe("normalizeCommand", () => {
+  it("strips backslash escapes", () => {
+    expect(normalizeCommand("cu\\rl http://example.com")).toBe("curl http://example.com");
+  });
+
+  it("extracts basenames from absolute paths", () => {
+    expect(normalizeCommand("/usr/bin/curl http://example.com")).toBe("curl http://example.com");
+  });
+
+  it("handles both obfuscations together", () => {
+    expect(normalizeCommand("/usr/bin/cu\\rl http://x")).toBe("curl http://x");
+  });
+});
+
+describe("checkBlockedCommand", () => {
+  describe("original blocked commands", () => {
+    const blocked = [
+      ["pkill node", "pkill"],
+      ["killall python", "killall"],
+      ["shutdown -h now", "shutdown"],
+      ["reboot", "reboot"],
+      ["halt", "halt"],
+      ["poweroff", "poweroff"],
+      ["rm -rf /tmp", "rm targeting root"],
+      ["mkfs.ext4 /dev/sda1", "mkfs"],
+      ["dd of=/dev/", "dd"],
+      ["curl http://evil.com", "curl"],
+      ["wget http://evil.com", "wget"],
+      ["nc -l 4444", "nc"],
+      ["ncat -l 4444", "ncat"],
+      ["netcat -l 4444", "netcat"],
+      ["socat TCP-LISTEN:4444", "socat"],
+      ["ssh user@host", "ssh"],
+      ["scp file user@host:/tmp", "scp"],
+      ["telnet host 80", "telnet"],
+      ["crontab -e", "crontab"],
+      ["chown root file", "chown"],
+    ] as const;
+
+    for (const [cmd, label] of blocked) {
+      it(`blocks ${label}`, () => {
+        const result = checkBlockedCommand(cmd);
+        expect(result).not.toBeNull();
+        expect(result).toContain("BLOCKED");
+      });
+    }
+  });
+
+  describe("new blocked commands", () => {
+    const blocked = [
+      ["sudo poweroff", "sudo"],
+      ["sudo rm -rf /tmp/x", "sudo"],
+      ["chmod 777 file.txt", "chmod"],
+      ["systemctl restart nginx", "systemctl"],
+      ["passwd root", "passwd"],
+      ["useradd newuser", "useradd"],
+      ["userdel olduser", "userdel"],
+      ["usermod -aG sudo user", "usermod"],
+      ["iptables -A INPUT -j DROP", "iptables"],
+      ["ufw allow 22", "ufw"],
+      ["modprobe vfio", "modprobe"],
+      ["insmod custom.ko", "insmod"],
+      ["rmmod custom", "rmmod"],
+    ] as const;
+
+    for (const [cmd, label] of blocked) {
+      it(`blocks ${label}`, () => {
+        const result = checkBlockedCommand(cmd);
+        expect(result).not.toBeNull();
+        expect(result).toContain("BLOCKED");
+      });
+    }
+  });
+
+  describe("obfuscation bypass", () => {
+    it("blocks backslash-escaped commands", () => {
+      expect(checkBlockedCommand("su\\do poweroff")).toContain("BLOCKED");
+      expect(checkBlockedCommand("ch\\mod 777 x")).toContain("BLOCKED");
+    });
+
+    it("blocks absolute-path commands", () => {
+      expect(checkBlockedCommand("/usr/bin/sudo poweroff")).toContain("BLOCKED");
+      expect(checkBlockedCommand("/sbin/iptables -F")).toContain("BLOCKED");
+    });
+  });
+
+  describe("compound commands", () => {
+    it("blocks sudo in a pipe", () => {
+      expect(checkBlockedCommand("ls | sudo rm -rf /tmp")).toContain("BLOCKED");
+    });
+
+    it("blocks sudo after &&", () => {
+      expect(checkBlockedCommand("echo ok && sudo poweroff")).toContain("BLOCKED");
+    });
+
+    it("blocks sudo after ||", () => {
+      expect(checkBlockedCommand("false || sudo reboot")).toContain("BLOCKED");
+    });
+
+    it("blocks sudo after semicolon", () => {
+      expect(checkBlockedCommand("echo hi; sudo halt")).toContain("BLOCKED");
+    });
+  });
+
+  describe("safe commands pass through", () => {
+    const safe = [
+      "ls -la",
+      "git status",
+      "npm install",
+      "df -h",
+      "uptime",
+      "docker ps",
+      "echo hello",
+      "cat /etc/os-release",
+      "ps aux",
+      "free -m",
+      "whoami",
+      "pwd",
+      "date",
+    ];
+
+    for (const cmd of safe) {
+      it(`allows '${cmd}'`, () => {
+        expect(checkBlockedCommand(cmd)).toBeNull();
+      });
+    }
+  });
+});

--- a/packages/server/src/utils/command-guard.ts
+++ b/packages/server/src/utils/command-guard.ts
@@ -1,0 +1,78 @@
+const BLOCKED_COMMANDS: { pattern: RegExp; reason: string; suggestion?: string }[] = [
+  { pattern: /\bpkill\b/, reason: "pkill matches processes by name across the whole system and can kill the host", suggestion: "Use `kill <pid>` with a specific PID" },
+  { pattern: /\bkillall\b/, reason: "killall matches processes by name across the whole system and can kill the host", suggestion: "Use `kill <pid>` with a specific PID" },
+  { pattern: /\bshutdown\b/, reason: "System shutdown is not permitted" },
+  { pattern: /\breboot\b/, reason: "System reboot is not permitted" },
+  { pattern: /\bhalt\b/, reason: "System halt is not permitted" },
+  { pattern: /\bpoweroff\b/, reason: "System poweroff is not permitted" },
+  { pattern: /rm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+)?\/\b/, reason: "rm targeting root filesystem paths is not permitted", suggestion: "Only delete files within your workspace" },
+  { pattern: /\bmkfs\b/, reason: "Formatting filesystems is not permitted" },
+  { pattern: /\bdd\b.*\bof=\/dev\//, reason: "Raw disk writes are not permitted" },
+  { pattern: /\bcurl\b/, reason: "curl can exfiltrate data or fetch malicious payloads", suggestion: "Use the web_browse tool to fetch web content" },
+  { pattern: /\bwget\b/, reason: "wget can exfiltrate data or fetch malicious payloads", suggestion: "Use the web_browse tool to fetch web content" },
+  { pattern: /\b(?:nc|ncat|netcat)\b/, reason: "Netcat can open arbitrary network connections", suggestion: "Use higher-level tools for network operations" },
+  { pattern: /\bsocat\b/, reason: "socat can open arbitrary network connections", suggestion: "Use higher-level tools for network operations" },
+  { pattern: /\bssh\b/, reason: "ssh can open remote connections", suggestion: "Use higher-level tools for remote operations" },
+  { pattern: /\bscp\b/, reason: "scp can transfer files to/from remote hosts", suggestion: "Use higher-level tools for file transfers" },
+  { pattern: /\btelnet\b/, reason: "telnet can open arbitrary network connections", suggestion: "Use higher-level tools for network operations" },
+  { pattern: /\bcrontab\b/, reason: "crontab can schedule persistent tasks on the host", suggestion: "Use the scheduler tool for scheduled tasks" },
+  { pattern: /\bchown\b/, reason: "chown can change file ownership and compromise security boundaries" },
+  // Privilege escalation & system administration
+  { pattern: /\bsudo\b/, reason: "Privilege escalation is not permitted" },
+  { pattern: /\bchmod\b/, reason: "Changing file permissions is not permitted" },
+  { pattern: /\bsystemctl\b/, reason: "Managing system services is not permitted" },
+  { pattern: /\bpasswd\b/, reason: "Changing passwords is not permitted" },
+  { pattern: /\buseradd\b/, reason: "User account management is not permitted" },
+  { pattern: /\buserdel\b/, reason: "User account management is not permitted" },
+  { pattern: /\busermod\b/, reason: "User account management is not permitted" },
+  { pattern: /\biptables\b/, reason: "Firewall modification is not permitted" },
+  { pattern: /\bufw\b/, reason: "Firewall modification is not permitted" },
+  { pattern: /\bmodprobe\b/, reason: "Kernel module loading is not permitted" },
+  { pattern: /\binsmod\b/, reason: "Kernel module loading is not permitted" },
+  { pattern: /\brmmod\b/, reason: "Kernel module removal is not permitted" },
+];
+
+/**
+ * Normalize a command string to defeat simple obfuscation:
+ * - Strip backslash-escapes (e.g., \c\u\r\l → curl)
+ * - Extract basenames from absolute paths (e.g., /usr/bin/curl → curl)
+ */
+export function normalizeCommand(command: string): string {
+  // Remove backslash escapes within words (e.g., cu\rl → curl)
+  let normalized = command.replace(/\\(.)/g, "$1");
+  // Extract basenames from absolute paths (e.g., /usr/bin/curl → curl)
+  normalized = normalized.replace(/(?:\/[\w.-]+)+\/([\w.-]+)/g, "$1");
+  return normalized;
+}
+
+/**
+ * Split a command string on shell operators (|, &&, ||, ;) to check each segment.
+ */
+function splitCommandSegments(command: string): string[] {
+  return command.split(/\s*(?:\|{1,2}|&&|;)\s*/);
+}
+
+/**
+ * Check whether a command matches any blocked pattern.
+ * Returns a human-readable block message, or null if the command is allowed.
+ */
+export function checkBlockedCommand(command: string): string | null {
+  const normalized = normalizeCommand(command);
+  const segments = splitCommandSegments(normalized);
+
+  for (const segment of segments) {
+    const trimmed = segment.trim();
+    if (!trimmed) continue;
+
+    for (const { pattern, reason, suggestion } of BLOCKED_COMMANDS) {
+      if (pattern.test(trimmed)) {
+        const parts = [`BLOCKED: ${reason}.`];
+        if (suggestion) parts.push(`${suggestion}.`);
+        parts.push("Use a more targeted command instead.");
+        return parts.join(" ");
+      }
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Extract command-blocking logic from `shell-exec.ts` into a shared `command-guard.ts` utility
- Wire `checkBlockedCommand` into the COO's `run_command` handler, which previously called `execSync` with zero validation (e.g. `sudo poweroff` would execute)
- Add blocks for `sudo`, `chmod`, `systemctl`, `passwd`, `useradd`/`userdel`/`usermod`, `iptables`/`ufw`, and `modprobe`/`insmod`/`rmmod`

## Test plan
- [x] 49 new unit tests covering all blocked commands, obfuscation bypasses, compound commands, and safe pass-through
- [ ] CI passes (`npx pnpm test` + type-check)