### PR TITLE
feat: specialist creation, module template, and dashboard improvements

### DIFF
--- a/modules/_template/package.json
+++ b/modules/_template/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "otterbot-module-CHANGEME",
+  "version": "0.1.0",
+  "description": "CHANGEME — describe what this specialist does",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "otterbot": {
+    "id": "CHANGEME"
+  },
+  "dependencies": {
+    "@otterbot/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3",
+    "@types/better-sqlite3": "^7.6.13"
+  }
+}

--- a/modules/_template/src/index.ts
+++ b/modules/_template/src/index.ts
@@ -1,0 +1,114 @@
+import {
+  defineModule,
+  type ModuleContext,
+  type PollResult,
+} from "@otterbot/shared";
+import { migration001 } from "./migrations/001-initial.js";
+
+// ─── Module definition ───────────────────────────────────────────────────────
+
+export default defineModule({
+  // --- Manifest: identifies this specialist ---
+  manifest: {
+    id: "CHANGEME",           // unique kebab-case ID
+    name: "CHANGEME Name",    // human-readable name
+    version: "0.1.0",
+    description: "CHANGEME — describe what this specialist does",
+    author: "Otterbot",
+  },
+
+  // --- Agent: the specialist's AI persona ---
+  agent: {
+    defaultName: "CHANGEME Agent",
+    defaultPrompt: [
+      "You are a specialist agent for CHANGEME.",
+      "",
+      "When answering questions:",
+      "- Use the knowledge_search tool to find relevant items",
+      "- Provide clear, concise answers with source references",
+    ].join("\n"),
+  },
+
+  // --- Config: user-provided settings (API keys, URLs, etc.) ---
+  configSchema: {
+    api_key: {
+      type: "secret",
+      description: "API key for the external service",
+      required: true,
+    },
+    // Add more config fields as needed:
+    // endpoint_url: {
+    //   type: "string",
+    //   description: "Base URL for the API",
+    //   required: false,
+    //   default: "https://api.example.com",
+    // },
+  },
+
+  // --- Tools: custom tools exposed to the specialist's agent ---
+  tools: [
+    {
+      name: "search_items",
+      description: "Search items in the knowledge store with filters.",
+      parameters: {
+        query: { type: "string", description: "Text to search for", required: false },
+        limit: { type: "number", description: "Max results (default 10)", required: false },
+      },
+      async execute(args, ctx) {
+        const limit = typeof args.limit === "number" ? Math.min(args.limit, 50) : 10;
+        const results = await ctx.knowledge.search(args.query as string ?? "", limit);
+
+        if (results.length === 0) return "No items found.";
+
+        return results
+          .map((doc) => `---\n${doc.content}\n`)
+          .join("\n");
+      },
+    },
+  ],
+
+  // --- Triggers: how data is ingested ---
+  triggers: [
+    { type: "poll", intervalMs: 300_000, minIntervalMs: 60_000 }, // every 5 min
+  ],
+
+  // --- Migrations: database schema evolution ---
+  migrations: [migration001],
+
+  // --- Handlers ---
+
+  async onPoll(ctx): Promise<PollResult> {
+    // Fetch new data from your source and return items to index.
+    // Each item is automatically stored in the knowledge store.
+    //
+    // Example:
+    // const data = await fetchFromAPI(ctx);
+    // const items = data.map(item => ({
+    //   id: item.id,
+    //   title: item.title,
+    //   content: item.content,
+    //   url: item.url,
+    //   metadata: { author: item.author },
+    // }));
+    // return { items, summary: `Indexed ${items.length} items` };
+
+    return { items: [], summary: "No items fetched (not yet implemented)" };
+  },
+
+  async onQuery(query: string, ctx): Promise<string> {
+    // Handle direct queries from other agents.
+    const results = await ctx.knowledge.search(query, 5);
+
+    if (results.length === 0) {
+      return "No matching items found.";
+    }
+
+    return results
+      .map((doc) => `---\n${doc.content}\n`)
+      .join("\n");
+  },
+
+  async onLoad(ctx) {
+    ctx.log("CHANGEME module loaded");
+  },
+});

--- a/modules/_template/src/migrations/001-initial.ts
+++ b/modules/_template/src/migrations/001-initial.ts
@@ -1,0 +1,21 @@
+import type { ModuleMigration } from "@otterbot/shared";
+
+export const migration001: ModuleMigration = {
+  version: 1,
+  description: "Create initial tables",
+  up(db) {
+    // Create your tables here. Example:
+    //
+    // db.exec(`
+    //   CREATE TABLE IF NOT EXISTS items (
+    //     id TEXT PRIMARY KEY,
+    //     title TEXT NOT NULL,
+    //     content TEXT,
+    //     url TEXT,
+    //     author TEXT,
+    //     created_at TEXT,
+    //     updated_at TEXT
+    //   )
+    // `);
+  },
+};

--- a/modules/_template/tsconfig.json
+++ b/modules/_template/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/server/src/skills/seed-skills.ts
+++ b/packages/server/src/skills/seed-skills.ts
@@ -550,6 +550,100 @@ When creating tools:
     },
   },
   {
+    id: "builtin-skill-specialist-creation",
+    data: {
+      meta: {
+        name: "Specialist Creation",
+        description:
+          "Guides the COO through creating new specialist agents by delegating to coding workers.",
+        version: "1.0.0",
+        author: "otterbot",
+        tools: [
+          "create_project",
+          "send_directive",
+          "module_install",
+          "module_list",
+          "module_toggle",
+        ],
+        capabilities: ["specialist-creation", "module-building"],
+        parameters: {},
+        tags: ["built-in", "specialist"],
+      },
+      body: `You have the ability to create new specialist agents when a user asks for one.
+
+## Recognition
+
+Activate this workflow when the user asks to create, build, or make a specialist agent — for example:
+- "Make a specialist for X"
+- "I want an agent that can Y"
+- "Create a specialist that monitors Z"
+- "Build me a stock trading agent"
+
+## Workflow
+
+### Step 1: Gather Requirements
+Discuss with the user:
+- What is the specialist's purpose? (e.g., "monitor Hacker News for AI news")
+- What data sources does it need? (APIs, RSS feeds, databases, etc.)
+- What tools should it expose? (search, create, update, etc.)
+- Does it need API keys or credentials?
+- What should its polling interval be?
+
+Keep it conversational — don't ask all questions at once. Infer sensible defaults.
+
+### Step 2: Create a Project
+Use \`create_project\` with a clear charter describing:
+- The specialist's name and purpose
+- Required API integrations
+- Tools to expose
+- Data schema needs
+- Polling/webhook triggers
+
+### Step 3: Delegate to a Coding Team Lead
+Use \`send_directive\` to the Team Lead with detailed instructions:
+
+Include in the directive:
+1. **Specialist purpose and name**
+2. **Reference files the coding worker MUST read first:**
+   - \`docs/AGENTS-VS-MODULES.md\` — the specialist agent specification
+   - \`modules/github-discussions/src/index.ts\` — a complete working example
+   - \`packages/shared/src/types/module.ts\` — TypeScript types for all module interfaces
+   - \`modules/_template/\` — the starter scaffold to copy and modify
+3. **Instructions:**
+   - Copy \`modules/_template/\` to \`modules/<specialist-name>/\`
+   - Update \`package.json\`: change the name and otterbot.id fields
+   - Implement the specialist in \`src/index.ts\` using \`defineModule()\` from \`@otterbot/shared\`
+   - Write real API integrations, not placeholder code
+   - Add database migrations if the specialist needs structured storage
+   - Add custom tools for querying the specialist's data
+   - Write unit tests for all tools and handlers
+   - Build with \`cd modules/<specialist-name> && npx pnpm install && npx pnpm build\`
+   - Run tests and ensure they pass
+
+### Step 4: Install the Module
+After the coding worker reports success, install the specialist:
+\`\`\`
+module_install with:
+  source: "local"
+  path: "modules/<specialist-name>"
+  name: "<Specialist Name>"
+\`\`\`
+
+### Step 5: Enable and Verify
+- Use \`module_toggle\` to enable the specialist if not already enabled
+- Use \`module_list\` to confirm it appears and is active
+- Report the result to the user: what was created, what it can do, and how to interact with it
+
+## Important Notes
+- The coding worker writes REAL TypeScript code with actual API integrations
+- Each specialist gets its own isolated knowledge store (SQLite DB) automatically
+- Specialists can define custom tools that the specialist's agent can use
+- The \`onPoll\` handler fetches data on a schedule; \`onWebhook\` handles incoming webhooks
+- The \`onQuery\` handler lets other agents query the specialist's knowledge
+- Config values (API keys, etc.) are set by the user after installation via the web UI`,
+    },
+  },
+  {
     id: "builtin-skill-demo-recording",
     data: {
       meta: {
@@ -683,7 +777,7 @@ When done, report:
  * Mapping from built-in registry entry IDs to their assigned skill IDs.
  */
 const ENTRY_SKILL_ASSIGNMENTS: Record<string, string[]> = {
-  "builtin-coo": ["builtin-skill-coo-operations"],
+  "builtin-coo": ["builtin-skill-coo-operations", "builtin-skill-specialist-creation"],
   "builtin-team-lead": ["builtin-skill-team-lead-operations", "builtin-skill-github-tools"],
   "builtin-coder": ["builtin-skill-coding-tools", "builtin-skill-github-tools"],
   "builtin-researcher": ["builtin-skill-research-tools", "builtin-skill-github-tools"],

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -10,6 +10,7 @@ import { AgentGraph } from "./components/graph/AgentGraph";
 import { LiveView } from "./components/live-view/LiveView";
 import { MessageStream } from "./components/stream/MessageStream";
 import { SettingsPage } from "./components/settings/SettingsPage";
+import type { SettingsSection } from "./components/settings/settings-nav";
 import { LoginScreen } from "./components/auth/LoginScreen";
 import { ChangeTemporaryPassphraseScreen } from "./components/auth/ChangeTemporaryPassphraseScreen";
 import { SetupWizard } from "./components/setup/SetupWizard";
@@ -129,7 +130,7 @@ function MainApp() {
   const toggleMode = useUIModeStore((s) => s.toggleMode);
   const unreadCount = useWhatsNewStore((s) => s.unreadCount);
   const fetchReleases = useWhatsNewStore((s) => s.fetchReleases);
-  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState<SettingsSection | true | false>(false);
   const [whatsNewOpen, setWhatsNewOpen] = useState(false);
   const [userProfile, setUserProfile] = useState<UserProfile | undefined>();
   const [centerView, setCenterView] = useState<CenterView>("dashboard");
@@ -426,7 +427,7 @@ function MainApp() {
 
       {/* Full-page settings or three-panel layout */}
       {settingsOpen ? (
-        <SettingsPage onClose={handleSettingsClose} />
+        <SettingsPage onClose={handleSettingsClose} initialSection={typeof settingsOpen === "string" ? settingsOpen : undefined} />
       ) : (
         <main className="flex-1 overflow-hidden">
           <ResizableLayout
@@ -438,7 +439,7 @@ function MainApp() {
             setCenterView={setCenterView}
             onEnterProject={handleEnterProject}
             cooName={userProfile?.cooName}
-            onOpenSettings={() => setSettingsOpen(true)}
+            onOpenSettings={(section?: SettingsSection) => setSettingsOpen(section ?? true)}
             isBasic={isBasic}
           />
         </main>
@@ -501,7 +502,7 @@ function ResizableLayout({
   setCenterView: (view: CenterView) => void;
   onEnterProject: (projectId: string) => void;
   cooName?: string;
-  onOpenSettings?: () => void;
+  onOpenSettings?: (section?: SettingsSection) => void;
   isBasic?: boolean;
 }) {
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({

--- a/packages/web/src/components/dashboard/GlobalDashboard.tsx
+++ b/packages/web/src/components/dashboard/GlobalDashboard.tsx
@@ -5,6 +5,9 @@ import { useClaudeUsageStore } from "../../stores/claude-usage-store";
 import { ProjectStatus } from "@otterbot/shared";
 import type { Project } from "@otterbot/shared";
 import { formatRelative } from "../../lib/format-relative";
+import { SetupChecklist } from "./SetupChecklist";
+import { SpecialistsIntro } from "./SpecialistsIntro";
+import type { SettingsSection } from "../settings/settings-nav";
 
 export function GlobalDashboard({
   projects,
@@ -13,7 +16,7 @@ export function GlobalDashboard({
 }: {
   projects: Project[];
   onEnterProject: (projectId: string) => void;
-  onOpenSettings?: () => void;
+  onOpenSettings?: (section?: SettingsSection) => void;
 }) {
   const agents = useAgentStore((s) => s.agents);
   const claudeCodeEnabled = useSettingsStore((s) => s.claudeCodeEnabled);
@@ -37,6 +40,9 @@ export function GlobalDashboard({
                 Your personal AI assistant. Create a project to get started, or explore the settings to connect your tools.
               </p>
             </div>
+
+            <SetupChecklist projects={projects} onOpenSettings={onOpenSettings} />
+            <SpecialistsIntro onOpenSettings={onOpenSettings} />
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full max-w-lg">
               <QuickAction
@@ -76,6 +82,9 @@ export function GlobalDashboard({
               <StatCard label="Completed" value={completedProjects.length} accent="green" />
               <StatCard label="Active Agents" value={agents.size} accent="yellow" />
             </div>
+
+            <SetupChecklist projects={projects} onOpenSettings={onOpenSettings} />
+            <SpecialistsIntro onOpenSettings={onOpenSettings} />
 
             {/* Claude Code OAuth usage */}
             {showUsageCard && <ClaudeCodeUsageCard />}

--- a/packages/web/src/components/dashboard/SetupChecklist.tsx
+++ b/packages/web/src/components/dashboard/SetupChecklist.tsx
@@ -1,0 +1,188 @@
+import { useState } from "react";
+import { useUIModeStore } from "../../stores/ui-mode-store";
+import type { SettingsSection } from "../settings/settings-nav";
+import type { Project } from "@otterbot/shared";
+
+const DISMISS_KEY = "otterbot-setup-checklist-dismissed";
+const CHECKED_KEY = "otterbot-setup-checklist-checked";
+
+interface ChecklistItem {
+  id: string;
+  label: string;
+  description: string;
+  settingsTarget: SettingsSection | "new-project" | "toggle-advanced";
+}
+
+const ITEMS: ChecklistItem[] = [
+  {
+    id: "provider",
+    label: "Configure an AI Provider",
+    description: "Add an API key for at least one LLM provider",
+    settingsTarget: "providers",
+  },
+  {
+    id: "google",
+    label: "Connect Google",
+    description: "Set up email sending and receiving via IMAP/SMTP",
+    settingsTarget: "email",
+  },
+  {
+    id: "github",
+    label: "Set up GitHub",
+    description: "Add a GitHub account for repository access",
+    settingsTarget: "github",
+  },
+  {
+    id: "chat",
+    label: "Connect a chat platform",
+    description: "Link Discord, Telegram, Slack, or another messaging app",
+    settingsTarget: "channels",
+  },
+  {
+    id: "coding",
+    label: "Set up a coding agent",
+    description: "Enable Claude Code, OpenCode, or another coding assistant",
+    settingsTarget: "opencode",
+  },
+  {
+    id: "project",
+    label: "Create your first project",
+    description: "Start a project to put your bot to work",
+    settingsTarget: "new-project",
+  },
+  {
+    id: "advanced",
+    label: "Explore advanced mode",
+    description: "Switch to advanced mode for agent graph, activity stream, and more",
+    settingsTarget: "toggle-advanced",
+  },
+];
+
+function loadChecked(): Set<string> {
+  try {
+    const raw = localStorage.getItem(CHECKED_KEY);
+    return raw ? new Set(JSON.parse(raw)) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function saveChecked(checked: Set<string>) {
+  localStorage.setItem(CHECKED_KEY, JSON.stringify([...checked]));
+}
+
+export function SetupChecklist({
+  projects,
+  onOpenSettings,
+}: {
+  projects: Project[];
+  onOpenSettings?: (section?: SettingsSection) => void;
+}) {
+  const [dismissed, setDismissed] = useState(() => localStorage.getItem(DISMISS_KEY) === "true");
+  const [checked, setChecked] = useState(loadChecked);
+
+  if (dismissed) return null;
+
+  const doneCount = ITEMS.filter((item) => checked.has(item.id)).length;
+  const total = ITEMS.length;
+  const allDone = doneCount === total;
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISS_KEY, "true");
+    setDismissed(true);
+  };
+
+  const handleToggle = (id: string) => {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      saveChecked(next);
+      return next;
+    });
+  };
+
+  const toggleMode = useUIModeStore((s) => s.toggleMode);
+
+  const handleNavigate = (item: ChecklistItem) => {
+    if (item.settingsTarget === "new-project") {
+      const btn = document.querySelector<HTMLButtonElement>('[data-action="new-project"]');
+      btn?.click();
+    } else if (item.settingsTarget === "toggle-advanced") {
+      const isBasic = useUIModeStore.getState().mode === "basic";
+      if (isBasic) toggleMode();
+    } else {
+      onOpenSettings?.(item.settingsTarget);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h3 className="text-sm font-medium">Getting Started</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {allDone ? "You're all set!" : `${doneCount} of ${total} complete`}
+          </p>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="text-xs text-muted-foreground hover:text-foreground px-2 py-1 rounded hover:bg-secondary transition-colors"
+        >
+          Dismiss
+        </button>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-1.5 rounded-full bg-muted overflow-hidden mb-3">
+        <div
+          className="h-full rounded-full bg-primary transition-all"
+          style={{ width: `${(doneCount / total) * 100}%` }}
+        />
+      </div>
+
+      <div className="space-y-1">
+        {ITEMS.map((item) => {
+          const done = checked.has(item.id);
+          return (
+            <div
+              key={item.id}
+              className={`flex items-start gap-3 rounded-md px-2 py-2 transition-colors ${
+                done ? "opacity-60" : ""
+              }`}
+            >
+              {/* Clickable checkbox */}
+              <button
+                onClick={() => handleToggle(item.id)}
+                className="mt-0.5 shrink-0 hover:scale-110 transition-transform"
+                aria-label={done ? `Mark "${item.label}" incomplete` : `Mark "${item.label}" complete`}
+              >
+                {done ? (
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                    <circle cx="8" cy="8" r="7" fill="currentColor" className="text-green-500" />
+                    <path d="M5 8l2 2 4-4" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                ) : (
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                    <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" className="text-muted-foreground" />
+                  </svg>
+                )}
+              </button>
+              {/* Clickable label navigates to settings */}
+              <button
+                onClick={() => handleNavigate(item)}
+                className="text-left hover:underline"
+              >
+                <div className="text-xs font-medium">{item.label}</div>
+                <div className="text-[11px] text-muted-foreground">{item.description}</div>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/dashboard/SpecialistsIntro.tsx
+++ b/packages/web/src/components/dashboard/SpecialistsIntro.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import type { SettingsSection } from "../settings/settings-nav";
+
+const DISMISS_KEY = "otterbot-specialists-intro-dismissed";
+
+export function SpecialistsIntro({
+  onOpenSettings,
+}: {
+  onOpenSettings?: (section?: SettingsSection) => void;
+}) {
+  const [dismissed, setDismissed] = useState(
+    () => localStorage.getItem(DISMISS_KEY) === "true",
+  );
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISS_KEY, "true");
+    setDismissed(true);
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start justify-between gap-4 mb-3">
+        <div className="flex items-center gap-2.5">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-primary shrink-0"
+          >
+            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+            <circle cx="9" cy="7" r="4" />
+            <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+            <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+          </svg>
+          <div>
+            <h3 className="text-sm font-medium">Specialist Agents</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Extend Otterbot with domain-specific agents
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="text-xs text-muted-foreground hover:text-foreground px-2 py-1 rounded hover:bg-secondary transition-colors shrink-0"
+        >
+          Dismiss
+        </button>
+      </div>
+
+      <p className="text-xs text-muted-foreground mb-3 leading-relaxed">
+        Specialists are agents with their own knowledge stores, tools, and data pipelines.
+        They connect to external APIs and build up domain expertise over time &mdash; monitoring
+        GitHub discussions, tracking news feeds, managing calendars, and more.
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 mb-3">
+        <FeatureCard
+          title="Knowledge Store"
+          description="Each specialist has its own private database for indexed data"
+        />
+        <FeatureCard
+          title="Custom Tools"
+          description="Specialists expose tools that other agents can query"
+        />
+        <FeatureCard
+          title="Data Pipelines"
+          description="Auto-ingest from APIs via polling, webhooks, or full syncs"
+        />
+      </div>
+
+      <div className="flex items-center gap-3 text-xs">
+        <span className="text-muted-foreground">
+          Ask the COO to create one, or install from the workshop.
+        </span>
+        {onOpenSettings && (
+          <button
+            onClick={() => onOpenSettings("workshop")}
+            className="text-primary hover:underline shrink-0"
+          >
+            Browse Workshop
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FeatureCard({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-md border border-border/50 bg-secondary/30 px-3 py-2">
+      <div className="text-xs font-medium mb-0.5">{title}</div>
+      <div className="text-[11px] text-muted-foreground leading-snug">{description}</div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/SettingsPage.tsx
+++ b/packages/web/src/components/settings/SettingsPage.tsx
@@ -38,10 +38,11 @@ import type { SettingsSearchHandle } from "./SettingsSearch";
 
 interface SettingsPageProps {
   onClose: () => void;
+  initialSection?: SettingsSection;
 }
 
-export function SettingsPage({ onClose }: SettingsPageProps) {
-  const [activeSection, setActiveSection] = useState<SettingsSection>("overview");
+export function SettingsPage({ onClose, initialSection }: SettingsPageProps) {
+  const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection ?? "overview");
   const loadSettings = useSettingsStore((s) => s.loadSettings);
   const loading = useSettingsStore((s) => s.loading);
   const contentRef = useRef<HTMLDivElement>(null);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "packages/*"
   - "modules/*"
+  - "!modules/_template"


### PR DESCRIPTION
## Summary

- **Specialist creation COO skill**: Seed skill guiding the COO through conversational specialist agent creation, delegating to coding workers who write real TypeScript modules
- **Module template**: `modules/_template/` scaffold for coding workers (excluded from pnpm workspace to avoid build failures)
- **Dashboard setup checklist**: Getting started checklist with manual checkboxes, progress tracking, and localStorage-backed dismissal
- **Specialists intro section**: Dismissible dashboard card explaining specialist agents with workshop link
- **Setup checklist fix**: Google item now navigates to email (IMAP/SMTP) settings

## Test plan
- [x] CI passes (build + tests)
- [x] E2E (Mock Mode) passes
- [ ] Docker image builds successfully
- [ ] Dashboard renders setup checklist and specialists intro
- [ ] Both sections dismiss permanently and stay hidden on reload