### PR TITLE
feat: triage adapts to issue comments (#431)

### DIFF
--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -216,6 +216,7 @@ Guidelines:
   5. **Explanation** (if shouldProceed is false): Why no implementation is needed (e.g. it's a question, user error, or duplicate)
   6. **Status**: End the comment with a "## Status" section. If shouldProceed is true AND nothing is unclear, write "Ready to proceed — assign this issue to begin implementation." If anything is unclear or needs clarification, write "Blocked — waiting for clarification on:" followed by a bulleted list of the specific questions or ambiguities that need to be resolved before work can start.
 - You will be given the repository file tree. Use it to identify relevant source files and formulate a concrete plan.
+- If issue comments are provided (in <issue-comments> tags), you MUST read and respond to them. Comments represent feedback from the issue author or other contributors. Address their questions, incorporate their suggestions, and adapt your plan accordingly. Do NOT ignore comments or simply repost a previous plan — directly engage with the feedback. If a comment asks a question, answer it. If a comment suggests a different approach, evaluate it and explain your reasoning.
 - Your comment MUST be consistent with the classification and shouldProceed value.
 - Never suggest closing the issue — just classify, plan, and comment.
 - If the issue is unclear or ambiguous, classify as "question" with shouldProceed: false, and ask for clarification in the comment.

--- a/packages/server/src/pipeline/__tests__/pipeline-manager.test.ts
+++ b/packages/server/src/pipeline/__tests__/pipeline-manager.test.ts
@@ -36,14 +36,14 @@ vi.mock("ai", () => ({
 }));
 
 vi.mock("../../registry/registry.js", () => ({
-  Registry: vi.fn().mockImplementation(() => ({
-    get: vi.fn(() => ({
+  Registry: class {
+    get = vi.fn(() => ({
       id: "builtin-triage",
       systemPrompt: "test",
       defaultProvider: "anthropic",
       defaultModel: "test-model",
-    })),
-  })),
+    }));
+  },
 }));
 
 vi.mock("../../agents/prompts/security-preamble.js", () => ({
@@ -63,6 +63,7 @@ import { PipelineManager } from "../pipeline-manager.js";
 import { createIssueComment, fetchIssueComments } from "../../github/github-service.js";
 import type { COO } from "../../agents/coo.js";
 import { MessageType } from "@otterbot/shared";
+import { generateText } from "ai";
 
 // --- Factory helpers ---
 
@@ -1047,6 +1048,103 @@ describe("PipelineManager", () => {
       (pm as any).recoverPipelines();
 
       expect((pm as any).pipelines.has("task-recover-bad")).toBe(false);
+    });
+  });
+
+  // ─── runTriage (issue comments) ────────────────────────────
+
+  describe("runTriage (issue comments)", () => {
+    const issue = {
+      number: 431,
+      title: "Triage should adapt to comments",
+      body: "Issue body",
+      labels: [],
+      assignees: [],
+    } as any;
+
+    beforeEach(() => {
+      vi.mocked(generateText).mockClear();
+      vi.mocked(fetchIssueComments).mockClear();
+    });
+
+    it("includes non-bot issue comments in triage prompt", async () => {
+      insertProject();
+      setPipelineConfig(PROJECT_ID, { triage: { enabled: true } });
+      configStore.set("github:token", "test-token");
+      configStore.set("github:username", "otterbot");
+
+      vi.mocked(generateText).mockResolvedValueOnce({
+        text: JSON.stringify({
+          classification: "feature",
+          shouldProceed: true,
+          comment: "Looks good",
+          labels: ["feature"],
+        }),
+      } as any);
+
+      (fetchIssueComments as any).mockResolvedValueOnce([
+        { id: 1, user: { login: "otterbot" }, body: "Bot triage output", created_at: "2026-03-01T00:00:00Z" },
+        { id: 2, user: { login: "renovate[bot]" }, body: "Automated bot message", created_at: "2026-03-02T00:00:00Z" },
+        { id: 3, user: { login: "alice" }, body: "Can we use the database instead?", created_at: "2026-03-03T00:00:00Z" },
+      ]);
+
+      await pm.runTriage(PROJECT_ID, "owner/repo", issue);
+
+      const call = vi.mocked(generateText).mock.calls.at(-1)?.[0] as any;
+      expect(call.prompt).toContain("<issue-comments>");
+      expect(call.prompt).toContain("@alice (2026-03-03T00:00:00Z):");
+      expect(call.prompt).toContain("Can we use the database instead?");
+      expect(call.prompt).not.toContain("Bot triage output");
+      expect(call.prompt).not.toContain("Automated bot message");
+    });
+
+    it("omits issue-comments section when only bot comments exist", async () => {
+      insertProject();
+      setPipelineConfig(PROJECT_ID, { triage: { enabled: true } });
+      configStore.set("github:token", "test-token");
+      configStore.set("github:username", "otterbot");
+
+      vi.mocked(generateText).mockResolvedValueOnce({
+        text: JSON.stringify({
+          classification: "question",
+          shouldProceed: false,
+          comment: "Need clarification",
+          labels: ["question"],
+        }),
+      } as any);
+
+      (fetchIssueComments as any).mockResolvedValueOnce([
+        { id: 1, user: { login: "otterbot" }, body: "Bot triage output", created_at: "2026-03-01T00:00:00Z" },
+        { id: 2, user: { login: "dependabot[bot]" }, body: "Automated update", created_at: "2026-03-02T00:00:00Z" },
+      ]);
+
+      await pm.runTriage(PROJECT_ID, "owner/repo", issue);
+
+      const call = vi.mocked(generateText).mock.calls.at(-1)?.[0] as any;
+      expect(call.prompt).not.toContain("<issue-comments>");
+    });
+
+    it("continues triage when fetching comments fails", async () => {
+      insertProject();
+      setPipelineConfig(PROJECT_ID, { triage: { enabled: true } });
+      configStore.set("github:token", "test-token");
+
+      vi.mocked(generateText).mockResolvedValueOnce({
+        text: JSON.stringify({
+          classification: "bug",
+          shouldProceed: true,
+          comment: "Proceed",
+          labels: ["bug"],
+        }),
+      } as any);
+
+      (fetchIssueComments as any).mockRejectedValueOnce(new Error("comments API down"));
+
+      await expect(pm.runTriage(PROJECT_ID, "owner/repo", issue)).resolves.toBeUndefined();
+
+      expect(generateText).toHaveBeenCalled();
+      const call = vi.mocked(generateText).mock.calls.at(-1)?.[0] as any;
+      expect(call.prompt).not.toContain("<issue-comments>");
     });
   });
 });

--- a/packages/server/src/pipeline/pipeline-manager.ts
+++ b/packages/server/src/pipeline/pipeline-manager.ts
@@ -531,6 +531,29 @@ export class PipelineManager {
       fileTreeSection = "\n<repository-file-tree>\n(unavailable)\n</repository-file-tree>";
     }
 
+    // Fetch issue comments to provide conversation context (especially for re-triage)
+    let commentsSection = "";
+    const botUsername = resolveGitHubUsername(projectId) ?? null;
+    try {
+      const comments = await fetchIssueComments(repo, token, issue.number);
+      const relevantComments = comments.filter((c) => {
+        // Skip bot comments — focus on human feedback
+        if (botUsername && c.user.login === botUsername) return false;
+        if (c.user.login.endsWith("[bot]")) return false;
+        return true;
+      });
+      if (relevantComments.length > 0) {
+        commentsSection =
+          `\n<issue-comments>\n` +
+          relevantComments
+            .map((c) => `@${c.user.login} (${c.created_at}):\n${c.body}`)
+            .join("\n\n---\n\n") +
+          `\n</issue-comments>`;
+      }
+    } catch (err) {
+      console.warn(`[PipelineManager] Failed to fetch comments for triage of #${issue.number}:`, err);
+    }
+
     // Build prompt — wrap in XML delimiters to isolate untrusted content
     const issueText =
       `<github-issue>\n` +
@@ -539,6 +562,7 @@ export class PipelineManager {
       `Labels: ${issue.labels.map((l) => l.name).join(", ") || "none"}\n` +
       `Assignees: ${issue.assignees.map((a) => a.login).join(", ") || "none"}\n` +
       `</github-issue>` +
+      commentsSection +
       fileTreeSection;
 
     try {


### PR DESCRIPTION
## Summary
- Fetches issue comments during triage and includes non-bot human comments in the triage prompt so the LLM can respond to feedback instead of ignoring it
- Updates the triage system prompt to explicitly instruct the agent to read, respond to, and incorporate comment feedback
- Gracefully handles comment fetch failures without blocking triage

Closes #431