### PR TITLE
fix: skip issue monitor polling when no projects are watched

### DIFF
--- a/packages/server/src/gitea/issue-monitor.test.ts
+++ b/packages/server/src/gitea/issue-monitor.test.ts
@@ -137,4 +137,46 @@ describe("GiteaIssueMonitor", () => {
       undefined,
     );
   });
+
+  describe("polling lifecycle", () => {
+    it("defers polling when start() is called without watched projects", () => {
+      vi.useFakeTimers();
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+      monitor.start(1_000);
+
+      expect(setIntervalSpy).not.toHaveBeenCalled();
+
+      setIntervalSpy.mockRestore();
+      vi.useRealTimers();
+    });
+
+    it("auto-starts polling when a project is watched after deferred start()", () => {
+      vi.useFakeTimers();
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+      monitor.start(1_234);
+      monitor.watchProject("proj-auto-start", "owner/repo", "bot");
+
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 1_234);
+
+      setIntervalSpy.mockRestore();
+      vi.useRealTimers();
+    });
+
+    it("pauses polling when the final watched project is removed", () => {
+      vi.useFakeTimers();
+      const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+
+      monitor.watchProject("proj-stop", "owner/repo", "bot");
+      monitor.start(1_000);
+      monitor.unwatchProject("proj-stop");
+
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+      clearIntervalSpy.mockRestore();
+      vi.useRealTimers();
+    });
+  });
 });

--- a/packages/server/src/gitea/issue-monitor.ts
+++ b/packages/server/src/gitea/issue-monitor.ts
@@ -31,6 +31,7 @@ interface WatchedProject {
 export class GiteaIssueMonitor {
   private watched = new Map<string, WatchedProject>();
   private intervalId: ReturnType<typeof setInterval> | null = null;
+  private pollIntervalMs: number | null = null;
   private coo: COO;
   private io: TypedServer;
   private pipelineManager: PipelineManager | null = null;
@@ -49,10 +50,20 @@ export class GiteaIssueMonitor {
   watchProject(projectId: string, repo: string, assignee: string): void {
     this.watched.set(projectId, { projectId, repo, assignee });
     console.log(`[GiteaIssueMonitor] Watching ${repo} for issues assigned to ${assignee} (project ${projectId})`);
+    // Auto-start polling if we have a stored interval and the timer isn't running
+    if (this.pollIntervalMs && !this.intervalId) {
+      this.startInterval(this.pollIntervalMs);
+    }
   }
 
   unwatchProject(projectId: string): void {
     this.watched.delete(projectId);
+    // Auto-stop polling when no projects remain
+    if (this.watched.size === 0 && this.intervalId) {
+      console.log("[GiteaIssueMonitor] No projects being watched — pausing polling");
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
   }
 
   loadFromDb(): void {
@@ -79,10 +90,19 @@ export class GiteaIssueMonitor {
   }
 
   start(pollIntervalMs = 300_000): void {
+    this.pollIntervalMs = pollIntervalMs;
     if (this.intervalId) {
       console.log("[GiteaIssueMonitor] start() called but polling is already active — ignoring");
       return;
     }
+    if (this.watched.size === 0) {
+      console.log("[GiteaIssueMonitor] No projects being watched — polling deferred until a project is added");
+      return;
+    }
+    this.startInterval(pollIntervalMs);
+  }
+
+  private startInterval(pollIntervalMs: number): void {
     this.intervalId = setInterval(() => {
       this.poll().catch((err) => {
         console.error("[GiteaIssueMonitor] Poll error:", err);
@@ -100,7 +120,6 @@ export class GiteaIssueMonitor {
 
   private async poll(): Promise<void> {
     if (this.watched.size === 0) {
-      console.log("[GiteaIssueMonitor] Poll skipped — no projects being watched");
       return;
     }
 

--- a/packages/server/src/github/__tests__/issue-monitor.test.ts
+++ b/packages/server/src/github/__tests__/issue-monitor.test.ts
@@ -173,6 +173,46 @@ describe("GitHubIssueMonitor", () => {
       // Should NOT have been called since we unwatched
       expect(mockFetchAssignedIssues).not.toHaveBeenCalled();
     });
+
+    it("defers polling when start() is called without watched projects", () => {
+      vi.useFakeTimers();
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+      monitor.start(2_000);
+
+      expect(setIntervalSpy).not.toHaveBeenCalled();
+
+      setIntervalSpy.mockRestore();
+      vi.useRealTimers();
+    });
+
+    it("auto-starts polling when a project is watched after deferred start()", () => {
+      vi.useFakeTimers();
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+      monitor.start(2_345);
+      monitor.watchProject("proj-auto-start", "owner/repo", "testuser");
+
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 2_345);
+
+      setIntervalSpy.mockRestore();
+      vi.useRealTimers();
+    });
+
+    it("pauses polling when the final watched project is removed", () => {
+      vi.useFakeTimers();
+      const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+
+      monitor.watchProject("proj-stop", "owner/repo", "testuser");
+      monitor.start(2_000);
+      monitor.unwatchProject("proj-stop");
+
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+      clearIntervalSpy.mockRestore();
+      vi.useRealTimers();
+    });
   });
 
   describe("loadFromDb", () => {
@@ -739,6 +779,7 @@ describe("GitHubIssueMonitor", () => {
   describe("start / stop", () => {
     it("starts and stops the polling interval", () => {
       vi.useFakeTimers();
+      monitor.watchProject("proj-start-stop", "owner/repo", "testuser");
 
       monitor.start(10_000);
 
@@ -753,6 +794,7 @@ describe("GitHubIssueMonitor", () => {
 
     it("does not start a second interval if already started", () => {
       vi.useFakeTimers();
+      monitor.watchProject("proj-start-twice", "owner/repo", "testuser");
 
       monitor.start(10_000);
       const firstId = (monitor as any).intervalId;
@@ -989,12 +1031,12 @@ describe("diagnostic logging", () => {
     warnSpy.mockRestore();
   });
 
-  it("logs when poll() finds no watched projects", async () => {
+  it("does not log when poll() finds no watched projects", async () => {
     const logSpy = vi.spyOn(console, "log");
 
     await (monitor as any).poll();
 
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(logSpy).not.toHaveBeenCalledWith(
       expect.stringContaining("no projects being watched"),
     );
     logSpy.mockRestore();
@@ -1017,6 +1059,7 @@ describe("diagnostic logging", () => {
   it("logs when start() is called while already running", () => {
     vi.useFakeTimers();
     const logSpy = vi.spyOn(console, "log");
+    monitor.watchProject("proj-already-running", "owner/repo", "testuser");
 
     monitor.start(10_000);
     logSpy.mockClear();

--- a/packages/server/src/github/issue-monitor.ts
+++ b/packages/server/src/github/issue-monitor.ts
@@ -31,6 +31,7 @@ interface WatchedProject {
 export class GitHubIssueMonitor {
   private watched = new Map<string, WatchedProject>();
   private intervalId: ReturnType<typeof setInterval> | null = null;
+  private pollIntervalMs: number | null = null;
   private coo: COO;
   private io: TypedServer;
   private pipelineManager: PipelineManager | null = null;
@@ -52,11 +53,21 @@ export class GitHubIssueMonitor {
   watchProject(projectId: string, repo: string, assignee: string): void {
     this.watched.set(projectId, { projectId, repo, assignee });
     console.log(`[IssueMonitor] Watching ${repo} for issues assigned to ${assignee} (project ${projectId})`);
+    // Auto-start polling if we have a stored interval and the timer isn't running
+    if (this.pollIntervalMs && !this.intervalId) {
+      this.startInterval(this.pollIntervalMs);
+    }
   }
 
   /** Unregister a project from issue monitoring */
   unwatchProject(projectId: string): void {
     this.watched.delete(projectId);
+    // Auto-stop polling when no projects remain
+    if (this.watched.size === 0 && this.intervalId) {
+      console.log("[IssueMonitor] No projects being watched — pausing polling");
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
   }
 
   /** Load watched projects from DB on startup */
@@ -85,10 +96,19 @@ export class GitHubIssueMonitor {
 
   /** Start the polling loop */
   start(pollIntervalMs = 300_000): void {
+    this.pollIntervalMs = pollIntervalMs;
     if (this.intervalId) {
       console.log("[IssueMonitor] start() called but polling is already active — ignoring");
       return;
     }
+    if (this.watched.size === 0) {
+      console.log("[IssueMonitor] No projects being watched — polling deferred until a project is added");
+      return;
+    }
+    this.startInterval(pollIntervalMs);
+  }
+
+  private startInterval(pollIntervalMs: number): void {
     this.intervalId = setInterval(() => {
       this.poll().catch((err) => {
         console.error("[IssueMonitor] Poll error:", err);
@@ -107,7 +127,6 @@ export class GitHubIssueMonitor {
 
   private async poll(): Promise<void> {
     if (this.watched.size === 0) {
-      console.log("[IssueMonitor] Poll skipped — no projects being watched");
       return;
     }
 


### PR DESCRIPTION
## Summary
- Defers polling in `GiteaIssueMonitor` and `GitHubIssueMonitor` when `start()` is called with no watched projects
- Auto-starts polling when the first project is watched after a deferred `start()`
- Auto-pauses polling when the last watched project is removed
- Removes the noisy per-poll "Poll skipped — no projects being watched" log message

Closes #123

## Test plan
- [x] New tests: deferred start, auto-start on watch, auto-pause on unwatch (both monitors)
- [x] Updated existing tests to reflect new behavior (watch a project before starting)
- [x] Full test suite passes (1475 tests across 123 files)