### PR TITLE
fix: make non-pipeline tasks pipeline-aware in pipeline-enabled projects

### DIFF
--- a/packages/server/src/agents/__tests__/team-lead-kanban.test.ts
+++ b/packages/server/src/agents/__tests__/team-lead-kanban.test.ts
@@ -70,9 +70,18 @@ vi.mock("../../tools/opencode-client.js", () => ({
   })),
 }));
 
+vi.mock("../../github/github-service.js", async () => {
+  const actual = await vi.importActual<typeof import("../../github/github-service.js")>("../../github/github-service.js");
+  return {
+    ...actual,
+    fetchIssue: vi.fn(),
+  };
+});
+
 import { TeamLead } from "../team-lead.js";
 import type { MessageBus } from "../../bus/message-bus.js";
 import type { WorkspaceManager } from "../../workspace/workspace.js";
+import { fetchIssue } from "../../github/github-service.js";
 
 function createMockBus(): MessageBus {
   return {
@@ -635,6 +644,154 @@ describe("TeamLead — Kanban logic", () => {
       expect(result).toContain("builtin-claude-code-coder");
       expect(result).not.toContain("builtin-opencode-coder");
       expect(result).not.toContain("builtin-codex-coder");
+    });
+  });
+
+  describe("pipeline-aware routing", () => {
+    function setupPipelineManager() {
+      const pm = {
+        isEnabled: vi.fn(() => true),
+        getConfig: vi.fn(() => ({
+          enabled: true,
+          stages: {
+            triage: { agentId: "builtin-triage", enabled: true },
+            coder: { agentId: "builtin-coder", enabled: true },
+            security: { agentId: "builtin-security-reviewer", enabled: true },
+            tester: { agentId: "builtin-tester", enabled: true },
+            reviewer: { agentId: "builtin-reviewer", enabled: false },
+          },
+        })),
+        runTriage: vi.fn(),
+        startImplementation: vi.fn(async () => true),
+        isPipelineTask: vi.fn(() => false),
+      };
+      (tl as any)._pipelineManager = pm;
+      return pm;
+    }
+
+    it("injects PIPELINE ACTIVE instructions into directives when pipeline is enabled", async () => {
+      setupPipelineManager();
+      const thinkSpy = vi.spyOn(tl as any, "thinkWithContinuation").mockResolvedValue({
+        text: "ok",
+        thinking: undefined,
+        hadToolCalls: false,
+      });
+
+      await (tl as any).handleDirective({
+        id: "m-1",
+        fromAgentId: "coo-1",
+        toAgentId: "team-lead-1",
+        type: "directive",
+        content: "Please re-triage issue #429",
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(thinkSpy).toHaveBeenCalled();
+      const enriched = thinkSpy.mock.calls[0][0] as string;
+      expect(enriched).toContain("[PIPELINE ACTIVE]");
+      expect(enriched).toContain("route_to_pipeline");
+      expect(enriched).toContain('action "triage"');
+      expect(enriched).toContain('action "implement"');
+    });
+
+    it("route_to_pipeline triage fetches the issue and runs triage", async () => {
+      const pm = setupPipelineManager();
+      configStore.set(`project:${PROJECT_ID}:github:repo`, "acme/repo");
+      configStore.set("github:token", "gh-token");
+      vi.mocked(fetchIssue).mockResolvedValue({ number: 429, title: "Bug", body: "" } as any);
+
+      const tools = (tl as any).getAllTeamLeadTools();
+      const result = await tools.route_to_pipeline.execute({ action: "triage", issueNumber: 429 });
+
+      expect(fetchIssue).toHaveBeenCalledWith("acme/repo", "gh-token", 429);
+      expect(pm.runTriage).toHaveBeenCalledWith(PROJECT_ID, "acme/repo", expect.objectContaining({ number: 429 }));
+      expect(result).toContain("Routed issue #429 through pipeline triage");
+    });
+
+    it("route_to_pipeline implement resolves linked task by github-issue label", async () => {
+      const pm = setupPipelineManager();
+      configStore.set(`project:${PROJECT_ID}:github:repo`, "acme/repo");
+      configStore.set("github:token", "gh-token");
+      insertTask({ id: "task-429", labels: ["github-issue-429"] });
+
+      const tools = (tl as any).getAllTeamLeadTools();
+      const result = await tools.route_to_pipeline.execute({ action: "implement", issueNumber: 429 });
+
+      expect(pm.startImplementation).toHaveBeenCalledWith("task-429", PROJECT_ID, 429, "acme/repo", { skipFallback: true });
+      expect(result).toContain("Routed task task-429 (issue #429) through the implementation pipeline");
+    });
+
+    it("route_to_pipeline implement refuses a taskId from another project", async () => {
+      const pm = setupPipelineManager();
+      configStore.set(`project:${PROJECT_ID}:github:repo`, "acme/repo");
+      configStore.set("github:token", "gh-token");
+      const db = getDb();
+      const now = new Date().toISOString();
+      db.insert(schema.kanbanTasks).values({
+        id: "other-project-task",
+        projectId: "other-project",
+        title: "Other task",
+        description: "",
+        column: "backlog",
+        position: 0,
+        assigneeAgentId: null,
+        createdBy: "test",
+        labels: ["github-issue-429"],
+        blockedBy: [],
+        retryCount: 0,
+        completionReport: null,
+        createdAt: now,
+        updatedAt: now,
+      }).run();
+
+      const tools = (tl as any).getAllTeamLeadTools();
+      const result = await tools.route_to_pipeline.execute({
+        action: "implement",
+        issueNumber: 429,
+        taskId: "other-project-task",
+      });
+
+      expect(result).toBe("REFUSED: Task other-project-task does not belong to this project or does not exist.");
+      expect(pm.startImplementation).not.toHaveBeenCalled();
+    });
+
+    it("spawnWorker routes non-coding issue-linked tasks through pipeline when enabled", async () => {
+      const pm = setupPipelineManager();
+      configStore.set(`project:${PROJECT_ID}:github:repo`, "acme/repo");
+      insertTask({ id: "issue-task", labels: ["github-issue-429"] });
+
+      const result = await (tl as any).spawnWorker("builtin-browser-agent", "Investigate issue details", "issue-task");
+
+      expect(pm.startImplementation).toHaveBeenCalledWith("issue-task", PROJECT_ID, 429, "acme/repo", { skipFallback: true });
+      expect(result).toContain("Routed task issue-task through pipeline");
+      expect(result).toContain("Do NOT spawn standalone workers");
+    });
+
+    it("spawnWorker does not route non-coding tasks from another project", async () => {
+      const pm = setupPipelineManager();
+      configStore.set(`project:${PROJECT_ID}:github:repo`, "acme/repo");
+      const db = getDb();
+      const now = new Date().toISOString();
+      db.insert(schema.kanbanTasks).values({
+        id: "foreign-issue-task",
+        projectId: "other-project",
+        title: "Foreign issue",
+        description: "",
+        column: "backlog",
+        position: 0,
+        assigneeAgentId: null,
+        createdBy: "test",
+        labels: ["github-issue-999"],
+        blockedBy: [],
+        retryCount: 0,
+        completionReport: null,
+        createdAt: now,
+        updatedAt: now,
+      }).run();
+
+      await (tl as any).spawnWorker("builtin-browser-agent", "Investigate issue details", "foreign-issue-task");
+
+      expect(pm.startImplementation).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/server/src/agents/prompts/team-lead.ts
+++ b/packages/server/src/agents/prompts/team-lead.ts
@@ -107,6 +107,17 @@ Coding workers are required to write unit tests and run them before reporting ba
 
 For simple non-coding tasks (research, browser automation), you may mark them done based on the report alone.
 
+## Pipeline-Aware Projects
+Some projects have an **active pipeline** that manages the full lifecycle of GitHub issues (triage → coding → security review → testing → code review). When a project has an active pipeline:
+
+- **ALWAYS use \`route_to_pipeline\`** instead of \`spawn_worker\` for any work related to GitHub issues
+- For triage/re-triage requests: use \`route_to_pipeline\` with action \`"triage"\`
+- For implementation requests: use \`route_to_pipeline\` with action \`"implement"\`
+- Do NOT spawn standalone research workers, coding workers, or other workers for issue-related tasks — the pipeline manages the entire workflow
+- Non-issue tasks (e.g., general project setup, internal tooling) can still use \`spawn_worker\` directly
+
+The system will tell you when a pipeline is active via a \`[PIPELINE ACTIVE]\` block in the directive.
+
 ## Rules
 - **NEVER do work yourself** — always spawn a worker
 - **NEVER poll** — when workers are in progress with no backlog, stop and return immediately

--- a/packages/server/src/agents/team-lead.ts
+++ b/packages/server/src/agents/team-lead.ts
@@ -5,6 +5,7 @@ import {
   AgentRole,
   AgentStatus,
   MessageType,
+  PIPELINE_STAGES,
   type BusMessage,
   type KanbanTask,
 } from "@otterbot/shared";
@@ -50,6 +51,7 @@ import {
   requestPullRequestReviewers,
   createIssueComment,
   resolveProjectBranch,
+  fetchIssue,
 } from "../github/github-service.js";
 import type { PipelineManager } from "../pipeline/pipeline-manager.js";
 import { cleanTerminalOutput, summarizeForGitHub } from "../utils/terminal.js";
@@ -405,6 +407,25 @@ export class TeamLead extends BaseAgent {
       enrichedDirective =
         `[CURRENT KANBAN BOARD]\n${board.summary}\n[/CURRENT KANBAN BOARD]\n\n` +
         `New directive: ${message.content}`;
+    }
+
+    // Inject pipeline awareness when pipeline is enabled for this project
+    if (this.projectId && this._pipelineManager?.isEnabled(this.projectId)) {
+      const pipelineConfig = this._pipelineManager.getConfig(this.projectId);
+      const enabledStages = pipelineConfig
+        ? PIPELINE_STAGES
+            .filter((s) => pipelineConfig.stages[s.key]?.enabled !== false)
+            .map((s) => s.label)
+        : [];
+      enrichedDirective =
+        `[PIPELINE ACTIVE]\n` +
+        `This project has an active pipeline with stages: ${enabledStages.join(" → ")}.\n` +
+        `When work involves a GitHub issue, you MUST route it through the pipeline instead of spawning standalone workers:\n` +
+        `- For triage or re-triage requests: use the \`route_to_pipeline\` tool with action "triage"\n` +
+        `- For implementation/coding requests: use the \`route_to_pipeline\` tool with action "implement"\n` +
+        `Do NOT spawn research workers or standalone coding workers for GitHub issue work — the pipeline handles the full lifecycle including triage, coding, security review, testing, and code review.\n` +
+        `[/PIPELINE ACTIVE]\n\n` +
+        enrichedDirective;
     }
 
     const { text } = await this.thinkWithContinuation(
@@ -1369,6 +1390,85 @@ export class TeamLead extends BaseAgent {
           return result;
         },
       }),
+      route_to_pipeline: tool({
+        description:
+          "Route a GitHub issue through this project's pipeline. Use this instead of spawning standalone workers when the project has an active pipeline. " +
+          "Action 'triage' runs the pipeline's triage stage (classification, labeling, analysis). " +
+          "Action 'implement' starts the full implementation pipeline (coding → security → testing → review).",
+        parameters: z.object({
+          action: z.enum(["triage", "implement"]).describe("Pipeline action: 'triage' to run triage analysis, 'implement' to start implementation pipeline"),
+          issueNumber: z.number().describe("GitHub issue number to route through the pipeline"),
+          taskId: z.string().optional().describe("Existing kanban task ID for this issue (if one exists)"),
+        }),
+        execute: async ({ action, issueNumber, taskId }) => {
+          if (!this.projectId) {
+            return "REFUSED: No project context — cannot route through pipeline.";
+          }
+          if (!this._pipelineManager) {
+            return "REFUSED: Pipeline manager not available.";
+          }
+          if (!this._pipelineManager.isEnabled(this.projectId)) {
+            return "REFUSED: Pipeline is not enabled for this project. Use spawn_worker instead.";
+          }
+
+          const repo = getConfig(`project:${this.projectId}:github:repo`) ?? null;
+          if (!repo) {
+            return "REFUSED: No GitHub repo configured for this project.";
+          }
+          const token = resolveGitHubToken(this.projectId);
+          if (!token) {
+            return "REFUSED: No GitHub token available for this project.";
+          }
+
+          if (action === "triage") {
+            try {
+              const issue = await fetchIssue(repo, token, issueNumber);
+              await this._pipelineManager.runTriage(this.projectId, repo, issue);
+              return `Routed issue #${issueNumber} through pipeline triage. The triage stage will classify the issue, apply labels, and create/update the kanban task.`;
+            } catch (err) {
+              return `Failed to run pipeline triage for issue #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`;
+            }
+          }
+
+          if (action === "implement") {
+            // Find or use the provided task ID
+            let resolvedTaskId = taskId;
+            if (!resolvedTaskId) {
+              // Look for an existing kanban task linked to this issue
+              const db = getDb();
+              const label = `github-issue-${issueNumber}`;
+              const tasks = db
+                .select()
+                .from(schema.kanbanTasks)
+                .where(eq(schema.kanbanTasks.projectId, this.projectId))
+                .all();
+              const linked = tasks.find((t) =>
+                (t.labels as string[]).includes(label),
+              );
+              if (linked) {
+                resolvedTaskId = linked.id;
+              } else {
+                return `No kanban task found for issue #${issueNumber}. Run triage first (action: "triage") to create the task, then implement.`;
+              }
+            }
+
+            // Check if already in pipeline
+            if (this._pipelineManager.isPipelineTask(resolvedTaskId)) {
+              return `Task ${resolvedTaskId} is already being managed by the pipeline. Do not re-route it.`;
+            }
+
+            const routed = await this._pipelineManager.startImplementation(
+              resolvedTaskId, this.projectId, issueNumber, repo, { skipFallback: true },
+            );
+            if (routed) {
+              return `Routed task ${resolvedTaskId} (issue #${issueNumber}) through the implementation pipeline. The pipeline will orchestrate coding, security review, testing, and code review stages.`;
+            }
+            return `Pipeline declined to route task ${resolvedTaskId}. The pipeline may be disabled or have no enabled stages. Use spawn_worker as fallback.`;
+          }
+
+          return "Unknown action.";
+        },
+      }),
       web_search: tool({
         description:
           "Search the web for information. Returns relevant results for the query.",
@@ -1564,11 +1664,13 @@ export class TeamLead extends BaseAgent {
         }
       }
 
-      // Route coding workers through pipeline when enabled
+      // Route workers through pipeline when enabled — applies to ALL worker types
+      // (not just coding agents) when the task is linked to a GitHub issue.
+      // This prevents standalone workers from bypassing the pipeline's lifecycle
+      // management (triage, security review, testing, code review).
       if (
         !options?.pipelineOverride &&
         taskId &&
-        CODING_AGENT_IDS.has(registryEntryId) &&
         this.projectId &&
         this._pipelineManager?.isEnabled(this.projectId) &&
         !this._pipelineManager.isPipelineTask(taskId)
@@ -1586,16 +1688,19 @@ export class TeamLead extends BaseAgent {
           ? parseInt(issueLabel.replace("github-issue-", ""), 10)
           : null;
 
-        console.log(
-          `[TeamLead ${this.id}] Routing task ${taskId} through pipeline (repo=${repo}, issue=${issueNumber})`,
-        );
-        const routed = await this._pipelineManager.startImplementation(
-          taskId, this.projectId, issueNumber, repo, { skipFallback: true },
-        );
-        if (routed) {
-          return `Routed task ${taskId} through pipeline. The pipeline will orchestrate coding, security review, testing, and code review stages.`;
+        // For issue-linked tasks OR coding agents, route through pipeline
+        if (issueNumber !== null || CODING_AGENT_IDS.has(registryEntryId)) {
+          console.log(
+            `[TeamLead ${this.id}] Routing task ${taskId} through pipeline (repo=${repo}, issue=${issueNumber}, agent=${registryEntryId})`,
+          );
+          const routed = await this._pipelineManager.startImplementation(
+            taskId, this.projectId, issueNumber, repo, { skipFallback: true },
+          );
+          if (routed) {
+            return `Routed task ${taskId} through pipeline. The pipeline will orchestrate coding, security review, testing, and code review stages. Do NOT spawn standalone workers for this task.`;
+          }
+          console.log(`[TeamLead ${this.id}] Pipeline declined task ${taskId} — spawning worker directly`);
         }
-        console.log(`[TeamLead ${this.id}] Pipeline declined task ${taskId} — spawning worker directly`);
       }
 
       // Enforce max concurrent coding workers

--- a/packages/server/src/agents/team-lead.ts
+++ b/packages/server/src/agents/team-lead.ts
@@ -30,7 +30,7 @@ import { Registry } from "../registry/registry.js";
 import { SkillService } from "../skills/skill-service.js";
 import type { MessageBus } from "../bus/message-bus.js";
 import type { WorkspaceManager } from "../workspace/workspace.js";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { getConfig, setConfig, deleteConfig } from "../auth/auth.js";
 import { resolveGitHubToken, resolveGitHubUsername } from "../github/account-resolver.js";
 import { execSync } from "node:child_process";
@@ -1450,6 +1450,17 @@ export class TeamLead extends BaseAgent {
               } else {
                 return `No kanban task found for issue #${issueNumber}. Run triage first (action: "triage") to create the task, then implement.`;
               }
+            } else {
+              // Validate that the provided taskId belongs to this project
+              const db = getDb();
+              const taskRecord = db
+                .select()
+                .from(schema.kanbanTasks)
+                .where(and(eq(schema.kanbanTasks.id, resolvedTaskId), eq(schema.kanbanTasks.projectId, this.projectId)))
+                .get();
+              if (!taskRecord) {
+                return `REFUSED: Task ${resolvedTaskId} does not belong to this project or does not exist.`;
+              }
             }
 
             // Check if already in pipeline
@@ -1680,7 +1691,7 @@ export class TeamLead extends BaseAgent {
         const kanbanTask = pipelineDb
           .select()
           .from(schema.kanbanTasks)
-          .where(eq(schema.kanbanTasks.id, taskId))
+          .where(and(eq(schema.kanbanTasks.id, taskId), eq(schema.kanbanTasks.projectId, this.projectId)))
           .get();
         const labels = Array.isArray(kanbanTask?.labels) ? kanbanTask.labels as string[] : [];
         const issueLabel = labels.find((l: string) => l.startsWith("github-issue-"));


### PR DESCRIPTION
## Summary
- When a project has an active pipeline, non-coding workers (research, browser agents) spawned for GitHub issue-linked tasks now route through the pipeline instead of bypassing it
- Adds `route_to_pipeline` tool so the team lead LLM can explicitly route triage/implementation requests through the pipeline
- Injects `[PIPELINE ACTIVE]` context into directives when pipeline is enabled, guiding the LLM to use pipeline routing
- Adds `projectId` validation on task lookups to prevent cross-project task manipulation

## Test plan
- [x] All 1462 existing tests pass
- [x] 6 new tests cover: directive enrichment, triage routing, implement routing, cross-project refusal, spawnWorker interception, and cross-project spawnWorker protection

Closes #429