### PR TITLE
fix: skip issue monitor polling when no projects are watched

### DIFF
--- a/packages/server/src/gitea/issue-monitor.ts
+++ b/packages/server/src/gitea/issue-monitor.ts
@@ -90,6 +90,8 @@ export class GiteaIssueMonitor {
   }
 
   private async poll(): Promise<void> {
+    if (this.watched.size === 0) return;
+
     for (const [projectId, watched] of this.watched) {
       const token = resolveGiteaToken(projectId);
       const instanceUrl = resolveGiteaInstanceUrl(projectId);

--- a/packages/server/src/github/issue-monitor.ts
+++ b/packages/server/src/github/issue-monitor.ts
@@ -97,6 +97,8 @@ export class GitHubIssueMonitor {
   }
 
   private async poll(): Promise<void> {
+    if (this.watched.size === 0) return;
+
     for (const [projectId, watched] of this.watched) {
       const token = resolveGitHubToken(projectId);
       if (!token) continue;


### PR DESCRIPTION
## Summary
- Adds early return in `poll()` for both `GiteaIssueMonitor` and `GitHubIssueMonitor` when no projects are being watched
- Eliminates unnecessary polling cycles and log noise when Gitea/GitHub issue monitoring is not configured for any project

## Test plan
- [x] All 1451 existing tests pass
- [ ] Verify no "Poll skipped" log spam when no projects have Gitea issue monitoring enabled
- [ ] Verify polling still works correctly when projects are being watched

Fixes #427