### PR TITLE
feat: add Google Chat channel support

### DIFF
--- a/packages/server/src/googlechat/google-chat-bridge.test.ts
+++ b/packages/server/src/googlechat/google-chat-bridge.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MessageType } from "@otterbot/shared";
+import type { BusMessage } from "@otterbot/shared";
+import { migrateDb, resetDb } from "../db/index.js";
+import { setConfig } from "../auth/auth.js";
+
+const mockChatCreate = vi.fn();
+const mockGoogleAuthConstructor = vi.fn();
+const mockOAuthVerifyIdToken = vi.fn();
+
+vi.mock("nanoid", () => ({
+  nanoid: vi.fn(() => "conv-googlechat-1"),
+}));
+
+vi.mock("googleapis", () => ({
+  google: {
+    auth: {
+      GoogleAuth: class {
+        constructor(config: Record<string, unknown>) {
+          mockGoogleAuthConstructor(config);
+        }
+      },
+    },
+    chat: vi.fn(() => ({
+      spaces: {
+        messages: {
+          create: (...args: unknown[]) => mockChatCreate(...args),
+        },
+      },
+    })),
+  },
+}));
+
+vi.mock("google-auth-library", () => ({
+  OAuth2Client: class {
+    verifyIdToken = (...args: unknown[]) => mockOAuthVerifyIdToken(...args);
+  },
+}));
+
+const { GoogleChatBridge } = await import("./google-chat-bridge.js");
+
+type SendParams = {
+  fromAgentId: string | null;
+  toAgentId: string | null;
+  type: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  conversationId?: string;
+};
+
+function createMockBus() {
+  const sent: SendParams[] = [];
+  const broadcastHandlers: ((message: BusMessage) => void)[] = [];
+
+  return {
+    send: vi.fn((params: SendParams) => {
+      sent.push(params);
+      return {
+        id: "msg-1",
+        timestamp: new Date().toISOString(),
+        metadata: {},
+        ...params,
+      };
+    }),
+    onBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      broadcastHandlers.push(handler);
+    }),
+    offBroadcast: vi.fn((handler: (message: BusMessage) => void) => {
+      const idx = broadcastHandlers.indexOf(handler);
+      if (idx >= 0) broadcastHandlers.splice(idx, 1);
+    }),
+    _sent: sent,
+    _broadcastHandlers: broadcastHandlers,
+  };
+}
+
+function createMockCoo() {
+  return {
+    startNewConversation: vi.fn(),
+  };
+}
+
+function createMockIo() {
+  return {
+    emit: vi.fn(),
+  };
+}
+
+describe("GoogleChatBridge", () => {
+  let tmpDir: string;
+  let bus: ReturnType<typeof createMockBus>;
+  let coo: ReturnType<typeof createMockCoo>;
+  let io: ReturnType<typeof createMockIo>;
+  let bridge: InstanceType<typeof GoogleChatBridge>;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-googlechat-bridge-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+
+    mockChatCreate.mockReset().mockResolvedValue({});
+    mockGoogleAuthConstructor.mockReset();
+    mockOAuthVerifyIdToken.mockReset().mockResolvedValue({
+      getPayload: () => ({ email: "chat@system.gserviceaccount.com" }),
+    });
+
+    bus = createMockBus();
+    coo = createMockCoo();
+    io = createMockIo();
+    bridge = new GoogleChatBridge({
+      bus: bus as any,
+      coo: coo as any,
+      io: io as any,
+    });
+  });
+
+  afterEach(async () => {
+    await bridge.stop();
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function startBridge() {
+    await bridge.start({
+      serviceAccountKey: {
+        client_email: "bot@example.com",
+        private_key: "private-key",
+      },
+      projectNumber: "123456789",
+    });
+  }
+
+  it("starts and emits connected status", async () => {
+    await startBridge();
+
+    expect(mockGoogleAuthConstructor).toHaveBeenCalledWith(expect.objectContaining({
+      credentials: expect.objectContaining({
+        client_email: "bot@example.com",
+      }),
+      scopes: ["https://www.googleapis.com/auth/chat.bot"],
+    }));
+    expect(bus.onBroadcast).toHaveBeenCalledOnce();
+    expect(io.emit).toHaveBeenCalledWith("googlechat:status", { status: "connected" });
+  });
+
+  it("throws when Authorization header is missing", async () => {
+    await startBridge();
+
+    await expect(bridge.verifyBearerToken(undefined)).rejects.toThrow("Missing or invalid Authorization header");
+  });
+
+  it("throws when token issuer is not Google Chat", async () => {
+    await startBridge();
+    mockOAuthVerifyIdToken.mockResolvedValueOnce({
+      getPayload: () => ({ email: "someone@example.com" }),
+    });
+
+    await expect(bridge.verifyBearerToken("Bearer valid-token")).rejects.toThrow("Token issuer is not Google Chat");
+  });
+
+  it("returns welcome text for ADDED_TO_SPACE events", async () => {
+    await startBridge();
+
+    const result = await bridge.handleWebhook({ type: "ADDED_TO_SPACE" }, "Bearer token");
+
+    expect(result).toEqual({ text: "Hello! I'm Otterbot. Send me a message to get started." });
+  });
+
+  it("returns pairing instructions for unpaired users and emits pairing-request", async () => {
+    await startBridge();
+
+    const result = await bridge.handleWebhook(
+      {
+        type: "MESSAGE",
+        space: { name: "spaces/AAA" },
+        message: {
+          text: "Hello",
+          sender: { name: "users/unpaired", displayName: "Alice", type: "HUMAN" },
+        },
+      },
+      "Bearer token",
+    );
+
+    expect(result).toEqual(expect.objectContaining({
+      text: expect.stringContaining("To pair with me"),
+    }));
+    expect(io.emit).toHaveBeenCalledWith(
+      "googlechat:pairing-request",
+      expect.objectContaining({
+        googleChatUserId: "users/unpaired",
+        googleChatUsername: "Alice",
+        code: expect.stringMatching(/^[A-F0-9]{6}$/),
+      }),
+    );
+    expect(bus.send).not.toHaveBeenCalled();
+  });
+
+  it("routes paired user message to COO and creates a conversation", async () => {
+    await startBridge();
+    setConfig("googlechat:paired:users/paired", JSON.stringify({
+      googleChatUserId: "users/paired",
+      googleChatUsername: "Paired User",
+      pairedAt: new Date().toISOString(),
+    }));
+
+    const result = await bridge.handleWebhook(
+      {
+        type: "MESSAGE",
+        space: { name: "spaces/AAA" },
+        message: {
+          text: "Need help",
+          sender: { name: "users/paired", displayName: "Paired User", type: "HUMAN" },
+          thread: { name: "spaces/AAA/threads/123" },
+        },
+      },
+      "Bearer token",
+    );
+
+    expect(result).toEqual({});
+    expect(coo.startNewConversation).toHaveBeenCalledWith("conv-googlechat-1", null, null);
+    expect(io.emit).toHaveBeenCalledWith(
+      "conversation:created",
+      expect.objectContaining({
+        id: "conv-googlechat-1",
+        title: expect.stringContaining("Google Chat: Paired User"),
+      }),
+    );
+    expect(bus.send).toHaveBeenCalledWith(expect.objectContaining({
+      toAgentId: "coo",
+      type: MessageType.Chat,
+      content: "Need help",
+      conversationId: "conv-googlechat-1",
+      metadata: expect.objectContaining({
+        source: "googlechat",
+        googleChatUserId: "users/paired",
+        googleChatSpaceName: "spaces/AAA",
+        googleChatThreadName: "spaces/AAA/threads/123",
+      }),
+    }));
+  });
+
+  it("sends long COO replies in chunks to Google Chat", async () => {
+    await startBridge();
+    setConfig("googlechat:paired:users/paired", JSON.stringify({
+      googleChatUserId: "users/paired",
+      googleChatUsername: "Paired User",
+      pairedAt: new Date().toISOString(),
+    }));
+
+    await bridge.handleWebhook(
+      {
+        type: "MESSAGE",
+        space: { name: "spaces/BBB" },
+        message: {
+          text: "Start",
+          sender: { name: "users/paired", displayName: "Paired User", type: "HUMAN" },
+        },
+      },
+      "Bearer token",
+    );
+
+    const broadcast = bus._broadcastHandlers[0];
+    expect(broadcast).toBeTypeOf("function");
+
+    broadcast!({
+      id: "coo-msg-1",
+      fromAgentId: "coo",
+      toAgentId: null,
+      type: MessageType.Chat,
+      content: "A".repeat(9001),
+      metadata: {},
+      conversationId: "conv-googlechat-1",
+      timestamp: new Date().toISOString(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockChatCreate).toHaveBeenCalledTimes(3);
+    for (const call of mockChatCreate.mock.calls) {
+      expect(call[0]).toEqual(expect.objectContaining({
+        parent: "spaces/BBB",
+        requestBody: { text: expect.any(String) },
+      }));
+    }
+  });
+
+  it("stops and emits disconnected status", async () => {
+    await startBridge();
+    await bridge.stop();
+
+    expect(bus.offBroadcast).toHaveBeenCalledOnce();
+    expect(io.emit).toHaveBeenCalledWith("googlechat:status", { status: "disconnected" });
+  });
+});

--- a/packages/server/src/googlechat/google-chat-settings.test.ts
+++ b/packages/server/src/googlechat/google-chat-settings.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PairedUser, PendingPairing } from "./pairing.js";
+
+const configStore = new Map<string, string>();
+const mockListPairedUsers = vi.fn((): PairedUser[] => []);
+const mockListPendingPairings = vi.fn((): PendingPairing[] => []);
+const mockGetClient = vi.fn();
+const mockGoogleAuthConstructor = vi.fn();
+
+vi.mock("../auth/auth.js", () => ({
+  getConfig: vi.fn((key: string) => configStore.get(key)),
+  setConfig: vi.fn((key: string, value: string) => configStore.set(key, value)),
+  deleteConfig: vi.fn((key: string) => configStore.delete(key)),
+}));
+
+vi.mock("./pairing.js", () => ({
+  listPairedUsers: () => mockListPairedUsers(),
+  listPendingPairings: () => mockListPendingPairings(),
+}));
+
+vi.mock("googleapis", () => ({
+  google: {
+    auth: {
+      GoogleAuth: class {
+        constructor(config: Record<string, unknown>) {
+          mockGoogleAuthConstructor(config);
+        }
+
+        getClient = (...args: unknown[]) => mockGetClient(...args);
+      },
+    },
+  },
+}));
+
+const {
+  getGoogleChatSettings,
+  updateGoogleChatSettings,
+  testGoogleChatConnection,
+} = await import("./google-chat-settings.js");
+
+describe("google-chat-settings", () => {
+  beforeEach(() => {
+    configStore.clear();
+    mockListPairedUsers.mockReset().mockReturnValue([]);
+    mockListPendingPairings.mockReset().mockReturnValue([]);
+    mockGetClient.mockReset().mockResolvedValue({});
+    mockGoogleAuthConstructor.mockReset();
+  });
+
+  it("returns defaults when unset", () => {
+    const settings = getGoogleChatSettings();
+
+    expect(settings).toEqual({
+      enabled: false,
+      serviceAccountKeySet: false,
+      projectNumber: "",
+      pairedUsers: [],
+      pendingPairings: [],
+    });
+  });
+
+  it("returns stored settings and pairing lists", () => {
+    configStore.set("googlechat:enabled", "true");
+    configStore.set("googlechat:service_account_key", JSON.stringify({ client_email: "a", private_key: "b" }));
+    configStore.set("googlechat:project_number", "123456");
+
+    const pairedUsers = [{ googleChatUserId: "users/1", googleChatUsername: "Alice", pairedAt: "2026-03-01T00:00:00.000Z" }];
+    const pendingPairings = [{ code: "ABC123", googleChatUserId: "users/2", googleChatUsername: "Bob", createdAt: "2026-03-01T00:00:00.000Z" }];
+    mockListPairedUsers.mockReturnValue(pairedUsers);
+    mockListPendingPairings.mockReturnValue(pendingPairings);
+
+    const settings = getGoogleChatSettings();
+
+    expect(settings.enabled).toBe(true);
+    expect(settings.serviceAccountKeySet).toBe(true);
+    expect(settings.projectNumber).toBe("123456");
+    expect(settings.pairedUsers).toEqual(pairedUsers);
+    expect(settings.pendingPairings).toEqual(pendingPairings);
+  });
+
+  it("updates and clears settings fields", () => {
+    updateGoogleChatSettings({
+      enabled: true,
+      serviceAccountKey: "service-key",
+      projectNumber: "999999",
+    });
+
+    expect(configStore.get("googlechat:enabled")).toBe("true");
+    expect(configStore.get("googlechat:service_account_key")).toBe("service-key");
+    expect(configStore.get("googlechat:project_number")).toBe("999999");
+
+    updateGoogleChatSettings({
+      serviceAccountKey: "",
+      projectNumber: "",
+    });
+
+    expect(configStore.has("googlechat:service_account_key")).toBe(false);
+    expect(configStore.has("googlechat:project_number")).toBe(false);
+  });
+
+  it("returns error when service account key is missing", async () => {
+    const result = await testGoogleChatConnection();
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Google Chat service account key must be configured.",
+    });
+  });
+
+  it("returns error for invalid JSON", async () => {
+    configStore.set("googlechat:service_account_key", "{broken");
+
+    const result = await testGoogleChatConnection();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/JSON|position|Expected/);
+  });
+
+  it("returns validation error when key lacks required fields", async () => {
+    configStore.set("googlechat:service_account_key", JSON.stringify({ client_email: "bot@example.com" }));
+
+    const result = await testGoogleChatConnection();
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Service account key is missing client_email or private_key.",
+    });
+  });
+
+  it("returns ok and configures GoogleAuth for valid credentials", async () => {
+    configStore.set("googlechat:service_account_key", JSON.stringify({
+      client_email: "bot@example.com",
+      private_key: "private-key",
+      project_id: "my-project",
+    }));
+
+    const result = await testGoogleChatConnection();
+
+    expect(result).toEqual({ ok: true });
+    expect(mockGoogleAuthConstructor).toHaveBeenCalledWith(expect.objectContaining({
+      credentials: expect.objectContaining({
+        client_email: "bot@example.com",
+        private_key: "private-key",
+      }),
+      scopes: ["https://www.googleapis.com/auth/chat.bot"],
+    }));
+    expect(mockGetClient).toHaveBeenCalledOnce();
+  });
+
+  it("returns auth errors from GoogleAuth client initialization", async () => {
+    configStore.set("googlechat:service_account_key", JSON.stringify({
+      client_email: "bot@example.com",
+      private_key: "private-key",
+    }));
+    mockGetClient.mockRejectedValue(new Error("invalid key"));
+
+    const result = await testGoogleChatConnection();
+
+    expect(result).toEqual({ ok: false, error: "invalid key" });
+  });
+});

--- a/packages/server/src/googlechat/pairing.test.ts
+++ b/packages/server/src/googlechat/pairing.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrateDb, resetDb } from "../db/index.js";
+import { getConfig, setConfig } from "../auth/auth.js";
+import {
+  approvePairing,
+  generatePairingCode,
+  getPairedUser,
+  isPaired,
+  listPairedUsers,
+  listPendingPairings,
+  rejectPairing,
+  revokePairing,
+} from "./pairing.js";
+
+describe("googlechat pairing", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "otterbot-googlechat-pairing-test-"));
+    resetDb();
+    process.env.DATABASE_URL = `file:${join(tmpDir, "test.db")}`;
+    process.env.OTTERBOT_DB_KEY = "test-key";
+    await migrateDb();
+  });
+
+  afterEach(() => {
+    resetDb();
+    delete process.env.DATABASE_URL;
+    delete process.env.OTTERBOT_DB_KEY;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("generates and replaces pending code for the same Google Chat user", () => {
+    const first = generatePairingCode("users/1", "Alice");
+    const second = generatePairingCode("users/1", "Alice");
+
+    expect(first).toMatch(/^[A-F0-9]{6}$/);
+    expect(second).toMatch(/^[A-F0-9]{6}$/);
+    expect(getConfig(`googlechat:pairing:${first}`)).toBeUndefined();
+    expect(getConfig(`googlechat:pairing:${second}`)).toBeDefined();
+  });
+
+  it("approves valid codes and persists paired user", () => {
+    const code = generatePairingCode("users/1", "Alice");
+
+    const paired = approvePairing(code);
+
+    expect(paired).toMatchObject({
+      googleChatUserId: "users/1",
+      googleChatUsername: "Alice",
+    });
+    expect(isPaired("users/1")).toBe(true);
+    expect(getPairedUser("users/1")).toMatchObject({
+      googleChatUserId: "users/1",
+      googleChatUsername: "Alice",
+    });
+    expect(getConfig(`googlechat:pairing:${code}`)).toBeUndefined();
+  });
+
+  it("rejects expired pairing codes and deletes them", () => {
+    setConfig("googlechat:pairing:EXPIRED", JSON.stringify({
+      code: "EXPIRED",
+      googleChatUserId: "users/old",
+      googleChatUsername: "Old User",
+      createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    }));
+
+    const approved = approvePairing("EXPIRED");
+
+    expect(approved).toBeNull();
+    expect(getConfig("googlechat:pairing:EXPIRED")).toBeUndefined();
+  });
+
+  it("lists paired users and filters malformed or expired pending records", () => {
+    setConfig("googlechat:paired:users/1", JSON.stringify({
+      googleChatUserId: "users/1",
+      googleChatUsername: "Alice",
+      pairedAt: new Date().toISOString(),
+    }));
+    setConfig("googlechat:paired:broken", "{bad-json");
+
+    setConfig("googlechat:pairing:VALID1", JSON.stringify({
+      code: "VALID1",
+      googleChatUserId: "users/2",
+      googleChatUsername: "Bob",
+      createdAt: new Date().toISOString(),
+    }));
+    setConfig("googlechat:pairing:EXPIRED", JSON.stringify({
+      code: "EXPIRED",
+      googleChatUserId: "users/3",
+      googleChatUsername: "Carol",
+      createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    }));
+    setConfig("googlechat:pairing:BROKEN", "{bad-json");
+
+    const paired = listPairedUsers();
+    const pending = listPendingPairings();
+
+    expect(paired).toHaveLength(1);
+    expect(paired[0]?.googleChatUserId).toBe("users/1");
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.code).toBe("VALID1");
+    expect(getConfig("googlechat:pairing:EXPIRED")).toBeUndefined();
+  });
+
+  it("rejects and revokes pairings", () => {
+    const code = generatePairingCode("users/1", "Alice");
+
+    expect(rejectPairing(code)).toBe(true);
+    expect(rejectPairing(code)).toBe(false);
+
+    const code2 = generatePairingCode("users/2", "Bob");
+    expect(approvePairing(code2)).toBeTruthy();
+
+    expect(revokePairing("users/2")).toBe(true);
+    expect(revokePairing("users/2")).toBe(false);
+    expect(isPaired("users/2")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Google Chat as a messaging channel integration using the Google Chat API / Bot framework with HTTP webhook push model
- Implement JWT-based webhook token verification using `google-auth-library` to authenticate incoming events from Google Chat
- Add pairing flow (consistent with Telegram, WhatsApp, Teams) for users to link their Google Chat identity
- Add settings CRUD, connection test, and UI integration in the channels section

Closes #228

## Test plan
- [x] All 1335 tests pass (112 test files), including new Google Chat tests
- [x] `google-chat-bridge.test.ts` — bridge lifecycle, webhook handling, pairing flow, message routing, chunked replies
- [x] `google-chat-settings.test.ts` — settings CRUD, connection test with valid/invalid credentials
- [x] `pairing.test.ts` — code generation, approval, rejection, expiry, revocation
- [x] CI passes (E2E + Test & Build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)