### PR TITLE
feat: add re-triage button for issues stuck in triage column

### DIFF
--- a/packages/server/src/pipeline/pipeline-manager.ts
+++ b/packages/server/src/pipeline/pipeline-manager.ts
@@ -20,8 +20,10 @@ import {
   addLabelsToIssue,
   fetchCompareCommitsDiff,
   fetchPullRequests,
+  fetchIssue,
   fetchIssueComments,
   fetchRepoTree,
+  removeLabelFromIssue,
   checkHasPushAccess,
   createFork,
   waitForFork,
@@ -393,6 +395,74 @@ export class PipelineManager {
     await this.startImplementation(taskId, task.projectId, task.taskNumber ?? null, repo);
 
     return updated as unknown as KanbanTask ?? null;
+  }
+
+  /**
+   * Re-triage a task: fetch the GitHub issue, remove the "triaged" label,
+   * delete the existing triage task, and re-run triage from scratch.
+   */
+  async retriage(taskId: string): Promise<KanbanTask | null> {
+    const db = getDb();
+    const task = db
+      .select()
+      .from(schema.kanbanTasks)
+      .where(eq(schema.kanbanTasks.id, taskId))
+      .get();
+    if (!task) return null;
+
+    // Extract issue number from labels
+    const issueLabel = (task.labels as string[]).find((l) => l.startsWith("github-issue-"));
+    if (!issueLabel) {
+      throw new Error("Task has no associated GitHub issue");
+    }
+    const issueNumber = parseInt(issueLabel.replace("github-issue-", ""), 10);
+
+    // Look up project for repo info
+    const project = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, task.projectId))
+      .get();
+    const repo = project?.githubRepo;
+    if (!repo) {
+      throw new Error("Project has no GitHub repo configured");
+    }
+
+    const token = resolveGitHubToken(task.projectId);
+    if (!token) {
+      throw new Error("No GitHub token available for this project");
+    }
+
+    // Remove "triaged" label from GitHub issue so triage can re-apply it
+    try {
+      await removeLabelFromIssue(repo, token, issueNumber, "triaged");
+    } catch (err) {
+      // Label may not exist — that's fine
+      debug("pipeline", `retriage: failed to remove triaged label from #${issueNumber}: ${err}`);
+    }
+
+    // Delete the existing triage task
+    db.delete(schema.kanbanTasks)
+      .where(eq(schema.kanbanTasks.id, taskId))
+      .run();
+    this.io.emit("kanban:task-deleted", { taskId, projectId: task.projectId });
+
+    // Fetch fresh issue data from GitHub and re-run triage
+    const issue = await fetchIssue(repo, token, issueNumber);
+    // Remove stale "triaged" label from fetched issue data
+    issue.labels = issue.labels.filter((l) => l.name !== "triaged");
+
+    await this.runTriage(task.projectId, repo, issue);
+
+    // Return the newly created task (if triage created one)
+    const newTask = db
+      .select()
+      .from(schema.kanbanTasks)
+      .where(eq(schema.kanbanTasks.projectId, task.projectId))
+      .all()
+      .find((t) => (t.labels as string[]).includes(issueLabel));
+
+    return (newTask as unknown as KanbanTask) ?? null;
   }
 
   // ─── Config helpers ──────────────────────────────────────────────

--- a/packages/server/src/socket/handlers.ts
+++ b/packages/server/src/socket/handlers.ts
@@ -1337,6 +1337,20 @@ export function setupSocketHandlers(
       }
     });
 
+    // ─── Re-triage handler ──────────────────────────────────────────
+    socket.on("kanban:retriage", async (data, callback) => {
+      if (!deps?.pipelineManager) {
+        callback?.({ ok: false, error: "Pipeline manager not available" });
+        return;
+      }
+      try {
+        await deps.pipelineManager.retriage(data.taskId);
+        callback?.({ ok: true });
+      } catch (err) {
+        callback?.({ ok: false, error: err instanceof Error ? err.message : "Unknown error" });
+      }
+    });
+
     // ─── Merge queue handlers ───────────────────────────────────────
     if (deps?.mergeQueue) {
       const mq = deps.mergeQueue;

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -252,6 +252,12 @@ export interface ClientToServerEvents {
     callback?: (ack: { ok: boolean; error?: string }) => void,
   ) => void;
 
+  // Re-triage
+  "kanban:retriage": (
+    data: { taskId: string },
+    callback?: (ack: { ok: boolean; error?: string }) => void,
+  ) => void;
+
   // Merge queue
   "merge-queue:approve": (
     data: { taskId: string },

--- a/packages/web/src/components/kanban/KanbanCard.tsx
+++ b/packages/web/src/components/kanban/KanbanCard.tsx
@@ -112,6 +112,12 @@ export function KanbanCard({
     socket.emit("kanban:reset-pipeline", { taskId: task.id });
   };
 
+  const handleRetriage = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const socket = getSocket();
+    socket.emit("kanban:retriage", { taskId: task.id });
+  };
+
   const showApproveButton =
     task.column === "in_review" &&
     task.prNumber != null &&
@@ -124,6 +130,9 @@ export function KanbanCard({
     !task.assigneeAgentId &&
     task.column !== "triage" &&
     !mqEntry;
+
+  // Show re-triage button for tasks in the triage column
+  const showRetriageButton = task.column === "triage";
 
   return (
     <div
@@ -222,6 +231,14 @@ export function KanbanCard({
           onClick={handleResetPipeline}
         >
           Reset Pipeline
+        </button>
+      )}
+      {showRetriageButton && (
+        <button
+          className="mt-2 w-full text-[11px] font-medium bg-blue-500/15 text-blue-400 hover:bg-blue-500/25 rounded px-2 py-1 transition-colors"
+          onClick={handleRetriage}
+        >
+          Re-triage
         </button>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Adds a `retriage()` method to `PipelineManager` that removes the "triaged" label from GitHub, deletes the existing triage task, fetches fresh issue data, and re-runs triage from scratch
- Adds `kanban:retriage` socket event handler and shared type definition
- Adds a "Re-triage" button on kanban cards in the triage column

Closes #125