### PR TITLE
fix: skip Gitea polling when unused, handle worker concurrency gracefully

### DIFF
--- a/packages/server/src/gitea/issue-monitor.ts
+++ b/packages/server/src/gitea/issue-monitor.ts
@@ -74,6 +74,10 @@ export class GiteaIssueMonitor {
 
   start(pollIntervalMs = 300_000): void {
     if (this.intervalId) return;
+    if (this.watched.size === 0) {
+      console.log("[GiteaIssueMonitor] No Gitea projects configured — polling not started");
+      return;
+    }
     this.intervalId = setInterval(() => {
       this.poll().catch((err) => {
         console.error("[GiteaIssueMonitor] Poll error:", err);
@@ -90,6 +94,7 @@ export class GiteaIssueMonitor {
   }
 
   private async poll(): Promise<void> {
+    if (this.watched.size === 0) return;
     for (const [projectId, watched] of this.watched) {
       const token = resolveGiteaToken(projectId);
       const instanceUrl = resolveGiteaInstanceUrl(projectId);

--- a/packages/server/src/gitea/pr-monitor.ts
+++ b/packages/server/src/gitea/pr-monitor.ts
@@ -42,12 +42,27 @@ export class GiteaPRMonitor {
 
   start(pollIntervalMs = 120_000): void {
     if (this.intervalId) return;
+    if (!this.hasGiteaProjects()) {
+      console.log("[GiteaPRMonitor] No Gitea projects configured — polling not started");
+      return;
+    }
     this.intervalId = setInterval(() => {
       this.poll().catch((err) => {
         console.error("[GiteaPRMonitor] Poll error:", err);
       });
     }, pollIntervalMs);
     console.log(`[GiteaPRMonitor] Started polling every ${pollIntervalMs / 1000}s`);
+  }
+
+  private hasGiteaProjects(): boolean {
+    const db = getDb();
+    const project = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.status, "active"))
+      .all()
+      .find((p) => !!p.giteaRepo);
+    return !!project;
   }
 
   stop(): void {

--- a/packages/server/src/pipeline/pipeline-manager.ts
+++ b/packages/server/src/pipeline/pipeline-manager.ts
@@ -947,6 +947,18 @@ export class PipelineManager {
       return;
     }
 
+    // Concurrency refusals are not real errors — just return to backlog silently
+    // so the task can be picked up when a worker becomes available.
+    const isConcurrencyRefusal = errorMessage.includes("REFUSED") && errorMessage.toLowerCase().includes("already running");
+    if (isConcurrencyRefusal) {
+      console.log(
+        `[PipelineManager] All coding workers busy for task ${taskId} — returning to backlog`,
+      );
+      this.resetTaskToBacklog(taskId);
+      this.pipelines.delete(taskId);
+      return;
+    }
+
     // Max retries exhausted — for re-reviews, fail gracefully instead of backlog
     if (state.isReReview && this.mergeQueue) {
       console.error(`[PipelineManager] Re-review spawn failed for task ${taskId} — aborting re-review`);


### PR DESCRIPTION
## Summary
- **GiteaIssueMonitor**: Skip starting the poll interval when no Gitea projects are being watched (`this.watched.size === 0`), eliminating repeated "Poll skipped" log noise
- **GiteaPRMonitor**: Skip starting the poll interval when no active projects have a Gitea repo configured
- **PipelineManager**: When all coding workers are busy (concurrency refusal), silently return the task to backlog instead of treating it as a hard failure after 3 retries — no more error notes appended to task descriptions

Fixes #427

## Test plan
- [x] All 39 existing tests pass (issue-monitor, pr-monitor, pipeline-manager)
- [ ] Deploy with no Gitea projects configured — verify no polling log messages appear
- [ ] Deploy with max coding workers reached — verify tasks return to backlog without error annotations