### PR TITLE
feat: add Vercel AI Gateway as LLM provider

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "^4.0.63",
     "@ai-sdk/anthropic": "^1.1.9",
+    "@ai-sdk/gateway": "^3.0.66",
     "@ai-sdk/google": "^3.0.30",
     "@ai-sdk/openai": "^1.1.14",
     "@ai-sdk/openai-compatible": "^0.1.8",

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -275,7 +275,7 @@ export const providers = sqliteTable("providers", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   type: text("type", {
-    enum: ["anthropic", "openai", "google", "ollama", "openai-compatible", "openrouter", "github-copilot", "huggingface", "nvidia", "minimax", "xai", "zai", "perplexity", "deepgram", "bedrock", "lmstudio", "deepseek", "mistral", "claude-code", "opencode", "codex", "gemini-cli"],
+    enum: ["anthropic", "openai", "google", "ollama", "openai-compatible", "openrouter", "github-copilot", "huggingface", "nvidia", "minimax", "xai", "zai", "perplexity", "deepgram", "bedrock", "lmstudio", "deepseek", "mistral", "vercel-ai-gateway", "claude-code", "opencode", "codex", "gemini-cli"],
   }).notNull(),
   apiKey: text("api_key"),
   baseUrl: text("base_url"),

--- a/packages/server/src/llm/__tests__/vercel-ai-gateway-provider.test.ts
+++ b/packages/server/src/llm/__tests__/vercel-ai-gateway-provider.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../db/index.js", () => ({
+  getDb: vi.fn(() => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          get: () => undefined,
+        }),
+      }),
+    }),
+  })),
+  schema: {
+    providers: { id: "id" },
+  },
+}));
+
+vi.mock("../../auth/auth.js", () => ({
+  getConfig: vi.fn(() => null),
+}));
+
+const mockGatewayModel = { modelId: "openai:gpt-4o", provider: "vercel-ai-gateway" };
+const mockGatewayFactory = vi.fn((model: string) => ({ ...mockGatewayModel, modelId: model }));
+const mockCreateGateway = vi.fn(() => mockGatewayFactory);
+
+vi.mock("@ai-sdk/gateway", () => ({
+  createGateway: mockCreateGateway,
+}));
+
+// Mock other imports from adapter.ts
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => vi.fn()),
+}));
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: vi.fn(() => vi.fn()),
+}));
+vi.mock("@ai-sdk/openai-compatible", () => ({
+  createOpenAICompatible: vi.fn(() => vi.fn()),
+}));
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: vi.fn(() => vi.fn()),
+}));
+vi.mock("@ai-sdk/amazon-bedrock", () => ({
+  createAmazonBedrock: vi.fn(() => vi.fn()),
+}));
+
+describe("Vercel AI Gateway provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("resolveModel", () => {
+    it("creates a gateway model with API key", async () => {
+      const { resolveModel } = await import("../adapter.js");
+
+      const model = resolveModel({
+        provider: "vercel-ai-gateway",
+        model: "openai:gpt-4o",
+        apiKey: "vercel_gateway_key",
+      });
+
+      expect(mockCreateGateway).toHaveBeenCalledWith({
+        apiKey: "vercel_gateway_key",
+      });
+      expect(model).toMatchObject({ modelId: "openai:gpt-4o" });
+    });
+
+    it("uses a custom base URL when provided", async () => {
+      const { resolveModel } = await import("../adapter.js");
+
+      resolveModel({
+        provider: "vercel-ai-gateway",
+        model: "anthropic:claude-sonnet-4-5-20250929",
+        apiKey: "vercel_gateway_key",
+        baseUrl: "https://gateway-proxy.example.com/v1",
+      });
+
+      expect(mockCreateGateway).toHaveBeenCalledWith({
+        apiKey: "vercel_gateway_key",
+        baseURL: "https://gateway-proxy.example.com/v1",
+      });
+      expect(mockGatewayFactory).toHaveBeenCalledWith("anthropic:claude-sonnet-4-5-20250929");
+    });
+
+    it("uses an empty API key when none is provided", async () => {
+      const { resolveModel } = await import("../adapter.js");
+
+      resolveModel({
+        provider: "vercel-ai-gateway",
+        model: "google:gemini-2.5-flash",
+      });
+
+      expect(mockCreateGateway).toHaveBeenCalledWith({
+        apiKey: "",
+      });
+    });
+  });
+
+  describe("resolveProviderCredentials", () => {
+    it("falls back to legacy config when provider is not in DB", async () => {
+      const { resolveProviderCredentials } = await import("../adapter.js");
+
+      const creds = resolveProviderCredentials("vercel-ai-gateway");
+      expect(creds.type).toBe("vercel-ai-gateway");
+    });
+  });
+});
+
+describe("Vercel AI Gateway provider configuration", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("includes vercel-ai-gateway in PROVIDER_TYPE_META", async () => {
+    const { PROVIDER_TYPE_META } = await import("../../settings/settings.js");
+
+    const meta = PROVIDER_TYPE_META.find((m) => m.type === "vercel-ai-gateway");
+    expect(meta).toBeDefined();
+    expect(meta!.label).toBe("Vercel AI Gateway");
+    expect(meta!.needsApiKey).toBe(true);
+    expect(meta!.needsBaseUrl).toBe(false);
+  });
+
+  it("returns fallback models when API key is missing", async () => {
+    const { fetchModelsWithCredentials } = await import("../../settings/settings.js");
+
+    const models = await fetchModelsWithCredentials("vercel-ai-gateway");
+    expect(models.length).toBeGreaterThan(0);
+    expect(models).toContain("openai:gpt-4o");
+    expect(models).toContain("google:gemini-2.5-flash");
+  });
+
+  it("fetches and sorts models using default gateway URL", async () => {
+    const mockFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: "xai:grok-3" },
+          { id: "anthropic:claude-sonnet-4-5-20250929" },
+          { id: "openai:gpt-4o" },
+        ],
+      }),
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { fetchModelsWithCredentials } = await import("../../settings/settings.js");
+    const models = await fetchModelsWithCredentials("vercel-ai-gateway", "vercel_gateway_key");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://gateway.ai.vercel.com/v1/models",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer vercel_gateway_key" },
+      }),
+    );
+    expect(models).toEqual([
+      "anthropic:claude-sonnet-4-5-20250929",
+      "openai:gpt-4o",
+      "xai:grok-3",
+    ]);
+  });
+
+  it("uses custom base URL and falls back when API returns non-OK", async () => {
+    const mockFetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+    }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { fetchModelsWithCredentials } = await import("../../settings/settings.js");
+    const models = await fetchModelsWithCredentials(
+      "vercel-ai-gateway",
+      "vercel_gateway_key",
+      "https://custom-gateway.example.com/v1",
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://custom-gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer vercel_gateway_key" },
+      }),
+    );
+    expect(models).toContain("anthropic:claude-sonnet-4-5-20250929");
+    expect(models).toContain("openai:gpt-4o");
+  });
+});

--- a/packages/server/src/llm/adapter.ts
+++ b/packages/server/src/llm/adapter.ts
@@ -3,6 +3,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { createGateway } from "@ai-sdk/gateway";
 import { streamText, generateText, type LanguageModel, type CoreMessage } from "ai";
 import { getConfig } from "../auth/auth.js";
 import { getDb, schema } from "../db/index.js";
@@ -233,6 +234,16 @@ export function resolveModel(config: LLMConfig): LanguageModel {
         apiKey: config.apiKey ?? resolved.apiKey ?? "",
       });
       return mistral(config.model);
+    }
+
+    case "vercel-ai-gateway": {
+      const gateway = createGateway({
+        apiKey: config.apiKey ?? resolved.apiKey ?? "",
+        ...(config.baseUrl ?? resolved.baseUrl
+          ? { baseURL: config.baseUrl ?? resolved.baseUrl }
+          : {}),
+      });
+      return gateway(config.model) as unknown as LanguageModel;
     }
 
     case "claude-code":

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -69,6 +69,7 @@ export const PROVIDER_TYPE_META: ProviderTypeMeta[] = [
   { type: "lmstudio", label: "LM Studio", needsApiKey: false, needsBaseUrl: true },
   { type: "deepseek", label: "DeepSeek", needsApiKey: true, needsBaseUrl: false },
   { type: "mistral", label: "Mistral", needsApiKey: true, needsBaseUrl: false },
+  { type: "vercel-ai-gateway", label: "Vercel AI Gateway", needsApiKey: true, needsBaseUrl: false },
   { type: "claude-code", label: "Claude Code", needsApiKey: false, needsBaseUrl: false },
   { type: "opencode", label: "OpenCode", needsApiKey: false, needsBaseUrl: false },
   { type: "codex", label: "Codex", needsApiKey: false, needsBaseUrl: false },
@@ -157,6 +158,14 @@ const FALLBACK_MODELS: Record<string, string[]> = {
     "mistral-small-latest",
     "codestral-latest",
     "mistral-medium-latest",
+  ],
+  "vercel-ai-gateway": [
+    "anthropic:claude-sonnet-4-5-20250929",
+    "openai:gpt-4o",
+    "openai:gpt-4o-mini",
+    "google:gemini-2.5-flash",
+    "google:gemini-2.5-pro",
+    "xai:grok-3",
   ],
   "claude-code": ["(default)", "claude-sonnet-4-6", "claude-opus-4-6", "sonnet", "opus"],
   opencode: ["(default)"],
@@ -757,6 +766,18 @@ export async function fetchModelsWithCredentials(
         if (!mistralRes.ok) return FALLBACK_MODELS.mistral ?? [];
         const mistralData = (await mistralRes.json()) as { data?: Array<{ id: string }> };
         return mistralData.data?.map((m) => m.id).sort() ?? FALLBACK_MODELS.mistral ?? [];
+      }
+
+      case "vercel-ai-gateway": {
+        if (!apiKey) return FALLBACK_MODELS["vercel-ai-gateway"] ?? [];
+        const gatewayBase = baseUrl ?? "https://gateway.ai.vercel.com/v1";
+        const gatewayRes = await fetch(`${gatewayBase}/models`, {
+          headers: { Authorization: `Bearer ${apiKey}` },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!gatewayRes.ok) return FALLBACK_MODELS["vercel-ai-gateway"] ?? [];
+        const gatewayData = (await gatewayRes.json()) as { data?: Array<{ id: string }> };
+        return gatewayData.data?.map((m) => m.id).sort() ?? FALLBACK_MODELS["vercel-ai-gateway"] ?? [];
       }
 
       // Coding agent CLIs — no live model discovery, use fallback lists

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -1,4 +1,4 @@
-export type ProviderType = "anthropic" | "openai" | "google" | "ollama" | "openai-compatible" | "openrouter" | "github-copilot" | "huggingface" | "nvidia" | "minimax" | "xai" | "zai" | "perplexity" | "deepgram" | "bedrock" | "lmstudio" | "deepseek" | "mistral" | "claude-code" | "opencode" | "codex" | "gemini-cli";
+export type ProviderType = "anthropic" | "openai" | "google" | "ollama" | "openai-compatible" | "openrouter" | "github-copilot" | "huggingface" | "nvidia" | "minimax" | "xai" | "zai" | "perplexity" | "deepgram" | "bedrock" | "lmstudio" | "deepseek" | "mistral" | "vercel-ai-gateway" | "claude-code" | "opencode" | "codex" | "gemini-cli";
 
 export interface NamedProvider {
   id: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^1.1.9
         version: 1.2.12(zod@3.25.76)
+      '@ai-sdk/gateway':
+        specifier: ^3.0.66
+        version: 3.0.66(zod@3.25.76)
       '@ai-sdk/google':
         specifier: ^3.0.30
         version: 3.0.30(zod@3.25.76)
@@ -376,6 +379,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@3.0.66':
+    resolution: {integrity: sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/google@3.0.30':
     resolution: {integrity: sha512-ZzG6dU0XUSSXbxQJJTQUFpWeKkfzdpR7IykEZwaiaW5d+3u3RZ/zkRiGwAOcUpLp6k0eMd+IJF4looJv21ecxw==}
     engines: {node: '>=18'}
@@ -411,6 +420,12 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.15':
     resolution: {integrity: sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.19':
+    resolution: {integrity: sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2207,6 +2222,10 @@ packages:
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
       react: '>= 16.8.0'
+
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
 
   '@vitejs/plugin-basic-ssl@2.1.4':
     resolution: {integrity: sha512-HXciTXN/sDBYWgeAD4V4s0DN0g72x5mlxQhHxtYu3Tt8BLa6MzcJZUyDVFCdtjNs3bfENVHVzOsmooTVuNgAAw==}
@@ -6383,6 +6402,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/gateway@3.0.66(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
   '@ai-sdk/google@3.0.30(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -6418,6 +6444,13 @@ snapshots:
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.15(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.19(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
@@ -8080,6 +8113,8 @@ snapshots:
     dependencies:
       '@use-gesture/core': 10.3.1
       react: 19.2.4
+
+  '@vercel/oidc@3.1.0': {}
 
   '@vitejs/plugin-basic-ssl@2.1.4(vite@6.4.1(@types/node@22.19.11)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `vercel-ai-gateway` as a new provider type using `@ai-sdk/gateway`
- Supports model resolution, API key auth, optional custom base URL, and model discovery via `/models` endpoint
- Includes fallback model list for when no API key is configured

Closes #224

## Test plan
- [x] Unit tests cover `resolveModel` with API key, custom base URL, and empty key
- [x] Tests verify `PROVIDER_TYPE_META` registration and `fetchModelsWithCredentials` (fallback, live fetch, error handling)
- [x] All new tests pass; pre-existing failure in `github-service.test.ts` is unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)