### PR TITLE
fix: detect coding agent auth errors and stop retries immediately

### DIFF
--- a/packages/server/src/agents/team-lead.ts
+++ b/packages/server/src/agents/team-lead.ts
@@ -569,6 +569,8 @@ export class TeamLead extends BaseAgent {
 
   private isFailureReport(report: string): boolean {
     if (!report.trim()) return true;
+    // Auth errors are always failures — non-retryable
+    if (report.startsWith("CODING_AGENT_AUTH_ERROR:")) return true;
     // PR creation is a definitive success signal — overrides any false-positive failure matches
     if (this.isPRCreated(report)) return false;
     const lower = report.toLowerCase();

--- a/packages/server/src/agents/worker.ts
+++ b/packages/server/src/agents/worker.ts
@@ -12,6 +12,10 @@ import { debug } from "../utils/debug.js";
 import { getConfig } from "../auth/auth.js";
 import { stripAnsi } from "../utils/terminal.js";
 import { auditGitRemotes } from "../utils/command-guard.js";
+import { detectAuthError } from "../coding-agents/coding-agent-client.js";
+
+/** Prefix for auth error reports — signals non-retryable failure to the pipeline */
+export const CODING_AGENT_AUTH_ERROR_PREFIX = "CODING_AGENT_AUTH_ERROR:";
 
 export interface WorkerDependencies {
   id?: string;
@@ -270,6 +274,11 @@ export class Worker extends BaseAgent {
       },
     });
 
+    // Auth error: non-retryable failure — report immediately
+    if (result.authError) {
+      return `${CODING_AGENT_AUTH_ERROR_PREFIX} OpenCode authentication failed: ${result.error}. Please check your API key configuration.`;
+    }
+
     // Post-execution: audit git remotes for unauthorized modifications
     if (result.success && this.workspacePath) {
       const unexpectedRemotes = auditGitRemotes(this.workspacePath);
@@ -365,6 +374,11 @@ export class Worker extends BaseAgent {
       },
     });
 
+    // Auth error: non-retryable failure — report immediately
+    if (result.authError) {
+      return `${CODING_AGENT_AUTH_ERROR_PREFIX} Codex authentication failed: ${result.error}. Please check your API key configuration.`;
+    }
+
     // Post-execution: audit git remotes for unauthorized modifications
     if (result.success && this.workspacePath) {
       const unexpectedRemotes = auditGitRemotes(this.workspacePath);
@@ -459,6 +473,11 @@ export class Worker extends BaseAgent {
         error: result.error,
       },
     });
+
+    // Auth error: non-retryable failure — report immediately
+    if (result.authError) {
+      return `${CODING_AGENT_AUTH_ERROR_PREFIX} Gemini CLI authentication failed: ${result.error}. Please check your API key configuration.`;
+    }
 
     // Post-execution: audit git remotes for unauthorized modifications
     if (result.success && this.workspacePath) {
@@ -577,6 +596,11 @@ export class Worker extends BaseAgent {
       },
     });
 
+    // Auth error: non-retryable failure — report immediately
+    if (result.authError) {
+      return `${CODING_AGENT_AUTH_ERROR_PREFIX} Claude Code authentication failed: ${result.error}. Please check your API key configuration.`;
+    }
+
     // Post-execution: audit git remotes for unauthorized modifications
     if (result.success && this.workspacePath) {
       const unexpectedRemotes = auditGitRemotes(this.workspacePath);
@@ -637,6 +661,15 @@ export class Worker extends BaseAgent {
       const hasOpenCodeCompletion = tailSegments.some(l =>
         /\b(Build|Bake|Think)\s+[·•]\s+\S+.*[·•]\s+\d+[ms]/i.test(l),
       );
+
+      // Check for auth/login errors — kill the process immediately to avoid wasting time
+      const authErr = detectAuthError(cleanOutput);
+      if (authErr) {
+        console.error(`[Worker ${this.id}] Terminal idle — auth error detected: ${authErr}`);
+        this._terminalExiting = true;
+        ptyClient.kill();
+        return;
+      }
 
       console.log(`[Worker ${this.id}] Terminal idle check — tail segments: ${JSON.stringify(tailSegments.slice(-8))}, prompt=${isReplPrompt}, completion=${hasCompletionSignal}, opencode=${hasOpenCodeCompletion}`);
 

--- a/packages/server/src/coding-agents/claude-code-pty-client.ts
+++ b/packages/server/src/coding-agents/claude-code-pty-client.ts
@@ -6,11 +6,12 @@
  * replacement for the SDK-based ClaudeCodeClient.
  */
 
-import { extractPtySummary } from "../utils/terminal.js";
+import { extractPtySummary, stripAnsi } from "../utils/terminal.js";
 import type {
   CodingAgentClient,
   CodingAgentTaskResult,
 } from "./coding-agent-client.js";
+import { detectAuthError } from "./coding-agent-client.js";
 import { computeGitDiff } from "../utils/git.js";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
@@ -121,12 +122,19 @@ export class ClaudeCodePtyClient implements CodingAgentClient {
 
           const success = exitCode === 0 || !this._killed;
 
+          // Check for auth/login errors in terminal output on failure
+          const authErrorMsg = !success ? detectAuthError(stripAnsi(this.ringBuffer)) : null;
+          if (authErrorMsg) {
+            console.error(`[${label}] Auth error detected: ${authErrorMsg}`);
+          }
+
           resolve({
             success,
             sessionId,
             summary: success ? extractPtySummary(this.ringBuffer) : `Process exited with code ${exitCode}`,
             diff,
             usage: null,
+            ...(authErrorMsg ? { authError: true, error: authErrorMsg } : {}),
           });
 
           this.ptyProcess = null;

--- a/packages/server/src/coding-agents/codex-pty-client.ts
+++ b/packages/server/src/coding-agents/codex-pty-client.ts
@@ -10,8 +10,9 @@ import type {
   CodingAgentClient,
   CodingAgentTaskResult,
 } from "./coding-agent-client.js";
+import { detectAuthError } from "./coding-agent-client.js";
 import { computeGitDiff } from "../utils/git.js";
-import { extractPtySummary } from "../utils/terminal.js";
+import { extractPtySummary, stripAnsi } from "../utils/terminal.js";
 import { getConfig } from "../auth/auth.js";
 import { resolveGitHubToken } from "../github/account-resolver.js";
 
@@ -111,12 +112,19 @@ export class CodexPtyClient implements CodingAgentClient {
 
           const success = exitCode === 0 || !this._killed;
 
+          // Check for auth/login errors in terminal output on failure
+          const authErrorMsg = !success ? detectAuthError(stripAnsi(this.ringBuffer)) : null;
+          if (authErrorMsg) {
+            console.error(`[${label}] Auth error detected: ${authErrorMsg}`);
+          }
+
           resolve({
             success,
             sessionId,
             summary: success ? extractPtySummary(this.ringBuffer) : `Process exited with code ${exitCode}`,
             diff,
             usage: null,
+            ...(authErrorMsg ? { authError: true, error: authErrorMsg } : {}),
           });
 
           this.ptyProcess = null;

--- a/packages/server/src/coding-agents/coding-agent-client.ts
+++ b/packages/server/src/coding-agents/coding-agent-client.ts
@@ -12,6 +12,8 @@ export interface CodingAgentTaskResult {
   diff: CodingAgentDiff | null;
   usage: CodingAgentTokenUsage | null;
   error?: string;
+  /** True when the agent failed due to an authentication/login issue (non-retryable) */
+  authError?: boolean;
 }
 
 export interface CodingAgentDiff {
@@ -59,3 +61,39 @@ export interface CodingAgentClient {
 
 /** Sentinel string that signals task completion when detected in streaming output. */
 export const TASK_COMPLETE_SENTINEL = "◊◊TASK_COMPLETE_9f8e7d◊◊";
+
+/**
+ * Detect authentication/login errors in terminal output from coding agents.
+ * These are non-retryable errors — the agent needs credentials configured.
+ */
+export function detectAuthError(terminalOutput: string): string | null {
+  const lower = terminalOutput.toLowerCase();
+  const patterns: Array<{ test: (s: string) => boolean; message: string }> = [
+    // Generic API key / auth errors
+    { test: (s) => /invalid\s*(api[_\s]?key|token|credentials?)/.test(s), message: "Invalid API key or credentials" },
+    { test: (s) => /authentication\s+(failed|error|required)/.test(s), message: "Authentication failed" },
+    { test: (s) => /unauthorized|401\s*unauthorized/.test(s), message: "Unauthorized — invalid or missing credentials" },
+    { test: (s) => /api[_\s]?key\s*(is\s*)?(not\s+set|missing|required|invalid|expired)/.test(s), message: "API key not configured or invalid" },
+    { test: (s) => s.includes("not authenticated") || s.includes("not logged in"), message: "Not authenticated — login required" },
+    { test: (s) => /please\s+(log\s*in|sign\s*in|authenticate)/.test(s), message: "Login required" },
+    // Claude Code specific
+    { test: (s) => s.includes("anthropic_api_key") && (s.includes("not set") || s.includes("invalid") || s.includes("missing")), message: "ANTHROPIC_API_KEY not set or invalid" },
+    { test: (s) => s.includes("could not authenticate with anthropic"), message: "Could not authenticate with Anthropic" },
+    // OpenAI / Codex specific
+    { test: (s) => s.includes("openai_api_key") && (s.includes("not set") || s.includes("invalid") || s.includes("missing")), message: "OPENAI_API_KEY not set or invalid" },
+    { test: (s) => /incorrect\s*api\s*key/.test(s), message: "Incorrect API key" },
+    // Gemini specific
+    { test: (s) => s.includes("gemini_api_key") && (s.includes("not set") || s.includes("invalid") || s.includes("missing")), message: "GEMINI_API_KEY not set or invalid" },
+    // Google OAuth
+    { test: (s) => /gcloud.*auth|google.*auth/.test(s) && /login|required|expired/.test(s), message: "Google authentication required" },
+    // Rate limit / quota (also non-retryable without intervention)
+    { test: (s) => /quota\s*(exceeded|exhausted)/.test(s), message: "API quota exceeded" },
+    { test: (s) => /billing\s*(not\s+active|required|issue)/.test(s), message: "Billing not active — payment required" },
+    { test: (s) => s.includes("insufficient_quota"), message: "Insufficient API quota" },
+  ];
+
+  for (const { test, message } of patterns) {
+    if (test(lower)) return message;
+  }
+  return null;
+}

--- a/packages/server/src/coding-agents/gemini-cli-pty-client.ts
+++ b/packages/server/src/coding-agents/gemini-cli-pty-client.ts
@@ -10,8 +10,9 @@ import type {
   CodingAgentClient,
   CodingAgentTaskResult,
 } from "./coding-agent-client.js";
+import { detectAuthError } from "./coding-agent-client.js";
 import { computeGitDiff } from "../utils/git.js";
-import { extractPtySummary } from "../utils/terminal.js";
+import { extractPtySummary, stripAnsi } from "../utils/terminal.js";
 import { getConfig } from "../auth/auth.js";
 import { resolveGitHubToken } from "../github/account-resolver.js";
 
@@ -128,12 +129,19 @@ export class GeminiCliPtyClient implements CodingAgentClient {
 
           const success = exitCode === 0 || !this._killed;
 
+          // Check for auth/login errors in terminal output on failure
+          const authErrorMsg = !success ? detectAuthError(stripAnsi(this.ringBuffer)) : null;
+          if (authErrorMsg) {
+            console.error(`[${label}] Auth error detected: ${authErrorMsg}`);
+          }
+
           resolve({
             success,
             sessionId,
             summary: success ? extractPtySummary(this.ringBuffer) : `Process exited with code ${exitCode}`,
             diff,
             usage: null,
+            ...(authErrorMsg ? { authError: true, error: authErrorMsg } : {}),
           });
 
           this.ptyProcess = null;

--- a/packages/server/src/coding-agents/opencode-pty-client.ts
+++ b/packages/server/src/coding-agents/opencode-pty-client.ts
@@ -10,8 +10,9 @@ import type {
   CodingAgentClient,
   CodingAgentTaskResult,
 } from "./coding-agent-client.js";
+import { detectAuthError } from "./coding-agent-client.js";
 import { computeGitDiff } from "../utils/git.js";
-import { extractPtySummary } from "../utils/terminal.js";
+import { extractPtySummary, stripAnsi } from "../utils/terminal.js";
 import { getConfig } from "../auth/auth.js";
 import { resolveGitHubToken } from "../github/account-resolver.js";
 
@@ -106,12 +107,19 @@ export class OpenCodePtyClient implements CodingAgentClient {
 
           const success = exitCode === 0 || !this._killed;
 
+          // Check for auth/login errors in terminal output on failure
+          const authErrorMsg = !success ? detectAuthError(stripAnsi(this.ringBuffer)) : null;
+          if (authErrorMsg) {
+            console.error(`[${label}] Auth error detected: ${authErrorMsg}`);
+          }
+
           resolve({
             success,
             sessionId,
             summary: success ? extractPtySummary(this.ringBuffer) : `Process exited with code ${exitCode}`,
             diff,
             usage: null,
+            ...(authErrorMsg ? { authError: true, error: authErrorMsg } : {}),
           });
 
           this.ptyProcess = null;

--- a/packages/server/src/pipeline/pipeline-manager.ts
+++ b/packages/server/src/pipeline/pipeline-manager.ts
@@ -814,6 +814,13 @@ export class PipelineManager {
       return;
     }
 
+    // Auth/login errors are non-retryable — skip directly to backlog with a clear message
+    if (workerReport.startsWith("CODING_AGENT_AUTH_ERROR:")) {
+      console.error(`[PipelineManager] Auth error for task ${taskId}: ${workerReport}`);
+      await this.handleAuthFailure(taskId, workerReport, state);
+      return;
+    }
+
     // Extract branch name from the worker report (any stage may mention it)
     if (!state.prBranch) {
       state.prBranch = this.extractBranchName(workerReport);
@@ -1143,6 +1150,52 @@ export class PipelineManager {
             formatBotComment(
               "Pipeline Spawn Failed",
               `Failed after ${MAX_SPAWN_RETRIES} retries at stage \`${currentStage}\`. Task moved to backlog for review.\n\nError: ${errorMessage}`,
+            ),
+          );
+        } catch { /* best effort */ }
+      }
+    }
+
+    this.resetTaskToBacklog(taskId);
+    this.pipelines.delete(taskId);
+  }
+
+  /**
+   * Handle a non-retryable auth/login failure from a coding agent.
+   * Moves the task to backlog immediately without retries and posts a clear error.
+   */
+  private async handleAuthFailure(
+    taskId: string,
+    errorMessage: string,
+    state: PipelineState,
+  ): Promise<void> {
+    const currentStage = state.stages[state.currentStageIndex];
+    console.error(
+      `[PipelineManager] Coding agent auth failure for task ${taskId} at stage ${currentStage} — skipping retries`,
+    );
+
+    // Append error note to task description
+    const db = getDb();
+    const task = db.select().from(schema.kanbanTasks).where(eq(schema.kanbanTasks.id, taskId)).get();
+    if (task) {
+      const errorNote = `\n\n---\n🔑 Coding agent authentication error at stage "${currentStage}" (no retries — requires configuration fix): ${errorMessage}`;
+      const updatedDesc = (task.description ?? "") + errorNote;
+      db.update(schema.kanbanTasks)
+        .set({ description: updatedDesc, updatedAt: new Date().toISOString() })
+        .where(eq(schema.kanbanTasks.id, taskId))
+        .run();
+    }
+
+    // Post GitHub comment
+    if (state.issueNumber && state.repo) {
+      const token = resolveGitHubToken(state.projectId);
+      if (token) {
+        try {
+          await createIssueComment(
+            state.repo, token, state.issueNumber,
+            formatBotComment(
+              "Coding Agent Authentication Error",
+              `The coding agent failed to authenticate at stage \`${currentStage}\`. This is a configuration issue that requires manual intervention — retries will not help.\n\n**Error:** ${errorMessage}\n\nPlease check the API key configuration in settings and retry.`,
             ),
           );
         } catch { /* best effort */ }


### PR DESCRIPTION
## Summary
- Adds centralized `detectAuthError()` function to detect authentication/credential errors in coding agent terminal output (Claude Code, Codex, Gemini CLI, OpenCode)
- PTY clients set `authError: true` on task results when auth errors are detected on failure
- Workers prefix auth error reports with `CODING_AGENT_AUTH_ERROR:` to signal non-retryable failure
- Pipeline manager intercepts the prefix and calls `handleAuthFailure()` which skips retries, posts a GitHub comment, and moves the task to backlog
- Terminal idle checker also detects auth errors and kills the PTY process immediately to avoid wasting time

Closes #441