### PR TITLE
feat: add vim to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pnpm build
 FROM base AS production
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tini git curl sudo gnupg apt-transport-https ca-certificates ffmpeg sqlite3 \
-    build-essential pkg-config iproute2 net-tools \
+    build-essential pkg-config iproute2 net-tools vim \
     # Playwright/Chromium system dependencies
     libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
     libdrm2 libdbus-1-3 libxkbcommon0 libatspi2.0-0 libxcomposite1 \


### PR DESCRIPTION
## Summary
- Adds `vim` to the existing `apt-get install` in the production stage of the Dockerfile
- Closes #418

## Test plan
- [ ] Verify Docker image builds successfully
- [ ] Verify `vim` and `vi` are available inside the container