### PR TITLE
feat: add Mastodon support via masto.js bridge

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,6 +41,7 @@
     "isolated-vm": "^6.0.2",
     "kokoro-js": "^1.1.0",
     "mailparser": "^3.9.3",
+    "masto": "^7.10.2",
     "matrix-js-sdk": "^34.11.1",
     "nanoid": "^5.0.9",
     "node-pty": "^1.1.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -280,6 +280,17 @@ import {
   rejectPairing as rejectNextcloudTalkPairing,
   revokePairing as revokeNextcloudTalkPairing,
 } from "./nextcloud-talk/pairing.js";
+import { MastodonBridge } from "./mastodon/mastodon-bridge.js";
+import {
+  getMastodonSettings,
+  updateMastodonSettings,
+  testMastodonConnection,
+} from "./mastodon/mastodon-settings.js";
+import {
+  approvePairing as approveMastodonPairing,
+  rejectPairing as rejectMastodonPairing,
+  revokePairing as revokeMastodonPairing,
+} from "./mastodon/pairing.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -803,6 +814,30 @@ async function main() {
     }
   }
 
+  // Mastodon bridge (initialized when enabled + credentials set)
+  let mastodonBridge: MastodonBridge | null = null;
+
+  function startMastodonBridge() {
+    if (mastodonBridge || !coo) return;
+    const settings = getMastodonSettings();
+    if (!settings.enabled || !settings.credentialsSet) return;
+    const instanceUrl = getConfig("mastodon:instance_url");
+    const accessToken = getConfig("mastodon:access_token");
+    if (!instanceUrl || !accessToken) return;
+    mastodonBridge = new MastodonBridge({ bus, coo, io });
+    mastodonBridge.start({ instanceUrl, accessToken }).catch((err) => {
+      console.error("[Mastodon] Failed to start bridge:", err);
+      mastodonBridge = null;
+    });
+  }
+
+  async function stopMastodonBridge() {
+    if (mastodonBridge) {
+      await mastodonBridge.stop();
+      mastodonBridge = null;
+    }
+  }
+
   function startCoo() {
     if (coo) return;
     try {
@@ -1205,6 +1240,7 @@ async function main() {
     startWhatsAppBridge();
     startSignalBridge();
     startNextcloudTalkBridge();
+    startMastodonBridge();
 
     // Start mock scenario playback if configured
     if (process.env.MOCK_MODE === "true" && process.env.MOCK_SCENARIO && coo) {
@@ -1565,6 +1601,7 @@ async function main() {
     startWhatsAppBridge();
     startSignalBridge();
     startNextcloudTalkBridge();
+    startMastodonBridge();
 
     return { ok: true };
   });
@@ -4598,6 +4635,72 @@ async function main() {
   });
 
   // =========================================================================
+  // Mastodon settings routes
+  // =========================================================================
+
+  app.get("/api/settings/mastodon", async () => {
+    return getMastodonSettings();
+  });
+
+  app.put<{
+    Body: {
+      enabled?: boolean;
+      instanceUrl?: string;
+      accessToken?: string;
+    };
+  }>("/api/settings/mastodon", async (req) => {
+    const wasEnabled = getMastodonSettings().enabled && getMastodonSettings().credentialsSet;
+    updateMastodonSettings(req.body);
+    const nowEnabled = getMastodonSettings().enabled && getMastodonSettings().credentialsSet;
+
+    // Start or stop bridge based on state change
+    if (nowEnabled && !wasEnabled) {
+      startMastodonBridge();
+    } else if (!nowEnabled && wasEnabled) {
+      await stopMastodonBridge();
+    }
+
+    return { ok: true };
+  });
+
+  app.post("/api/settings/mastodon/test", async () => {
+    return testMastodonConnection();
+  });
+
+  app.post<{
+    Body: { code: string };
+  }>("/api/settings/mastodon/pair/approve", async (req, reply) => {
+    const result = approveMastodonPairing(req.body.code);
+    if (!result) {
+      reply.code(400);
+      return { ok: false, error: "Invalid or expired pairing code" };
+    }
+    return { ok: true, user: result };
+  });
+
+  app.post<{
+    Body: { code: string };
+  }>("/api/settings/mastodon/pair/reject", async (req, reply) => {
+    const ok = rejectMastodonPairing(req.body.code);
+    if (!ok) {
+      reply.code(400);
+      return { ok: false, error: "Pairing code not found" };
+    }
+    return { ok: true };
+  });
+
+  app.delete<{
+    Params: { userId: string };
+  }>("/api/settings/mastodon/pair/:userId", async (req, reply) => {
+    const ok = revokeMastodonPairing(req.params.userId);
+    if (!ok) {
+      reply.code(400);
+      return { ok: false, error: "User not found" };
+    }
+    return { ok: true };
+  });
+
+  // =========================================================================
   // Google settings routes
   // =========================================================================
 
@@ -5697,6 +5800,7 @@ Respond with ONLY a JSON object (no markdown, no explanation) with these fields:
     await stopMattermostBridge();
     await stopSignalBridge();
     await stopNextcloudTalkBridge();
+    await stopMastodonBridge();
     await McpClientManager.stopAll();
     await closeBrowser();
     process.exit(0);

--- a/packages/server/src/mastodon/__tests__/mastodon-bridge.test.ts
+++ b/packages/server/src/mastodon/__tests__/mastodon-bridge.test.ts
@@ -246,4 +246,122 @@ describe("MastodonBridge", () => {
 
     await bridge.stop();
   });
+
+  it("ignores mentions from the bot account itself", async () => {
+    mockIsPaired.mockReturnValue(true);
+    mockNotificationsList.mockResolvedValue([
+      {
+        id: "n-self",
+        type: "mention",
+        account: { id: "bot-id", acct: "otterbot" },
+        status: {
+          id: "status-self",
+          visibility: "public",
+          content: "<p>@otterbot hello from myself</p>",
+        },
+      },
+    ]);
+
+    const { bridge, bus } = await createBridge();
+
+    await bridge.start({
+      instanceUrl: "https://mastodon.example",
+      accessToken: "token-123",
+    });
+
+    await vi.waitFor(() => {
+      expect(mockNotificationsList).toHaveBeenCalled();
+    });
+
+    expect(bus.send).not.toHaveBeenCalled();
+    expect(mockStatusesCreate).not.toHaveBeenCalled();
+
+    await bridge.stop();
+  });
+
+  it("emits error status when polling receives auth failures", async () => {
+    mockNotificationsList.mockRejectedValue(new Error("401 Unauthorized"));
+
+    const { bridge, io } = await createBridge();
+
+    await bridge.start({
+      instanceUrl: "https://mastodon.example",
+      accessToken: "token-123",
+    });
+
+    await vi.waitFor(() => {
+      expect(io.emit).toHaveBeenCalledWith("mastodon:status", { status: "error" });
+    });
+
+    await bridge.stop();
+  });
+
+  it("splits long COO replies into a threaded sequence", async () => {
+    mockIsPaired.mockReturnValue(true);
+    mockNotificationsList.mockResolvedValue([
+      {
+        id: "n3",
+        type: "mention",
+        account: { id: "user-3", acct: "charlie" },
+        status: {
+          id: "status-3",
+          visibility: "public",
+          content: "<p>@otterbot give me a long answer</p>",
+        },
+      },
+    ]);
+
+    let replyCounter = 0;
+    mockStatusesCreate.mockImplementation(async () => {
+      replyCounter += 1;
+      return { id: `reply-${replyCounter}`, url: null };
+    });
+
+    const { bridge, bus } = await createBridge();
+
+    await bridge.start({
+      instanceUrl: "https://mastodon.example",
+      accessToken: "token-123",
+    });
+
+    await vi.waitFor(() => {
+      expect(bus.send).toHaveBeenCalledOnce();
+    });
+
+    const conversationId = (bus.send as ReturnType<typeof vi.fn>).mock.calls[0][0].conversationId as string;
+    const handler = (bus as ReturnType<typeof createMockBus>)._handlers[0];
+    const longReply = "x".repeat(750);
+
+    handler?.({
+      id: "coo-msg-long",
+      fromAgentId: "coo",
+      toAgentId: null,
+      type: MessageType.Chat,
+      content: longReply,
+      metadata: {},
+      conversationId,
+      timestamp: new Date().toISOString(),
+    });
+
+    await vi.waitFor(() => {
+      expect(mockStatusesCreate).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockStatusesCreate).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        inReplyToId: "status-3",
+        visibility: "public",
+      }),
+    );
+    expect(mockStatusesCreate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        inReplyToId: "reply-1",
+        visibility: "public",
+      }),
+    );
+
+    await bridge.stop();
+  });
 });

--- a/packages/server/src/mastodon/__tests__/mastodon-bridge.test.ts
+++ b/packages/server/src/mastodon/__tests__/mastodon-bridge.test.ts
@@ -364,4 +364,54 @@ describe("MastodonBridge", () => {
 
     await bridge.stop();
   });
+
+  it("supports direct posting and timeline reads only when connected", async () => {
+    const { bridge } = await createBridge();
+
+    // Not started yet
+    await expect(bridge.createPost("hello")).resolves.toBeNull();
+    await expect(bridge.getTimeline()).resolves.toEqual([]);
+
+    mockStatusesCreate.mockResolvedValue({ id: "status-created", url: "https://mastodon.example/@otterbot/1" });
+    mockTimelineList.mockResolvedValue([{ id: "status-1" }]);
+
+    await bridge.start({
+      instanceUrl: "https://mastodon.example",
+      accessToken: "token-123",
+    });
+
+    await expect(bridge.createPost("hello mastodon", "unlisted")).resolves.toEqual({
+      id: "status-created",
+      url: "https://mastodon.example/@otterbot/1",
+    });
+    expect(mockStatusesCreate).toHaveBeenCalledWith({
+      status: "hello mastodon",
+      visibility: "unlisted",
+    });
+
+    await expect(bridge.getTimeline(5)).resolves.toEqual([{ id: "status-1" }]);
+    expect(mockTimelineList).toHaveBeenCalledWith({ limit: 5 });
+
+    await bridge.stop();
+  });
+
+  it("emits connected and disconnected status lifecycle events", async () => {
+    const { bridge, io } = await createBridge();
+
+    await bridge.start({
+      instanceUrl: "https://mastodon.example",
+      accessToken: "token-123",
+    });
+
+    expect(io.emit).toHaveBeenCalledWith("mastodon:status", {
+      status: "connected",
+      acct: "otterbot",
+    });
+
+    await bridge.stop();
+
+    expect(io.emit).toHaveBeenCalledWith("mastodon:status", {
+      status: "disconnected",
+    });
+  });
 });

--- a/packages/server/src/mastodon/__tests__/mastodon-bridge.test.ts
+++ b/packages/server/src/mastodon/__tests__/mastodon-bridge.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage } from "@otterbot/shared";
+import { migrateDb, resetDb } from "../../db/index.js";
+
+const mockIsPaired = vi.fn();
+const mockGeneratePairingCode = vi.fn();
+
+const mockVerifyCredentials = vi.fn();
+const mockNotificationsList = vi.fn();
+const mockStatusesCreate = vi.fn();
+const mockTimelineList = vi.fn();
+
+vi.mock("../pairing.js", () => ({
+  isPaired: (...args: unknown[]) => mockIsPaired(...args),
+  generatePairingCode: (...args: unknown[]) => mockGeneratePairingCode(...args),
+}));
+
+vi.mock("masto", () => ({
+  createRestAPIClient: vi.fn(() => ({
+    v1: {
+      accounts: {
+        verifyCredentials: (...args: unknown[]) => mockVerifyCredentials(...args),
+      },
+      notifications: {
+        list: (...args: unknown[]) => mockNotificationsList(...args),
+      },
+      statuses: {
+        create: (...args: unknown[]) => mockStatusesCreate(...args),
+      },
+      timelines: {
+        home: {
+          list: (...args: unknown[]) => mockTimelineList(...args),
+        },
+      },
+    },
+  })),
+  createStreamingAPIClient: vi.fn(() => {
+    throw new Error("streaming unavailable");
+  }),
+}));
+
+interface SendParams {
+  fromAgentId: string | null;
+  toAgentId: string | null;
+  type: MessageType;
+  content: string;
+  metadata?: Record<string, unknown>;
+  conversationId?: string;
+}
+
+function createMockBus() {
+  const handlers: Array<(message: BusMessage) => void> = [];
+  const sent: SendParams[] = [];
+
+  return {
+    send: vi.fn((params: SendParams) => {
+      sent.push(params);
+      return {
+        id: "msg-id",
+        fromAgentId: params.fromAgentId,
+        toAgentId: params.toAgentId,
+        type: params.type,
+        content: params.content,
+        metadata: params.metadata ?? {},
+        conversationId: params.conversationId,
+        timestamp: new Date().toISOString(),
+      } as BusMessage;
+    }),
+    onBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      handlers.push(handler);
+    }),
+    offBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      const idx = handlers.indexOf(handler);
+      if (idx >= 0) handlers.splice(idx, 1);
+    }),
+    _handlers: handlers,
+    _sent: sent,
+  };
+}
+
+function createMockCoo() {
+  return {
+    startNewConversation: vi.fn(),
+  };
+}
+
+function createMockIo() {
+  return {
+    emit: vi.fn(),
+  };
+}
+
+describe("MastodonBridge", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-mastodon-bridge-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+
+    vi.clearAllMocks();
+
+    mockVerifyCredentials.mockResolvedValue({
+      id: "bot-id",
+      acct: "otterbot",
+    });
+    mockNotificationsList.mockResolvedValue([]);
+    mockStatusesCreate.mockResolvedValue({ id: "reply-1", url: null });
+    mockTimelineList.mockResolvedValue([]);
+    mockGeneratePairingCode.mockReturnValue("ABC123");
+  });
+
+  afterEach(() => {
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function createBridge() {
+    const { MastodonBridge } = await import("../mastodon-bridge.js");
+    const bus = createMockBus();
+    const coo = createMockCoo();
+    const io = createMockIo();
+
+    const bridge = new MastodonBridge({ bus: bus as any, coo: coo as any, io: io as any });
+    return { bridge, bus, coo, io };
+  }
+
+  it("posts pairing instructions for unpaired mentions", async () => {
+    mockIsPaired.mockReturnValue(false);
+    mockNotificationsList.mockResolvedValue([
+      {
+        id: "n1",
+        type: "mention",
+        account: { id: "user-1", acct: "alice" },
+        status: {
+          id: "status-1",
+          visibility: "public",
+          content: "<p>@otterbot hello</p>",
+        },
+      },
+    ]);
+
+    const { bridge, bus, io } = await createBridge();
+
+    await bridge.start({
+      instanceUrl: "https://mastodon.example",
+      accessToken: "token-123",
+    });
+
+    await vi.waitFor(() => {
+      expect(mockStatusesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inReplyToId: "status-1",
+          visibility: "public",
+        }),
+      );
+    });
+
+    expect(mockGeneratePairingCode).toHaveBeenCalledWith("user-1", "alice");
+    await vi.waitFor(() => {
+      expect(io.emit).toHaveBeenCalledWith("mastodon:pairing-request", {
+        code: "ABC123",
+        mastodonId: "user-1",
+        mastodonAcct: "alice",
+      });
+    });
+    expect(bus.send).not.toHaveBeenCalled();
+
+    await bridge.stop();
+  });
+
+  it("routes paired mentions to COO and replies to pending conversations", async () => {
+    mockIsPaired.mockReturnValue(true);
+    mockNotificationsList.mockResolvedValue([
+      {
+        id: "n2",
+        type: "mention",
+        account: { id: "user-2", acct: "bob" },
+        status: {
+          id: "status-2",
+          visibility: "unlisted",
+          content: "<p>@otterbot Please summarize this</p>",
+        },
+      },
+    ]);
+
+    const { bridge, bus, coo } = await createBridge();
+
+    await bridge.start({
+      instanceUrl: "https://mastodon.example",
+      accessToken: "token-123",
+    });
+
+    await vi.waitFor(() => {
+      expect(bus.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toAgentId: "coo",
+          type: MessageType.Chat,
+          content: "Please summarize this",
+          metadata: expect.objectContaining({
+            source: "mastodon",
+            mastodonId: "user-2",
+            mastodonAcct: "bob",
+            statusId: "status-2",
+          }),
+        }),
+      );
+    });
+
+    expect(coo.startNewConversation).toHaveBeenCalledOnce();
+
+    const conversationId = (bus.send as ReturnType<typeof vi.fn>).mock.calls[0][0].conversationId as string;
+    expect(typeof conversationId).toBe("string");
+
+    const handler = (bus as ReturnType<typeof createMockBus>)._handlers[0];
+    expect(handler).toBeDefined();
+
+    handler?.({
+      id: "coo-msg",
+      fromAgentId: "coo",
+      toAgentId: null,
+      type: MessageType.Chat,
+      content: "Here is your summary",
+      metadata: {},
+      conversationId,
+      timestamp: new Date().toISOString(),
+    });
+
+    await vi.waitFor(() => {
+      expect(mockStatusesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "Here is your summary",
+          inReplyToId: "status-2",
+          visibility: "unlisted",
+        }),
+      );
+    });
+
+    await bridge.stop();
+  });
+});

--- a/packages/server/src/mastodon/mastodon-bridge.ts
+++ b/packages/server/src/mastodon/mastodon-bridge.ts
@@ -1,0 +1,455 @@
+import { createRestAPIClient, createStreamingAPIClient } from "masto";
+import type { mastodon } from "masto";
+import { nanoid } from "nanoid";
+import { eq } from "drizzle-orm";
+import { Server } from "socket.io";
+import type { ServerToClientEvents, ClientToServerEvents } from "@otterbot/shared";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage, Conversation } from "@otterbot/shared";
+import { MessageBus } from "../bus/message-bus.js";
+import { COO } from "../agents/coo.js";
+import { getDb, schema } from "../db/index.js";
+import { isPaired, generatePairingCode } from "./pairing.js";
+
+type TypedServer = Server<ClientToServerEvents, ServerToClientEvents>;
+
+// ---------------------------------------------------------------------------
+// Mastodon Bridge
+// ---------------------------------------------------------------------------
+
+const MASTODON_MAX_LENGTH = 500; // Mastodon default post limit
+const POLL_INTERVAL_MS = 30_000; // Poll notifications every 30 seconds
+
+export interface MastodonBridgeConfig {
+  instanceUrl: string;
+  accessToken: string;
+}
+
+interface PendingResponse {
+  authorId: string;
+  statusId: string;
+  conversationId: string;
+  visibility: mastodon.v1.StatusVisibility;
+}
+
+export class MastodonBridge {
+  private client: mastodon.rest.Client | null = null;
+  private streaming: mastodon.streaming.Client | null = null;
+  private bus: MessageBus;
+  private coo: COO;
+  private io: TypedServer;
+  private pendingResponses = new Map<string, PendingResponse>();
+  private broadcastHandler: ((message: BusMessage) => void) | null = null;
+  /** Map of mastodon account id → conversationId */
+  private conversationMap = new Map<string, string>();
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private lastNotificationId: string | null = null;
+  private myAccountId: string | null = null;
+  private myAcct: string | null = null;
+  private instanceUrl: string | null = null;
+  private subscription: { unsubscribe: () => void } | null = null;
+
+  constructor(deps: { bus: MessageBus; coo: COO; io: TypedServer }) {
+    this.bus = deps.bus;
+    this.coo = deps.coo;
+    this.io = deps.io;
+  }
+
+  async start(config: MastodonBridgeConfig): Promise<void> {
+    if (this.client) {
+      await this.stop();
+    }
+
+    this.instanceUrl = config.instanceUrl;
+
+    this.client = createRestAPIClient({
+      url: config.instanceUrl,
+      accessToken: config.accessToken,
+    });
+
+    // Verify credentials and get our account info
+    const account = await this.client.v1.accounts.verifyCredentials();
+    this.myAccountId = account.id;
+    this.myAcct = account.acct;
+    console.log(`[Mastodon] Logged in as @${account.acct} (${account.id}) on ${config.instanceUrl}`);
+    this.io.emit("mastodon:status", {
+      status: "connected",
+      acct: account.acct,
+    });
+
+    // Subscribe to bus broadcasts to intercept COO responses
+    this.broadcastHandler = (message: BusMessage) => {
+      this.handleBusMessage(message);
+    };
+    this.bus.onBroadcast(this.broadcastHandler);
+
+    // Try to set up streaming for real-time notifications
+    try {
+      this.streaming = createStreamingAPIClient({
+        streamingApiUrl: `${config.instanceUrl}/api/v1/streaming`,
+        accessToken: config.accessToken,
+        implementation: typeof WebSocket !== "undefined" ? WebSocket : (await import("ws")).default as unknown as typeof WebSocket,
+      });
+
+      const events = this.streaming.user.subscribe();
+      const iter = events[Symbol.asyncIterator]();
+      let stopped = false;
+
+      const processEvents = async () => {
+        try {
+          while (!stopped) {
+            const result = await iter.next();
+            if (result.done) break;
+            const event = result.value;
+            if (event.event === "notification") {
+              const notification = event.payload as mastodon.v1.Notification;
+              if (notification.type === "mention") {
+                await this.handleMention(notification);
+              }
+            }
+          }
+        } catch (err) {
+          if (!stopped) {
+            console.warn("[Mastodon] Streaming connection lost, falling back to polling:", err);
+          }
+        }
+      };
+
+      this.subscription = {
+        unsubscribe: () => {
+          stopped = true;
+          iter.return?.();
+        },
+      };
+
+      processEvents();
+      console.log("[Mastodon] Streaming connection established");
+    } catch (err) {
+      console.warn("[Mastodon] Streaming not available, using polling fallback:", err);
+      this.streaming = null;
+    }
+
+    // Always set up polling as a fallback/supplement
+    this.pollTimer = setInterval(() => {
+      this.pollNotifications().catch((err) => {
+        console.error("[Mastodon] Error polling notifications:", err);
+      });
+    }, POLL_INTERVAL_MS);
+
+    // Initial poll
+    this.pollNotifications().catch((err) => {
+      console.error("[Mastodon] Error on initial notification poll:", err);
+    });
+  }
+
+  async stop(): Promise<void> {
+    // Stop streaming
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+      this.subscription = null;
+    }
+    this.streaming = null;
+
+    // Stop polling
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+
+    // Unsubscribe from bus
+    if (this.broadcastHandler) {
+      this.bus.offBroadcast(this.broadcastHandler);
+      this.broadcastHandler = null;
+    }
+
+    this.pendingResponses.clear();
+    this.myAccountId = null;
+    this.myAcct = null;
+
+    if (this.client) {
+      this.client = null;
+      this.io.emit("mastodon:status", { status: "disconnected" });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Public: post to Mastodon
+  // -------------------------------------------------------------------------
+
+  async createPost(text: string, visibility: mastodon.v1.StatusVisibility = "public"): Promise<{ id: string; url: string | null } | null> {
+    if (!this.client) return null;
+
+    const status = await this.client.v1.statuses.create({
+      status: text,
+      visibility,
+    });
+
+    return { id: status.id, url: status.url ?? null };
+  }
+
+  async getTimeline(limit = 20): Promise<mastodon.v1.Status[]> {
+    if (!this.client) return [];
+
+    const statuses = await this.client.v1.timelines.home.list({ limit });
+    return statuses;
+  }
+
+  // -------------------------------------------------------------------------
+  // Inbound: Mastodon notifications → COO
+  // -------------------------------------------------------------------------
+
+  private async pollNotifications(): Promise<void> {
+    if (!this.client || !this.myAccountId) return;
+
+    try {
+      const params: { limit: number; sinceId?: string; types?: readonly mastodon.v1.NotificationType[] } = {
+        limit: 30,
+        types: ["mention"] as const,
+      };
+      if (this.lastNotificationId) {
+        params.sinceId = this.lastNotificationId;
+      }
+
+      const notifications = await this.client.v1.notifications.list(params);
+
+      // Process from oldest to newest
+      const sorted = [...notifications].reverse();
+
+      for (const notif of sorted) {
+        if (notif.type === "mention") {
+          await this.handleMention(notif);
+        }
+        // Track the latest notification ID
+        if (!this.lastNotificationId || notif.id > this.lastNotificationId) {
+          this.lastNotificationId = notif.id;
+        }
+      }
+    } catch (err) {
+      if (err instanceof Error && (err.message.includes("401") || err.message.includes("403"))) {
+        console.error("[Mastodon] Authentication error, token may be invalid");
+        this.io.emit("mastodon:status", { status: "error" });
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  private async handleMention(notif: mastodon.v1.Notification): Promise<void> {
+    if (!notif.status || !notif.account) return;
+
+    const authorId = notif.account.id;
+    const authorAcct = notif.account.acct;
+
+    // Don't respond to our own posts
+    if (authorId === this.myAccountId) return;
+
+    // Check pairing
+    if (!isPaired(authorId)) {
+      const code = generatePairingCode(authorId, authorAcct);
+
+      // Reply with pairing instructions
+      await this.replyToStatus(
+        notif.status.id,
+        notif.status.visibility,
+        `@${authorAcct} I don't recognize you yet. Ask my owner to approve code ${code} in the Otterbot dashboard. Expires in 1 hour.`,
+      );
+
+      this.io.emit("mastodon:pairing-request", {
+        code,
+        mastodonId: authorId,
+        mastodonAcct: authorAcct,
+      });
+      return;
+    }
+
+    // Extract plain text from HTML content
+    const text = this.stripHtml(notif.status.content);
+    if (!text) return;
+
+    // Strip the bot's mention from the text
+    const cleanText = text
+      .replace(new RegExp(`@${this.myAcct}\\b`, "gi"), "")
+      .trim();
+    if (!cleanText) return;
+
+    await this.routeToCOO(authorId, authorAcct, notif.status.id, notif.status.visibility, cleanText);
+  }
+
+  private stripHtml(html: string): string {
+    return html
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/p><p>/gi, "\n\n")
+      .replace(/<[^>]+>/g, "")
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .trim();
+  }
+
+  private async routeToCOO(
+    authorId: string,
+    authorAcct: string,
+    statusId: string,
+    visibility: mastodon.v1.StatusVisibility,
+    content: string,
+  ): Promise<void> {
+    const db = getDb();
+    let conversationId = this.conversationMap.get(authorId);
+
+    if (!conversationId) {
+      // Create a new conversation for this Mastodon user
+      conversationId = nanoid();
+      const now = new Date().toISOString();
+      const title = `Mastodon: @${authorAcct} — ${content.slice(0, 60)}`;
+      const conversation: Conversation = {
+        id: conversationId,
+        title,
+        projectId: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      db.insert(schema.conversations).values(conversation).run();
+      this.coo.startNewConversation(conversationId, null, null);
+      this.io.emit("conversation:created", conversation);
+      this.conversationMap.set(authorId, conversationId);
+    } else {
+      // Update timestamp
+      db.update(schema.conversations)
+        .set({ updatedAt: new Date().toISOString() })
+        .where(eq(schema.conversations.id, conversationId))
+        .run();
+    }
+
+    // Track pending response
+    this.pendingResponses.set(conversationId, {
+      authorId,
+      statusId,
+      conversationId,
+      visibility,
+    });
+
+    // Send to COO via bus
+    this.bus.send({
+      fromAgentId: null, // External user
+      toAgentId: "coo",
+      type: MessageType.Chat,
+      content,
+      conversationId,
+      metadata: {
+        source: "mastodon",
+        mastodonId: authorId,
+        mastodonAcct: authorAcct,
+        statusId,
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound: COO → Mastodon
+  // -------------------------------------------------------------------------
+
+  private handleBusMessage(message: BusMessage): void {
+    // Only care about COO → CEO (null) responses
+    if (message.fromAgentId !== "coo" || message.toAgentId !== null) return;
+
+    const conversationId = message.conversationId;
+    if (!conversationId) return;
+
+    const pending = this.pendingResponses.get(conversationId);
+    if (!pending) return;
+
+    this.pendingResponses.delete(conversationId);
+
+    this.replyToStatus(
+      pending.statusId,
+      pending.visibility,
+      message.content,
+    ).catch((err) => {
+      console.error("[Mastodon] Error sending reply:", err);
+    });
+  }
+
+  private async replyToStatus(
+    inReplyToId: string,
+    visibility: mastodon.v1.StatusVisibility,
+    content: string,
+  ): Promise<void> {
+    if (!this.client) return;
+
+    const chunks = splitMessage(content, MASTODON_MAX_LENGTH);
+
+    let currentReplyId = inReplyToId;
+
+    for (const chunk of chunks) {
+      const status = await this.client.v1.statuses.create({
+        status: chunk,
+        inReplyToId: currentReplyId,
+        visibility,
+      });
+
+      // Thread subsequent chunks off the previous reply
+      currentReplyId = status.id;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Message splitting
+// ---------------------------------------------------------------------------
+
+function splitMessage(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLength) {
+    let splitIdx = -1;
+
+    // Try to split at paragraph boundary
+    const paragraphIdx = remaining.lastIndexOf("\n\n", maxLength);
+    if (paragraphIdx > maxLength * 0.3) {
+      splitIdx = paragraphIdx;
+    }
+
+    // Try sentence boundary
+    if (splitIdx === -1) {
+      const sentenceMatch = remaining.slice(0, maxLength).match(/.*[.!?]\s/s);
+      if (sentenceMatch) {
+        splitIdx = sentenceMatch[0].length;
+      }
+    }
+
+    // Hard cut at newline
+    if (splitIdx === -1) {
+      const newlineIdx = remaining.lastIndexOf("\n", maxLength);
+      if (newlineIdx > maxLength * 0.3) {
+        splitIdx = newlineIdx;
+      }
+    }
+
+    // Final fallback: hard cut at space
+    if (splitIdx === -1) {
+      const spaceIdx = remaining.lastIndexOf(" ", maxLength);
+      if (spaceIdx > maxLength * 0.3) {
+        splitIdx = spaceIdx;
+      }
+    }
+
+    // Absolute fallback
+    if (splitIdx === -1) {
+      splitIdx = maxLength;
+    }
+
+    chunks.push(remaining.slice(0, splitIdx).trimEnd());
+    remaining = remaining.slice(splitIdx).trimStart();
+  }
+
+  if (remaining) {
+    chunks.push(remaining);
+  }
+
+  return chunks;
+}

--- a/packages/server/src/mastodon/mastodon-settings.test.ts
+++ b/packages/server/src/mastodon/mastodon-settings.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PairedUser, PendingPairing } from "./pairing.js";
 
 const configStore = new Map<string, string>();
 
-const mockListPairedUsers = vi.fn(() => []);
-const mockListPendingPairings = vi.fn(() => []);
+const mockListPairedUsers = vi.fn((): PairedUser[] => []);
+const mockListPendingPairings = vi.fn((): PendingPairing[] => []);
 
 const mockVerifyCredentials = vi.fn();
 
@@ -14,8 +15,8 @@ vi.mock("../auth/auth.js", () => ({
 }));
 
 vi.mock("./pairing.js", () => ({
-  listPairedUsers: (...args: unknown[]) => mockListPairedUsers(...args),
-  listPendingPairings: (...args: unknown[]) => mockListPendingPairings(...args),
+  listPairedUsers: () => mockListPairedUsers(),
+  listPendingPairings: () => mockListPendingPairings(),
 }));
 
 vi.mock("masto", () => ({

--- a/packages/server/src/mastodon/mastodon-settings.test.ts
+++ b/packages/server/src/mastodon/mastodon-settings.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const configStore = new Map<string, string>();
+
+const mockListPairedUsers = vi.fn(() => []);
+const mockListPendingPairings = vi.fn(() => []);
+
+const mockVerifyCredentials = vi.fn();
+
+vi.mock("../auth/auth.js", () => ({
+  getConfig: vi.fn((key: string) => configStore.get(key)),
+  setConfig: vi.fn((key: string, value: string) => configStore.set(key, value)),
+  deleteConfig: vi.fn((key: string) => configStore.delete(key)),
+}));
+
+vi.mock("./pairing.js", () => ({
+  listPairedUsers: (...args: unknown[]) => mockListPairedUsers(...args),
+  listPendingPairings: (...args: unknown[]) => mockListPendingPairings(...args),
+}));
+
+vi.mock("masto", () => ({
+  createRestAPIClient: vi.fn(() => ({
+    v1: {
+      accounts: {
+        verifyCredentials: (...args: unknown[]) => mockVerifyCredentials(...args),
+      },
+    },
+  })),
+}));
+
+const { getMastodonSettings, updateMastodonSettings, testMastodonConnection } = await import("./mastodon-settings.js");
+
+describe("mastodon-settings", () => {
+  beforeEach(() => {
+    configStore.clear();
+    mockListPairedUsers.mockReset().mockReturnValue([]);
+    mockListPendingPairings.mockReset().mockReturnValue([]);
+    mockVerifyCredentials.mockReset();
+  });
+
+  it("returns defaults when unset", () => {
+    const settings = getMastodonSettings();
+
+    expect(settings).toEqual({
+      enabled: false,
+      credentialsSet: false,
+      displayName: null,
+      acct: null,
+      instanceUrl: "https://mastodon.social",
+      pairedUsers: [],
+      pendingPairings: [],
+    });
+  });
+
+  it("returns stored settings and pairing state", () => {
+    configStore.set("mastodon:enabled", "true");
+    configStore.set("mastodon:instance_url", "https://mastodon.example");
+    configStore.set("mastodon:access_token", "secret-token");
+    configStore.set("mastodon:display_name", "Otter Bot");
+    configStore.set("mastodon:acct", "otterbot");
+
+    const pairedUsers = [{ mastodonId: "u1", mastodonAcct: "alice", pairedAt: "2026-03-01T00:00:00.000Z" }];
+    const pendingPairings = [{ code: "ABC123", mastodonId: "u2", mastodonAcct: "bob", createdAt: "2026-03-01T00:00:00.000Z" }];
+    mockListPairedUsers.mockReturnValue(pairedUsers);
+    mockListPendingPairings.mockReturnValue(pendingPairings);
+
+    const settings = getMastodonSettings();
+
+    expect(settings.enabled).toBe(true);
+    expect(settings.credentialsSet).toBe(true);
+    expect(settings.instanceUrl).toBe("https://mastodon.example");
+    expect(settings.displayName).toBe("Otter Bot");
+    expect(settings.acct).toBe("otterbot");
+    expect(settings.pairedUsers).toEqual(pairedUsers);
+    expect(settings.pendingPairings).toEqual(pendingPairings);
+  });
+
+  it("updates enabled, instance URL, and token", () => {
+    updateMastodonSettings({
+      enabled: true,
+      instanceUrl: "https://mastodon.example",
+      accessToken: "token-123",
+    });
+
+    expect(configStore.get("mastodon:enabled")).toBe("true");
+    expect(configStore.get("mastodon:instance_url")).toBe("https://mastodon.example");
+    expect(configStore.get("mastodon:access_token")).toBe("token-123");
+  });
+
+  it("clears URL-related and token fields when empty strings are provided", () => {
+    configStore.set("mastodon:instance_url", "https://mastodon.example");
+    configStore.set("mastodon:acct", "otterbot");
+    configStore.set("mastodon:display_name", "Otter Bot");
+    configStore.set("mastodon:access_token", "token-123");
+
+    updateMastodonSettings({
+      instanceUrl: "",
+      accessToken: "",
+    });
+
+    expect(configStore.has("mastodon:instance_url")).toBe(false);
+    expect(configStore.has("mastodon:acct")).toBe(false);
+    expect(configStore.has("mastodon:display_name")).toBe(false);
+    expect(configStore.has("mastodon:access_token")).toBe(false);
+  });
+
+  it("returns error when credentials are missing", async () => {
+    const result = await testMastodonConnection();
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Mastodon credentials not configured.",
+    });
+  });
+
+  it("verifies connection and caches account metadata", async () => {
+    configStore.set("mastodon:instance_url", "https://mastodon.example");
+    configStore.set("mastodon:access_token", "token-123");
+
+    mockVerifyCredentials.mockResolvedValue({
+      id: "acct-id",
+      acct: "otterbot",
+      displayName: "Otter Bot",
+    });
+
+    const result = await testMastodonConnection();
+
+    expect(result.ok).toBe(true);
+    expect(result.id).toBe("acct-id");
+    expect(result.acct).toBe("otterbot");
+    expect(result.displayName).toBe("Otter Bot");
+    expect(typeof result.latencyMs).toBe("number");
+
+    expect(configStore.get("mastodon:acct")).toBe("otterbot");
+    expect(configStore.get("mastodon:display_name")).toBe("Otter Bot");
+  });
+
+  it("returns SDK errors from verification", async () => {
+    configStore.set("mastodon:instance_url", "https://mastodon.example");
+    configStore.set("mastodon:access_token", "token-123");
+
+    mockVerifyCredentials.mockRejectedValue(new Error("Unauthorized"));
+
+    const result = await testMastodonConnection();
+
+    expect(result).toEqual({ ok: false, error: "Unauthorized" });
+  });
+});

--- a/packages/server/src/mastodon/mastodon-settings.ts
+++ b/packages/server/src/mastodon/mastodon-settings.ts
@@ -1,0 +1,114 @@
+import { createRestAPIClient } from "masto";
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+import { listPairedUsers, listPendingPairings } from "./pairing.js";
+import type { PairedUser, PendingPairing } from "./pairing.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MastodonSettingsResponse {
+  enabled: boolean;
+  credentialsSet: boolean;
+  displayName: string | null;
+  acct: string | null;
+  instanceUrl: string;
+  pairedUsers: PairedUser[];
+  pendingPairings: PendingPairing[];
+}
+
+export interface MastodonTestResult {
+  ok: boolean;
+  error?: string;
+  latencyMs?: number;
+  acct?: string;
+  id?: string;
+  displayName?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Settings CRUD
+// ---------------------------------------------------------------------------
+
+export function getMastodonSettings(): MastodonSettingsResponse {
+  return {
+    enabled: getConfig("mastodon:enabled") === "true",
+    credentialsSet: !!getConfig("mastodon:instance_url") && !!getConfig("mastodon:access_token"),
+    displayName: getConfig("mastodon:display_name") ?? null,
+    acct: getConfig("mastodon:acct") ?? null,
+    instanceUrl: getConfig("mastodon:instance_url") ?? "https://mastodon.social",
+    pairedUsers: listPairedUsers(),
+    pendingPairings: listPendingPairings(),
+  };
+}
+
+export function updateMastodonSettings(data: {
+  enabled?: boolean;
+  instanceUrl?: string;
+  accessToken?: string;
+}): void {
+  if (data.enabled !== undefined) {
+    setConfig("mastodon:enabled", data.enabled ? "true" : "false");
+  }
+  if (data.instanceUrl !== undefined) {
+    if (data.instanceUrl === "") {
+      deleteConfig("mastodon:instance_url");
+      deleteConfig("mastodon:acct");
+      deleteConfig("mastodon:display_name");
+    } else {
+      setConfig("mastodon:instance_url", data.instanceUrl);
+    }
+  }
+  if (data.accessToken !== undefined) {
+    if (data.accessToken === "") {
+      deleteConfig("mastodon:access_token");
+    } else {
+      setConfig("mastodon:access_token", data.accessToken);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connection test
+// ---------------------------------------------------------------------------
+
+export async function testMastodonConnection(): Promise<MastodonTestResult> {
+  const instanceUrl = getConfig("mastodon:instance_url");
+  const accessToken = getConfig("mastodon:access_token");
+
+  if (!instanceUrl || !accessToken) {
+    return { ok: false, error: "Mastodon credentials not configured." };
+  }
+
+  const start = Date.now();
+
+  try {
+    const client = createRestAPIClient({
+      url: instanceUrl,
+      accessToken,
+    });
+
+    const account = await client.v1.accounts.verifyCredentials();
+
+    // Cache the resolved account info
+    if (account.acct) {
+      setConfig("mastodon:acct", account.acct);
+    }
+    if (account.displayName) {
+      setConfig("mastodon:display_name", account.displayName);
+    }
+
+    return {
+      ok: true,
+      latencyMs: Date.now() - start,
+      acct: account.acct,
+      id: account.id,
+      displayName: account.displayName,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/packages/server/src/mastodon/pairing.test.ts
+++ b/packages/server/src/mastodon/pairing.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrateDb, resetDb } from "../db/index.js";
+import { getConfig, setConfig } from "../auth/auth.js";
+import {
+  approvePairing,
+  generatePairingCode,
+  getPairedUser,
+  isPaired,
+  listPairedUsers,
+  listPendingPairings,
+  rejectPairing,
+  revokePairing,
+} from "./pairing.js";
+
+describe("mastodon pairing", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-mastodon-pairing-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+  });
+
+  afterEach(() => {
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("generates a pairing code and replaces previous code for same user", () => {
+    const firstCode = generatePairingCode("u1", "alice");
+    const secondCode = generatePairingCode("u1", "alice");
+
+    expect(firstCode).toMatch(/^[A-F0-9]{6}$/);
+    expect(secondCode).toMatch(/^[A-F0-9]{6}$/);
+    expect(getConfig(`mastodon:pairing:${firstCode}`)).toBeUndefined();
+    expect(getConfig(`mastodon:pairing:${secondCode}`)).toBeDefined();
+  });
+
+  it("approves valid pairing codes and persists paired user", () => {
+    const code = generatePairingCode("u1", "alice");
+
+    const paired = approvePairing(code);
+
+    expect(paired).not.toBeNull();
+    expect(paired?.mastodonId).toBe("u1");
+    expect(paired?.mastodonAcct).toBe("alice");
+    expect(getConfig(`mastodon:pairing:${code}`)).toBeUndefined();
+    expect(isPaired("u1")).toBe(true);
+    expect(getPairedUser("u1")?.mastodonAcct).toBe("alice");
+  });
+
+  it("rejects expired pairing codes and cleans them up", () => {
+    const oldCreatedAt = new Date(Date.now() - 61 * 60 * 1000).toISOString();
+    setConfig(
+      "mastodon:pairing:EXPIRE1",
+      JSON.stringify({
+        code: "EXPIRE1",
+        mastodonId: "u-expired",
+        mastodonAcct: "expired-user",
+        createdAt: oldCreatedAt,
+      }),
+    );
+
+    const approved = approvePairing("EXPIRE1");
+
+    expect(approved).toBeNull();
+    expect(getConfig("mastodon:pairing:EXPIRE1")).toBeUndefined();
+    expect(isPaired("u-expired")).toBe(false);
+  });
+
+  it("lists pending pairings and cleans expired entries", () => {
+    const freshCreatedAt = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    const oldCreatedAt = new Date(Date.now() - 61 * 60 * 1000).toISOString();
+
+    setConfig(
+      "mastodon:pairing:FRESH1",
+      JSON.stringify({
+        code: "FRESH1",
+        mastodonId: "u-fresh",
+        mastodonAcct: "fresh-user",
+        createdAt: freshCreatedAt,
+      }),
+    );
+
+    setConfig(
+      "mastodon:pairing:EXPIRE2",
+      JSON.stringify({
+        code: "EXPIRE2",
+        mastodonId: "u-expired",
+        mastodonAcct: "expired-user",
+        createdAt: oldCreatedAt,
+      }),
+    );
+
+    const pending = listPendingPairings();
+
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.code).toBe("FRESH1");
+    expect(getConfig("mastodon:pairing:EXPIRE2")).toBeUndefined();
+  });
+
+  it("rejects and revokes pairings", () => {
+    const code = generatePairingCode("u1", "alice");
+
+    expect(rejectPairing(code)).toBe(true);
+    expect(rejectPairing(code)).toBe(false);
+
+    const nextCode = generatePairingCode("u2", "bob");
+    approvePairing(nextCode);
+
+    expect(revokePairing("u2")).toBe(true);
+    expect(revokePairing("u2")).toBe(false);
+  });
+
+  it("lists only valid paired users", () => {
+    const code = generatePairingCode("u1", "alice");
+    approvePairing(code);
+
+    setConfig("mastodon:paired:broken", "not-json");
+
+    const paired = listPairedUsers();
+
+    expect(paired).toHaveLength(1);
+    expect(paired[0]?.mastodonId).toBe("u1");
+  });
+});

--- a/packages/server/src/mastodon/pairing.ts
+++ b/packages/server/src/mastodon/pairing.ts
@@ -1,0 +1,152 @@
+import { randomBytes } from "node:crypto";
+import { like } from "drizzle-orm";
+import { getDb, schema } from "../db/index.js";
+import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateCode(): string {
+  return randomBytes(3).toString("hex").toUpperCase(); // 6-char hex
+}
+
+const PAIRING_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export interface PendingPairing {
+  code: string;
+  mastodonId: string;
+  mastodonAcct: string;
+  createdAt: string;
+}
+
+export interface PairedUser {
+  mastodonId: string;
+  mastodonAcct: string;
+  pairedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Config-prefix query helper
+// ---------------------------------------------------------------------------
+
+function getConfigsByPrefix(prefix: string): Array<{ key: string; value: string }> {
+  const db = getDb();
+  return db
+    .select({ key: schema.config.key, value: schema.config.value })
+    .from(schema.config)
+    .where(like(schema.config.key, `${prefix}%`))
+    .all();
+}
+
+// ---------------------------------------------------------------------------
+// Pairing code management
+// ---------------------------------------------------------------------------
+
+export function generatePairingCode(mastodonId: string, mastodonAcct: string): string {
+  // Remove any existing code for this user
+  const existing = getConfigsByPrefix("mastodon:pairing:");
+  for (const row of existing) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (data.mastodonId === mastodonId) {
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+
+  const code = generateCode();
+  const data: PendingPairing = {
+    code,
+    mastodonId,
+    mastodonAcct,
+    createdAt: new Date().toISOString(),
+  };
+  setConfig(`mastodon:pairing:${code}`, JSON.stringify(data));
+  return code;
+}
+
+export function isPaired(mastodonId: string): boolean {
+  return !!getConfig(`mastodon:paired:${mastodonId}`);
+}
+
+export function getPairedUser(mastodonId: string): PairedUser | null {
+  const raw = getConfig(`mastodon:paired:${mastodonId}`);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as PairedUser;
+  } catch {
+    return null;
+  }
+}
+
+export function approvePairing(code: string): PairedUser | null {
+  const raw = getConfig(`mastodon:pairing:${code}`);
+  if (!raw) return null;
+
+  let pending: PendingPairing;
+  try {
+    pending = JSON.parse(raw) as PendingPairing;
+  } catch {
+    return null;
+  }
+
+  // Check expiry
+  if (Date.now() - new Date(pending.createdAt).getTime() > PAIRING_TTL_MS) {
+    deleteConfig(`mastodon:pairing:${code}`);
+    return null;
+  }
+
+  const paired: PairedUser = {
+    mastodonId: pending.mastodonId,
+    mastodonAcct: pending.mastodonAcct,
+    pairedAt: new Date().toISOString(),
+  };
+
+  setConfig(`mastodon:paired:${pending.mastodonId}`, JSON.stringify(paired));
+  deleteConfig(`mastodon:pairing:${code}`);
+  return paired;
+}
+
+export function rejectPairing(code: string): boolean {
+  const raw = getConfig(`mastodon:pairing:${code}`);
+  if (!raw) return false;
+  deleteConfig(`mastodon:pairing:${code}`);
+  return true;
+}
+
+export function revokePairing(mastodonId: string): boolean {
+  const raw = getConfig(`mastodon:paired:${mastodonId}`);
+  if (!raw) return false;
+  deleteConfig(`mastodon:paired:${mastodonId}`);
+  return true;
+}
+
+export function listPairedUsers(): PairedUser[] {
+  const rows = getConfigsByPrefix("mastodon:paired:");
+  const users: PairedUser[] = [];
+  for (const row of rows) {
+    try {
+      users.push(JSON.parse(row.value) as PairedUser);
+    } catch { /* ignore malformed */ }
+  }
+  return users;
+}
+
+export function listPendingPairings(): PendingPairing[] {
+  const rows = getConfigsByPrefix("mastodon:pairing:");
+  const now = Date.now();
+  const pending: PendingPairing[] = [];
+  for (const row of rows) {
+    try {
+      const data = JSON.parse(row.value) as PendingPairing;
+      if (now - new Date(data.createdAt).getTime() <= PAIRING_TTL_MS) {
+        pending.push(data);
+      } else {
+        // Clean up expired
+        deleteConfig(row.key);
+      }
+    } catch { /* ignore malformed */ }
+  }
+  return pending;
+}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -71,6 +71,8 @@ export interface ServerToClientEvents {
   "signal:status": (data: { status: "connected" | "disconnected" | "error"; phoneNumber?: string }) => void;
   "nextcloud-talk:pairing-request": (data: { code: string; nextcloudUserId: string; nextcloudDisplayName: string }) => void;
   "nextcloud-talk:status": (data: { status: "connected" | "disconnected" | "error"; botUsername?: string }) => void;
+  "mastodon:pairing-request": (data: { code: string; mastodonId: string; mastodonAcct: string }) => void;
+  "mastodon:status": (data: { status: "connected" | "disconnected" | "error"; acct?: string }) => void;
   "merge-queue:updated": (data: { entries: MergeQueueEntry[] }) => void;
   "merge-queue:entry-updated": (entry: MergeQueueEntry) => void;
   "mcp:status": (runtime: McpServerRuntime) => void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       mailparser:
         specifier: ^3.9.3
         version: 3.9.3
+      masto:
+        specifier: ^7.10.2
+        version: 7.10.2
       matrix-js-sdk:
         specifier: ^34.11.1
         version: 34.13.0
@@ -2730,6 +2733,9 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -3500,6 +3506,9 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  events-to-async@2.0.2:
+    resolution: {integrity: sha512-WzI6m/SU+F38t2tejHh6IQuQkNZ0dMOmSEmODJb9czaeMYtQ5FVZ+b6DOHr3hC6hNKNnn9CwDUN8mJiAkWSI9Q==}
+
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
@@ -4214,6 +4223,11 @@ packages:
   isomorphic-textencoder@1.0.1:
     resolution: {integrity: sha512-676hESgHullDdHDsj469hr+7t3i/neBKU9J7q1T4RHaWwLAsaQnywC0D1dIUId0YZ+JtVrShzuBk1soo0+GVcQ==}
 
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
@@ -4495,6 +4509,9 @@ packages:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  masto@7.10.2:
+    resolution: {integrity: sha512-zJr0NyKne9eljadKxS/ZJI5bBhlLQsn8WWXCGlRxIg6lb5J84O5IlWJG8CF7mMLj4avEzrN9fuEjtJVagonIXg==}
 
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
@@ -5854,6 +5871,10 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-custom-error@3.3.1:
+    resolution: {integrity: sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==}
+    engines: {node: '>=14.0.0'}
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -8746,6 +8767,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  change-case@5.4.4: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -9585,6 +9608,8 @@ snapshots:
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
+
+  events-to-async@2.0.2: {}
 
   events-universal@1.0.1:
     dependencies:
@@ -10434,6 +10459,10 @@ snapshots:
     dependencies:
       fast-text-encoding: 1.0.6
 
+  isomorphic-ws@5.0.0(ws@8.19.0):
+    dependencies:
+      ws: 8.19.0
+
   isstream@0.1.2: {}
 
   istanbul-lib-coverage@3.2.2: {}
@@ -10722,6 +10751,17 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
+
+  masto@7.10.2:
+    dependencies:
+      change-case: 5.4.4
+      events-to-async: 2.0.2
+      isomorphic-ws: 5.0.0(ws@8.19.0)
+      ts-custom-error: 3.3.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   matcher@3.0.0:
     dependencies:
@@ -12587,6 +12627,8 @@ snapshots:
   troika-worker-utils@0.52.0: {}
 
   trough@2.2.0: {}
+
+  ts-custom-error@3.3.1: {}
 
   ts-dedent@2.2.0: {}
 


### PR DESCRIPTION
## Summary

- Adds Mastodon integration using the `masto` (masto.js) library with streaming + polling fallback for real-time mention notifications
- Implements pairing system (generate code → approve/reject/revoke) consistent with existing bridges (Signal, Nextcloud Talk, etc.)
- Routes mentions from paired users to COO and replies with responses, threading long messages and respecting post visibility
- Adds settings CRUD, connection test endpoint, and WebSocket events for frontend status updates
- Includes comprehensive test coverage for bridge, settings, and pairing modules (all 1266 tests pass)

Closes #383

## Test plan

- [x] All existing tests pass (1266 tests, 103 files)
- [x] New tests cover: pairing lifecycle, settings CRUD, connection testing, bridge mention handling, COO response routing
- [ ] Manual: configure Mastodon instance URL + access token, verify connection test works
- [ ] Manual: mention the bot from an unpaired account, verify pairing code flow
- [ ] Manual: approve pairing, send mention, verify COO response is posted as reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)