### PR TITLE
feat: add pop-out window support for 2D view and agent graph

### DIFF
--- a/packages/web/src/App.detached-modes.test.ts
+++ b/packages/web/src/App.detached-modes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("App detached mode wiring", () => {
+  it("routes detached 2D mode to DetachedLive2DView", () => {
+    const source = readFileSync(resolve(__dirname, "./App.tsx"), "utf-8");
+
+    expect(source).toContain('import { DetachedLive2DView } from "./components/live-2d-view/DetachedLive2DView";');
+    expect(source).toContain('const isDetached2D = new URLSearchParams(window.location.search).has("detached-2d");');
+    expect(source).toContain("if (isDetached2D && screen === \"app\") {");
+    expect(source).toContain("return <DetachedLive2DView />;");
+  });
+
+  it("routes detached graph mode to DetachedAgentGraph", () => {
+    const source = readFileSync(resolve(__dirname, "./App.tsx"), "utf-8");
+
+    expect(source).toContain('import { DetachedAgentGraph } from "./components/graph/DetachedAgentGraph";');
+    expect(source).toContain('const isDetachedGraph = new URLSearchParams(window.location.search).has("detached-graph");');
+    expect(source).toContain("if (isDetachedGraph && screen === \"app\") {");
+    expect(source).toContain("return <DetachedAgentGraph />;");
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -34,6 +34,8 @@ import { GameStudio } from "./components/games/GameStudio";
 import { AppStudio } from "./components/apps/AppStudio";
 import { VideoStudio } from "./components/videos/VideoStudio";
 import { DetachedLiveView } from "./components/live-view/DetachedLiveView";
+import { DetachedLive2DView } from "./components/live-2d-view/DetachedLive2DView";
+import { DetachedAgentGraph } from "./components/graph/DetachedAgentGraph";
 import { DetachedCeoChat } from "./components/chat/DetachedCeoChat";
 import { useDesktopStore } from "./stores/desktop-store";
 import { useOpenCodeStore } from "./stores/opencode-store";
@@ -72,6 +74,18 @@ export default function App() {
   const isDetached3D = new URLSearchParams(window.location.search).has("detached-3d");
   if (isDetached3D && screen === "app") {
     return <DetachedLiveView />;
+  }
+
+  // Detached 2D view mode
+  const isDetached2D = new URLSearchParams(window.location.search).has("detached-2d");
+  if (isDetached2D && screen === "app") {
+    return <DetachedLive2DView />;
+  }
+
+  // Detached agent graph mode
+  const isDetachedGraph = new URLSearchParams(window.location.search).has("detached-graph");
+  if (isDetachedGraph && screen === "app") {
+    return <DetachedAgentGraph />;
   }
 
   // Detached chat mode

--- a/packages/web/src/components/detached-popouts-wiring.test.ts
+++ b/packages/web/src/components/detached-popouts-wiring.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("Detached view and pop-out wiring", () => {
+  it("wires 2D view pop-out button and detached loader setup", () => {
+    const live2DSource = readFileSync(resolve(__dirname, "./live-2d-view/Live2DView.tsx"), "utf-8");
+    const detached2DSource = readFileSync(resolve(__dirname, "./live-2d-view/DetachedLive2DView.tsx"), "utf-8");
+
+    expect(live2DSource).toContain('title="Pop out 2D View"');
+    expect(live2DSource).toContain('window.open(window.location.origin + "?detached-2d=true", "Detached2D", "width=1200,height=800")');
+
+    expect(detached2DSource).toContain('fetch("/api/profile")');
+    expect(detached2DSource).toContain('fetch("/api/agents")');
+    expect(detached2DSource).toContain("initMovementTriggers();");
+    expect(detached2DSource).toContain("initBreakRoomRoaming();");
+    expect(detached2DSource).toContain("Loading 2D View...");
+  });
+
+  it("wires graph pop-out button and detached graph loader setup", () => {
+    const graphSource = readFileSync(resolve(__dirname, "./graph/AgentGraph.tsx"), "utf-8");
+    const detachedGraphSource = readFileSync(resolve(__dirname, "./graph/DetachedAgentGraph.tsx"), "utf-8");
+
+    expect(graphSource).toContain('title="Pop out Agent Graph"');
+    expect(graphSource).toContain('window.open(window.location.origin + "?detached-graph=true", "DetachedGraph", "width=1200,height=800")');
+
+    expect(detachedGraphSource).toContain('fetch("/api/profile")');
+    expect(detachedGraphSource).toContain('fetch("/api/agents")');
+    expect(detachedGraphSource).toContain("Loading Agent Graph...");
+  });
+});

--- a/packages/web/src/components/graph/AgentGraph.tsx
+++ b/packages/web/src/components/graph/AgentGraph.tsx
@@ -181,17 +181,30 @@ function AgentGraphInner({
             {activeCount} agents
           </span>
           {onToggleView && (
-            <button
-              onClick={onToggleView}
-              title="Switch to Live View"
-              className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded hover:bg-secondary"
-            >
-              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
-                <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
-                <line x1="12" y1="22.08" x2="12" y2="12" />
-              </svg>
-            </button>
+            <>
+              <button
+                onClick={() => window.open(window.location.origin + "?detached-graph=true", "DetachedGraph", "width=1200,height=800")}
+                title="Pop out Agent Graph"
+                className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded hover:bg-secondary"
+              >
+                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                  <polyline points="15 3 21 3 21 9" />
+                  <line x1="10" y1="14" x2="21" y2="3" />
+                </svg>
+              </button>
+              <button
+                onClick={onToggleView}
+                title="Switch to Live View"
+                className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded hover:bg-secondary"
+              >
+                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+                  <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+                  <line x1="12" y1="22.08" x2="12" y2="12" />
+                </svg>
+              </button>
+            </>
           )}
         </div>
       </div>

--- a/packages/web/src/components/graph/DetachedAgentGraph.tsx
+++ b/packages/web/src/components/graph/DetachedAgentGraph.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { AgentGraph } from "./AgentGraph";
+import { useSocket } from "../../hooks/use-socket";
+import { useAgentStore } from "../../stores/agent-store";
+
+interface UserProfile {
+  name: string | null;
+  avatar: string | null;
+  cooName?: string;
+}
+
+export function DetachedAgentGraph() {
+  const [userProfile, setUserProfile] = useState<UserProfile | undefined>();
+  const loadAgents = useAgentStore((s) => s.loadAgents);
+
+  // Initialize socket listeners
+  useSocket();
+
+  useEffect(() => {
+    fetch("/api/profile")
+      .then((r) => r.json())
+      .then(setUserProfile)
+      .catch(console.error);
+
+    fetch("/api/agents")
+      .then((r) => r.json())
+      .then(loadAgents)
+      .catch(console.error);
+  }, [loadAgents]);
+
+  if (!userProfile) {
+    return (
+      <div className="h-screen w-screen bg-black text-white flex items-center justify-center">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <div className="w-6 h-6 rounded-md bg-primary/20 flex items-center justify-center animate-pulse">
+            <span className="text-primary text-xs font-bold">G</span>
+          </div>
+          <span className="text-sm">Loading Agent Graph...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen w-screen overflow-hidden bg-black">
+      <AgentGraph userProfile={userProfile} />
+    </div>
+  );
+}

--- a/packages/web/src/components/live-2d-view/DetachedLive2DView.tsx
+++ b/packages/web/src/components/live-2d-view/DetachedLive2DView.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { Live2DView } from "./Live2DView";
+import { useSocket } from "../../hooks/use-socket";
+import { useAgentStore } from "../../stores/agent-store";
+import { initMovementTriggers } from "../../lib/movement-triggers";
+import { initBreakRoomRoaming } from "../../lib/break-room-roaming";
+
+interface UserProfile {
+  name: string | null;
+  avatar: string | null;
+  modelPackId?: string | null;
+  gearConfig?: Record<string, boolean> | null;
+  cooName?: string;
+}
+
+export function DetachedLive2DView() {
+  const [userProfile, setUserProfile] = useState<UserProfile | undefined>();
+  const loadAgents = useAgentStore((s) => s.loadAgents);
+
+  // Initialize socket listeners
+  useSocket();
+
+  useEffect(() => {
+    fetch("/api/profile")
+      .then((r) => r.json())
+      .then(setUserProfile)
+      .catch(console.error);
+
+    fetch("/api/agents")
+      .then((r) => r.json())
+      .then(loadAgents)
+      .catch(console.error);
+
+    initMovementTriggers();
+    initBreakRoomRoaming();
+  }, [loadAgents]);
+
+  if (!userProfile) {
+    return (
+      <div className="h-screen w-screen bg-black text-white flex items-center justify-center">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <div className="w-6 h-6 rounded-md bg-primary/20 flex items-center justify-center animate-pulse">
+            <span className="text-primary text-xs font-bold">2D</span>
+          </div>
+          <span className="text-sm">Loading 2D View...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen w-screen overflow-hidden bg-black">
+      <Live2DView userProfile={userProfile} />
+    </div>
+  );
+}

--- a/packages/web/src/components/live-2d-view/Live2DView.tsx
+++ b/packages/web/src/components/live-2d-view/Live2DView.tsx
@@ -105,17 +105,30 @@ export function Live2DView({ userProfile, onToggleView }: Live2DViewProps) {
         <h2 className="text-sm font-semibold tracking-tight">2D View</h2>
         <div className="flex items-center gap-2">
           {onToggleView && (
-            <button
-              onClick={onToggleView}
-              title="Switch to Agent Graph"
-              className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded hover:bg-secondary"
-            >
-              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="10" />
-                <line x1="2" y1="12" x2="22" y2="12" />
-                <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-              </svg>
-            </button>
+            <>
+              <button
+                onClick={() => window.open(window.location.origin + "?detached-2d=true", "Detached2D", "width=1200,height=800")}
+                title="Pop out 2D View"
+                className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded hover:bg-secondary"
+              >
+                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                  <polyline points="15 3 21 3 21 9" />
+                  <line x1="10" y1="14" x2="21" y2="3" />
+                </svg>
+              </button>
+              <button
+                onClick={onToggleView}
+                title="Switch to Agent Graph"
+                className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded hover:bg-secondary"
+              >
+                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="10" />
+                  <line x1="2" y1="12" x2="22" y2="12" />
+                  <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+                </svg>
+              </button>
+            </>
           )}
         </div>
       </div>

--- a/packages/web/src/components/project/CreateProjectDialog.test.tsx
+++ b/packages/web/src/components/project/CreateProjectDialog.test.tsx
@@ -93,6 +93,7 @@ describe("CreateProjectDialog PAT dropdown", () => {
         "", // description
         "", // rules
         false, // issueMonitor
+        [], // studios
         false, // loading
         null, // error
         true, // showPatSection
@@ -120,6 +121,7 @@ describe("CreateProjectDialog PAT dropdown", () => {
         "", // description
         "", // rules
         false, // issueMonitor
+        [], // studios
         false, // loading
         null, // error
         true, // showPatSection
@@ -147,6 +149,7 @@ describe("CreateProjectDialog PAT dropdown", () => {
         "", // description
         "", // rules
         false, // issueMonitor
+        [], // studios
         false, // loading
         null, // error
         true, // showPatSection
@@ -170,6 +173,7 @@ describe("CreateProjectDialog PAT dropdown", () => {
         "", // description
         "", // rules
         false, // issueMonitor
+        [], // studios
         false, // loading
         null, // error
         true, // showPatSection


### PR DESCRIPTION
## Summary
- Adds pop-out window buttons to the 2D View and Agent Graph panels, matching existing 3D view behavior
- Creates `DetachedLive2DView` and `DetachedAgentGraph` components that bootstrap standalone windows with socket, agent, and movement initialization
- Wires detached mode routing in `App.tsx` via `?detached-2d` and `?detached-graph` query params

Closes #455

## Test plan
- [x] Verify pop-out button appears in 2D View header when `onToggleView` is provided
- [x] Verify pop-out button appears in Agent Graph header when `onToggleView` is provided
- [x] Verify clicking pop-out opens a new window with the correct query param
- [x] Verify detached 2D view loads profile, agents, and movement systems
- [x] Verify detached agent graph loads profile and agents
- [x] String-based wiring tests pass for both detached modes