### PR TITLE
feat: redirect to project settings page after creating a new project

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -236,6 +236,32 @@ function MainApp() {
     [enterProject, setCenterView, clearChat, loadConversationMessages, setCurrentConversation],
   );
 
+  const handleProjectCreated = useCallback(
+    (projectId: string) => {
+      clearChat();
+      const cached = useProjectStore.getState().projects.find((p) => p.id === projectId);
+      if (cached) {
+        enterProject(projectId, cached, [], []);
+        setCenterView("settings");
+      }
+      const socket = getSocket();
+      socket.emit("project:enter", { projectId }, (result) => {
+        if (result.project) {
+          enterProject(projectId, result.project, result.conversations, result.tasks);
+          setCenterView("settings");
+          if (result.conversations.length > 0) {
+            const latest = result.conversations[0];
+            socket.emit("ceo:load-conversation", { conversationId: latest.id }, (convResult) => {
+              loadConversationMessages(convResult.messages);
+              setCurrentConversation(latest.id);
+            });
+          }
+        }
+      });
+    },
+    [enterProject, setCenterView, clearChat, loadConversationMessages, setCurrentConversation],
+  );
+
   const handleExitProject = useCallback(() => {
     clearChat();
     exitProject();
@@ -438,6 +464,7 @@ function MainApp() {
             centerView={centerView}
             setCenterView={setCenterView}
             onEnterProject={handleEnterProject}
+            onProjectCreated={handleProjectCreated}
             cooName={userProfile?.cooName}
             onOpenSettings={(section?: SettingsSection) => setSettingsOpen(section ?? true)}
             isBasic={isBasic}
@@ -490,6 +517,7 @@ function ResizableLayout({
   centerView,
   setCenterView,
   onEnterProject,
+  onProjectCreated,
   cooName,
   onOpenSettings,
   isBasic,
@@ -501,6 +529,7 @@ function ResizableLayout({
   centerView: CenterView;
   setCenterView: (view: CenterView) => void;
   onEnterProject: (projectId: string) => void;
+  onProjectCreated?: (projectId: string) => void;
   cooName?: string;
   onOpenSettings?: (section?: SettingsSection) => void;
   isBasic?: boolean;
@@ -593,7 +622,7 @@ function ResizableLayout({
           {/* Project list — compact, scrollable */}
           {!activeProjectId && (
             <div className="shrink-0 max-h-[40%] border-b border-border overflow-y-auto">
-              <ProjectList projects={projects} onEnterProject={onEnterProject} cooName={cooName} />
+              <ProjectList projects={projects} onEnterProject={onEnterProject} onProjectCreated={onProjectCreated} cooName={cooName} />
             </div>
           )}
           {/* CEO Chat fills remaining space */}

--- a/packages/web/src/components/project/CreateProjectDialog.tsx
+++ b/packages/web/src/components/project/CreateProjectDialog.tsx
@@ -5,9 +5,10 @@ import { useSettingsStore } from "../../stores/settings-store";
 interface CreateProjectDialogProps {
   open: boolean;
   onClose: () => void;
+  onCreated?: (projectId: string) => void;
 }
 
-export function CreateProjectDialog({ open, onClose }: CreateProjectDialogProps) {
+export function CreateProjectDialog({ open, onClose, onCreated }: CreateProjectDialogProps) {
   const [githubRepo, setGithubRepo] = useState("");
   const [branch, setBranch] = useState("");
   const [name, setName] = useState("");
@@ -88,7 +89,11 @@ export function CreateProjectDialog({ open, onClose }: CreateProjectDialogProps)
       (ack: { ok: boolean; projectId?: string; error?: string }) => {
         setLoading(false);
         if (ack.ok) {
+          const createdProjectId = ack.projectId;
           handleClose();
+          if (createdProjectId && onCreated) {
+            onCreated(createdProjectId);
+          }
         } else {
           setError(ack.error ?? "Failed to create project.");
         }

--- a/packages/web/src/components/project/ProjectList.tsx
+++ b/packages/web/src/components/project/ProjectList.tsx
@@ -13,10 +13,12 @@ const statusColors: Record<ProjectStatus, string> = {
 export function ProjectList({
   projects,
   onEnterProject,
+  onProjectCreated,
   cooName,
 }: {
   projects: Project[];
   onEnterProject: (projectId: string) => void;
+  onProjectCreated?: (projectId: string) => void;
   cooName?: string;
 }) {
   const [showForm, setShowForm] = useState(false);
@@ -142,6 +144,7 @@ export function ProjectList({
       <CreateProjectDialog
         open={showGitHubDialog}
         onClose={() => setShowGitHubDialog(false)}
+        onCreated={onProjectCreated}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- After creating a new project via the GitHub dialog, the UI now automatically navigates to the project's settings page instead of the dashboard
- Adds `onProjectCreated` callback that flows from `CreateProjectDialog` → `ProjectList` → `ResizableLayout` → `MainApp`
- New `handleProjectCreated` handler in `App.tsx` enters the project and sets the center view to "settings"

Closes #406

## Test plan
- [ ] Create a new project via the GitHub repo dialog and verify it redirects to the project settings page
- [ ] Verify entering an existing project still goes to the dashboard
- [ ] Verify the inline "Create via COO" form still works (note: this path delegates to the COO agent and does not redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)