### PR TITLE
fix: add arm64 platform detection to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -151,8 +151,14 @@ case "$OS" in
 esac
 
 case "$ARCH" in
-  x86_64|amd64)  ARCH_NAME="x86_64" ;;
-  aarch64|arm64) ARCH_NAME="arm64" ;;
+  x86_64|amd64)
+    ARCH_NAME="x86_64"
+    DOCKER_PLATFORM="linux/amd64"
+    ;;
+  aarch64|arm64)
+    ARCH_NAME="arm64"
+    DOCKER_PLATFORM="linux/arm64"
+    ;;
   *)
     error "Unsupported architecture: $ARCH"
     exit 1
@@ -256,6 +262,7 @@ cat > "$INSTALL_DIR/docker-compose.yml" <<EOF
 services:
   otterbot:
     image: ${IMAGE}:${TAG}
+    platform: ${DOCKER_PLATFORM}
     shm_size: "256m"
     ports:
       - "\${PORT:-62626}:62626"
@@ -272,7 +279,7 @@ services:
     restart: unless-stopped
 EOF
 
-info "Generated docker-compose.yml (image tag: ${TAG})"
+info "Generated docker-compose.yml (image tag: ${TAG}, platform: ${DOCKER_PLATFORM})"
 
 # ── Pull & start ─────────────────────────────────────────────────────────────
 

--- a/packages/server/src/install-script.test.ts
+++ b/packages/server/src/install-script.test.ts
@@ -136,3 +136,71 @@ exit 0
     expect(result.stdout).toContain(`Opened browser to ${TEST_URL}`);
   });
 });
+
+describe("install.sh architecture platform detection", () => {
+  it("writes linux/amd64 platform for x86_64", () => {
+    const unameStub = `#!/bin/sh
+if [ "$1" = "-s" ]; then
+  echo "Linux"
+  exit 0
+fi
+if [ "$1" = "-m" ]; then
+  echo "x86_64"
+  exit 0
+fi
+exit 1
+`;
+    const { result, installDir } = runInstallScript({
+      args: ["--no-start", "--no-open"],
+      commands: { uname: unameStub },
+    });
+
+    const compose = readFileSync(join(installDir, "docker-compose.yml"), "utf8");
+    expect(result.status).toBe(0);
+    expect(compose).toContain("platform: linux/amd64");
+    expect(result.stdout).toContain("platform: linux/amd64");
+  });
+
+  it("writes linux/arm64 platform for arm64", () => {
+    const unameStub = `#!/bin/sh
+if [ "$1" = "-s" ]; then
+  echo "Linux"
+  exit 0
+fi
+if [ "$1" = "-m" ]; then
+  echo "arm64"
+  exit 0
+fi
+exit 1
+`;
+    const { result, installDir } = runInstallScript({
+      args: ["--no-start", "--no-open"],
+      commands: { uname: unameStub },
+    });
+
+    const compose = readFileSync(join(installDir, "docker-compose.yml"), "utf8");
+    expect(result.status).toBe(0);
+    expect(compose).toContain("platform: linux/arm64");
+    expect(result.stdout).toContain("platform: linux/arm64");
+  });
+
+  it("fails for unsupported architectures", () => {
+    const unameStub = `#!/bin/sh
+if [ "$1" = "-s" ]; then
+  echo "Linux"
+  exit 0
+fi
+if [ "$1" = "-m" ]; then
+  echo "sparc"
+  exit 0
+fi
+exit 1
+`;
+    const { result } = runInstallScript({
+      commands: { uname: unameStub },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Unsupported architecture: sparc");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `DOCKER_PLATFORM` variable to `install.sh` architecture detection, setting `linux/amd64` or `linux/arm64` based on `uname -m`
- Injects `platform:` field into the generated `docker-compose.yml` so Docker pulls the correct architecture image
- Adds tests covering x86_64, arm64, and unsupported architecture cases

Closes #375

## Test plan
- [x] New tests verify `linux/amd64` platform for x86_64 arch
- [x] New tests verify `linux/arm64` platform for arm64 arch
- [x] New test verifies failure for unsupported architectures
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)