### PR TITLE
chore: target dev branch for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `target-branch: "dev"` to `.github/dependabot.yml` so Dependabot PRs go to `dev` instead of `main`, matching our branch promotion model.
- Closed 5 existing Dependabot PRs (#413–#417) that targeted `main`.

## Test plan
- [ ] Verify Dependabot recreates PRs against `dev` after merge