### PR TITLE
feat: add SVG otterbot logo variations

### DIFF
--- a/logo/otterbot-logo-v1.svg
+++ b/logo/otterbot-logo-v1.svg
@@ -1,0 +1,63 @@
+<!-- Otterbot Logo v1: Minimal robotic otter head/bust icon
+     Metallic silver/blue color scheme with glowing cyan eyes
+     and subtle circuit line details. Optimized for small sizes (16-64px). -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <style>
+    .body { fill: #8a9bb0; }
+    .body-dark { fill: #6b7d94; }
+    .body-highlight { fill: #a8b8ca; }
+    .eye-glow { fill: #00e5ff; }
+    .eye-inner { fill: #ffffff; }
+    .nose { fill: #2a3a4a; }
+    .circuit { stroke: #00bcd4; stroke-width: 0.6; fill: none; opacity: 0.5; }
+    .ear { fill: #7a8da2; }
+    .whisker { stroke: #5a6d82; stroke-width: 0.7; stroke-linecap: round; fill: none; }
+    .chin { fill: #c8d4e0; }
+    .metal-plate { fill: #5a6d82; stroke: #4a5d72; stroke-width: 0.4; }
+  </style>
+  <!-- Ears -->
+  <ellipse class="ear" cx="16" cy="16" rx="8" ry="6" transform="rotate(-20 16 16)"/>
+  <ellipse class="ear" cx="48" cy="16" rx="8" ry="6" transform="rotate(20 48 16)"/>
+  <!-- Head shape -->
+  <ellipse class="body" cx="32" cy="30" rx="22" ry="20"/>
+  <!-- Forehead plate -->
+  <path class="metal-plate" d="M20 18 Q32 12 44 18 Q42 22 32 24 Q22 22 20 18Z"/>
+  <!-- Face highlight / muzzle area -->
+  <ellipse class="chin" cx="32" cy="38" rx="12" ry="9"/>
+  <!-- Eyes - outer glow -->
+  <circle class="eye-glow" cx="23" cy="28" r="4.5" opacity="0.3"/>
+  <circle class="eye-glow" cx="41" cy="28" r="4.5" opacity="0.3"/>
+  <!-- Eyes -->
+  <ellipse class="eye-glow" cx="23" cy="28" rx="3.5" ry="3.8"/>
+  <ellipse class="eye-glow" cx="41" cy="28" rx="3.5" ry="3.8"/>
+  <!-- Eye inner -->
+  <circle class="eye-inner" cx="24" cy="27" r="1.2"/>
+  <circle class="eye-inner" cx="42" cy="27" r="1.2"/>
+  <!-- Pupil -->
+  <circle cx="23" cy="29" r="1.5" fill="#0a2a3a"/>
+  <circle cx="41" cy="29" r="1.5" fill="#0a2a3a"/>
+  <!-- Nose -->
+  <ellipse class="nose" cx="32" cy="35" rx="3" ry="2"/>
+  <ellipse cx="32" cy="34.5" rx="1.5" ry="0.8" fill="#3a4a5a"/>
+  <!-- Mouth -->
+  <path d="M29 37.5 Q32 40 35 37.5" stroke="#4a5d72" stroke-width="0.8" fill="none"/>
+  <!-- Whiskers -->
+  <line class="whisker" x1="20" y1="35" x2="10" y2="33"/>
+  <line class="whisker" x1="20" y1="37" x2="9" y2="38"/>
+  <line class="whisker" x1="44" y1="35" x2="54" y2="33"/>
+  <line class="whisker" x1="44" y1="37" x2="55" y2="38"/>
+  <!-- Circuit details -->
+  <path class="circuit" d="M18 20 L14 24 L14 28"/>
+  <path class="circuit" d="M46 20 L50 24 L50 28"/>
+  <path class="circuit" d="M28 14 L28 10"/>
+  <path class="circuit" d="M36 14 L36 10"/>
+  <circle class="circuit" cx="14" cy="28" r="1" fill="#00bcd4" opacity="0.5"/>
+  <circle class="circuit" cx="50" cy="28" r="1" fill="#00bcd4" opacity="0.5"/>
+  <circle class="circuit" cx="28" cy="10" r="0.8" fill="#00bcd4" opacity="0.5"/>
+  <circle class="circuit" cx="36" cy="10" r="0.8" fill="#00bcd4" opacity="0.5"/>
+  <!-- Neck / bust -->
+  <path class="body-dark" d="M20 46 Q32 52 44 46 L46 56 Q32 62 18 56Z"/>
+  <path class="body" d="M22 44 Q32 48 42 44 L44 54 Q32 60 20 54Z"/>
+  <!-- Neck circuit -->
+  <path class="circuit" d="M28 48 L28 54 M36 48 L36 54 M32 46 L32 56"/>
+</svg>

--- a/logo/otterbot-logo-v2.svg
+++ b/logo/otterbot-logo-v2.svg
@@ -1,0 +1,158 @@
+<!-- Otterbot Logo v2: Detailed robotic otter, 3/4 body view
+     Dark gray/charcoal body with blue/cyan accents
+     Visible circuit patterns and tech elements. For larger displays. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240">
+  <defs>
+    <linearGradient id="bodyGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4a4f5a"/>
+      <stop offset="50%" style="stop-color:#3a3f4a"/>
+      <stop offset="100%" style="stop-color:#2a2f3a"/>
+    </linearGradient>
+    <linearGradient id="bellyGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#6a7080"/>
+      <stop offset="100%" style="stop-color:#5a6070"/>
+    </linearGradient>
+    <radialGradient id="eyeGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" style="stop-color:#00e5ff"/>
+      <stop offset="60%" style="stop-color:#00bcd4"/>
+      <stop offset="100%" style="stop-color:#00838f;stop-opacity:0"/>
+    </radialGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <style>
+    .body { fill: url(#bodyGrad); }
+    .belly { fill: url(#bellyGrad); }
+    .plate { fill: #3a4550; stroke: #2a3540; stroke-width: 0.8; }
+    .circuit { stroke: #00bcd4; stroke-width: 0.8; fill: none; opacity: 0.6; }
+    .circuit-dot { fill: #00bcd4; opacity: 0.7; }
+    .accent { fill: #00bcd4; }
+    .accent-line { stroke: #00bcd4; stroke-width: 1; fill: none; opacity: 0.4; }
+    .dark { fill: #1a1f2a; }
+    .whisker { stroke: #5a6575; stroke-width: 1; stroke-linecap: round; fill: none; }
+    .claw { fill: #6a7585; }
+  </style>
+
+  <!-- Tail -->
+  <path class="body" d="M55 195 Q30 210 25 230 Q23 240 30 238 Q40 235 50 220 Q60 205 65 195" stroke="#2a2f3a" stroke-width="1"/>
+  <path class="circuit" d="M45 200 Q35 215 33 228"/>
+  <circle class="circuit-dot" cx="33" cy="228" r="1.5"/>
+
+  <!-- Back legs -->
+  <ellipse class="body" cx="70" cy="210" rx="20" ry="14" transform="rotate(-10 70 210)"/>
+  <ellipse class="body" cx="130" cy="210" rx="20" ry="14" transform="rotate(10 130 210)"/>
+  <!-- Feet -->
+  <ellipse class="plate" cx="58" cy="222" rx="14" ry="6"/>
+  <ellipse class="plate" cx="142" cy="222" rx="14" ry="6"/>
+  <!-- Toe claws -->
+  <ellipse class="claw" cx="48" cy="224" rx="3" ry="2"/>
+  <ellipse class="claw" cx="55" cy="226" rx="3" ry="2"/>
+  <ellipse class="claw" cx="62" cy="226" rx="3" ry="2"/>
+  <ellipse class="claw" cx="138" cy="226" rx="3" ry="2"/>
+  <ellipse class="claw" cx="145" cy="226" rx="3" ry="2"/>
+  <ellipse class="claw" cx="152" cy="224" rx="3" ry="2"/>
+
+  <!-- Body -->
+  <ellipse class="body" cx="100" cy="170" rx="50" ry="45"/>
+  <!-- Belly -->
+  <ellipse class="belly" cx="100" cy="175" rx="32" ry="30"/>
+
+  <!-- Body circuit patterns -->
+  <path class="circuit" d="M68 150 L60 160 L60 180 L65 190"/>
+  <path class="circuit" d="M132 150 L140 160 L140 180 L135 190"/>
+  <path class="circuit" d="M80 145 L80 155 L90 160"/>
+  <path class="circuit" d="M120 145 L120 155 L110 160"/>
+  <circle class="circuit-dot" cx="60" cy="160" r="2"/>
+  <circle class="circuit-dot" cx="140" cy="160" r="2"/>
+  <circle class="circuit-dot" cx="65" cy="190" r="1.5"/>
+  <circle class="circuit-dot" cx="135" cy="190" r="1.5"/>
+  <!-- Belly panel lines -->
+  <path class="accent-line" d="M82 158 Q100 152 118 158"/>
+  <path class="accent-line" d="M78 168 Q100 162 122 168"/>
+  <path class="accent-line" d="M80 178 Q100 172 120 178"/>
+
+  <!-- Front arms -->
+  <path class="body" d="M58 145 Q45 160 42 178 Q40 185 48 183 Q55 180 60 168 Q65 155 62 145"/>
+  <path class="body" d="M142 145 Q155 160 158 178 Q160 185 152 183 Q145 180 140 168 Q135 155 138 145"/>
+  <!-- Paws -->
+  <ellipse class="plate" cx="45" cy="182" rx="8" ry="5" transform="rotate(-15 45 182)"/>
+  <ellipse class="plate" cx="155" cy="182" rx="8" ry="5" transform="rotate(15 155 182)"/>
+  <!-- Arm circuits -->
+  <path class="circuit" d="M52 155 L48 168 L44 178"/>
+  <path class="circuit" d="M148 155 L152 168 L156 178"/>
+
+  <!-- Neck -->
+  <rect class="plate" x="82" y="118" width="36" height="14" rx="4"/>
+  <path class="circuit" d="M88 120 L88 130 M100 118 L100 132 M112 120 L112 130"/>
+  <circle class="circuit-dot" cx="88" cy="130" r="1.2"/>
+  <circle class="circuit-dot" cx="100" cy="132" r="1.2"/>
+  <circle class="circuit-dot" cx="112" cy="130" r="1.2"/>
+
+  <!-- Head -->
+  <ellipse class="body" cx="100" cy="80" rx="42" ry="38"/>
+
+  <!-- Ears -->
+  <ellipse cx="62" cy="50" rx="14" ry="10" fill="#3a4550" transform="rotate(-15 62 50)"/>
+  <ellipse cx="138" cy="50" rx="14" ry="10" fill="#3a4550" transform="rotate(15 138 50)"/>
+  <ellipse cx="62" cy="50" rx="9" ry="6" fill="#2a3540" transform="rotate(-15 62 50)"/>
+  <ellipse cx="138" cy="50" rx="9" ry="6" fill="#2a3540" transform="rotate(15 138 50)"/>
+  <!-- Ear antenna dots -->
+  <circle class="accent" cx="56" cy="42" r="2.5" filter="url(#glow)"/>
+  <circle class="accent" cx="144" cy="42" r="2.5" filter="url(#glow)"/>
+
+  <!-- Forehead plate -->
+  <path class="plate" d="M75 58 Q100 48 125 58 Q122 66 100 70 Q78 66 75 58Z"/>
+  <!-- Forehead circuit -->
+  <path class="circuit" d="M90 56 L90 50 L95 46"/>
+  <path class="circuit" d="M110 56 L110 50 L105 46"/>
+  <path class="circuit" d="M100 54 L100 48"/>
+  <circle class="circuit-dot" cx="95" cy="46" r="1.5"/>
+  <circle class="circuit-dot" cx="105" cy="46" r="1.5"/>
+  <circle class="circuit-dot" cx="100" cy="48" r="1.5"/>
+
+  <!-- Cheek / muzzle area -->
+  <ellipse cx="100" cy="90" rx="22" ry="16" fill="#5a6575"/>
+
+  <!-- Eyes - glow effect -->
+  <circle cx="82" cy="74" r="10" fill="url(#eyeGlow)" filter="url(#glow)"/>
+  <circle cx="118" cy="74" r="10" fill="url(#eyeGlow)" filter="url(#glow)"/>
+  <!-- Eyes - main -->
+  <ellipse cx="82" cy="74" rx="7" ry="8" fill="#00e5ff"/>
+  <ellipse cx="118" cy="74" rx="7" ry="8" fill="#00e5ff"/>
+  <!-- Eyes - inner ring -->
+  <ellipse cx="82" cy="74" rx="5" ry="6" fill="none" stroke="#004d5a" stroke-width="0.5"/>
+  <ellipse cx="118" cy="74" rx="5" ry="6" fill="none" stroke="#004d5a" stroke-width="0.5"/>
+  <!-- Pupils -->
+  <ellipse cx="82" cy="75" rx="3" ry="4" fill="#003a4a"/>
+  <ellipse cx="118" cy="75" rx="3" ry="4" fill="#003a4a"/>
+  <!-- Eye highlights -->
+  <circle cx="85" cy="71" r="2" fill="#ffffff" opacity="0.8"/>
+  <circle cx="121" cy="71" r="2" fill="#ffffff" opacity="0.8"/>
+  <circle cx="80" cy="77" r="1" fill="#ffffff" opacity="0.4"/>
+  <circle cx="116" cy="77" r="1" fill="#ffffff" opacity="0.4"/>
+
+  <!-- Nose -->
+  <ellipse cx="100" cy="88" rx="5" ry="3.5" fill="#1a1f2a"/>
+  <ellipse cx="100" cy="87" rx="2.5" ry="1.2" fill="#2a3040"/>
+  <!-- Mouth -->
+  <path d="M93 93 Q100 98 107 93" stroke="#3a4555" stroke-width="1.2" fill="none"/>
+
+  <!-- Whiskers -->
+  <line class="whisker" x1="80" y1="90" x2="55" y2="86"/>
+  <line class="whisker" x1="79" y1="94" x2="52" y2="94"/>
+  <line class="whisker" x1="80" y1="98" x2="56" y2="102"/>
+  <line class="whisker" x1="120" y1="90" x2="145" y2="86"/>
+  <line class="whisker" x1="121" y1="94" x2="148" y2="94"/>
+  <line class="whisker" x1="120" y1="98" x2="144" y2="102"/>
+
+  <!-- Side head circuits -->
+  <path class="circuit" d="M62 68 L55 72 L55 82 L58 88"/>
+  <path class="circuit" d="M138 68 L145 72 L145 82 L142 88"/>
+  <circle class="circuit-dot" cx="55" cy="72" r="1.5"/>
+  <circle class="circuit-dot" cx="145" cy="72" r="1.5"/>
+</svg>

--- a/logo/otterbot-logo-v3.svg
+++ b/logo/otterbot-logo-v3.svg
@@ -1,0 +1,105 @@
+<!-- Otterbot Logo v3: Geometric/stylized robotic otter
+     Clean geometric shapes, modern flat design aesthetic
+     Teal/green accent color scheme. Professional and brand-friendly. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <style>
+    .bg { fill: none; }
+    .body-main { fill: #37474f; }
+    .body-light { fill: #455a64; }
+    .body-dark { fill: #263238; }
+    .accent { fill: #009688; }
+    .accent-light { fill: #4db6ac; }
+    .accent-bright { fill: #1de9b6; }
+    .white { fill: #eceff1; }
+    .muzzle { fill: #607d8b; }
+    .eye { fill: #1de9b6; }
+    .nose { fill: #263238; }
+    .geo-line { stroke: #009688; stroke-width: 0.6; fill: none; opacity: 0.5; }
+  </style>
+
+  <!-- Body - geometric trapezoid -->
+  <polygon class="body-main" points="40,72 80,72 88,110 32,110"/>
+  <!-- Belly panel -->
+  <polygon class="body-light" points="48,76 72,76 76,106 44,106"/>
+
+  <!-- Chest accent stripe -->
+  <polygon class="accent" points="55,76 65,76 67,106 53,106" opacity="0.3"/>
+
+  <!-- Arms - angular -->
+  <polygon class="body-main" points="40,76 28,88 32,100 40,96"/>
+  <polygon class="body-main" points="80,76 92,88 88,100 80,96"/>
+  <!-- Arm accents -->
+  <line class="geo-line" x1="34" y1="85" x2="38" y2="93" stroke-width="1.2"/>
+  <line class="geo-line" x1="86" y1="85" x2="82" y2="93" stroke-width="1.2"/>
+
+  <!-- Paws - hexagonal -->
+  <polygon class="body-dark" points="26,88 22,92 24,97 30,99 34,95 32,90"/>
+  <polygon class="body-dark" points="94,88 98,92 96,97 90,99 86,95 88,90"/>
+
+  <!-- Head - rounded hexagon shape -->
+  <path class="body-main" d="M60 18 L82 28 L88 52 L80 68 L40 68 L32 52 L38 28Z"/>
+
+  <!-- Ears - triangular -->
+  <polygon class="body-dark" points="38,28 28,14 36,22"/>
+  <polygon class="body-dark" points="82,28 92,14 84,22"/>
+  <!-- Ear inner -->
+  <polygon class="accent" points="36,25 30,16 35,22" opacity="0.6"/>
+  <polygon class="accent" points="84,25 90,16 85,22" opacity="0.6"/>
+  <!-- Ear tip lights -->
+  <circle class="accent-bright" cx="29" cy="15" r="2"/>
+  <circle class="accent-bright" cx="91" cy="15" r="2"/>
+
+  <!-- Forehead plate - angular -->
+  <polygon class="body-dark" points="48,28 72,28 76,38 60,42 44,38"/>
+  <!-- Forehead accent lines -->
+  <line class="geo-line" x1="54" y1="30" x2="54" y2="38" stroke-width="1"/>
+  <line class="geo-line" x1="60" y1="28" x2="60" y2="40" stroke-width="1"/>
+  <line class="geo-line" x1="66" y1="30" x2="66" y2="38" stroke-width="1"/>
+  <!-- Forehead dots -->
+  <circle class="accent-bright" cx="54" cy="30" r="1.2"/>
+  <circle class="accent-bright" cx="60" cy="28" r="1.5"/>
+  <circle class="accent-bright" cx="66" cy="30" r="1.2"/>
+
+  <!-- Muzzle - rounded rectangle area -->
+  <rect class="muzzle" x="44" y="48" width="32" height="16" rx="8"/>
+
+  <!-- Eyes - diamond/gem shaped -->
+  <polygon class="eye" points="48,42 52,38 56,42 52,46"/>
+  <polygon class="eye" points="68,42 72,38 76,42 72,46"/>
+  <!-- Eye inner highlights -->
+  <polygon class="white" points="51,40 52,39 53,40 52,41" opacity="0.8"/>
+  <polygon class="white" points="71,40 72,39 73,40 72,41" opacity="0.8"/>
+  <!-- Eye outer glow -->
+  <polygon points="48,42 52,38 56,42 52,46" fill="none" stroke="#1de9b6" stroke-width="0.8" opacity="0.5"/>
+  <polygon points="68,42 72,38 76,42 72,46" fill="none" stroke="#1de9b6" stroke-width="0.8" opacity="0.5"/>
+
+  <!-- Nose - small diamond -->
+  <polygon class="nose" points="60,52 62,50 64,52 62,54"/>
+
+  <!-- Mouth - simple angular -->
+  <polyline points="56,57 60,60 64,57" stroke="#455a64" stroke-width="1" fill="none" stroke-linejoin="round"/>
+
+  <!-- Whiskers - straight geometric -->
+  <line x1="44" y1="53" x2="28" y2="50" stroke="#546e7a" stroke-width="0.8"/>
+  <line x1="44" y1="56" x2="26" y2="57" stroke="#546e7a" stroke-width="0.8"/>
+  <line x1="76" y1="53" x2="92" y2="50" stroke="#546e7a" stroke-width="0.8"/>
+  <line x1="76" y1="56" x2="94" y2="57" stroke="#546e7a" stroke-width="0.8"/>
+
+  <!-- Side head circuits -->
+  <path class="geo-line" d="M36 36 L30 40 L30 50" stroke-width="1"/>
+  <path class="geo-line" d="M84 36 L90 40 L90 50" stroke-width="1"/>
+  <circle class="accent-bright" cx="30" cy="50" r="1.5"/>
+  <circle class="accent-bright" cx="90" cy="50" r="1.5"/>
+
+  <!-- Body circuit patterns -->
+  <path class="geo-line" d="M50 80 L50 90 L55 95" stroke-width="0.8"/>
+  <path class="geo-line" d="M70 80 L70 90 L65 95" stroke-width="0.8"/>
+  <path class="geo-line" d="M60 78 L60 100" stroke-width="0.8"/>
+  <circle class="accent-bright" cx="50" cy="80" r="1"/>
+  <circle class="accent-bright" cx="60" cy="78" r="1"/>
+  <circle class="accent-bright" cx="70" cy="80" r="1"/>
+
+  <!-- Tail - angular -->
+  <polygon class="body-main" points="32,100 20,108 18,116 24,114 34,106"/>
+  <line class="geo-line" x1="28" y1="104" x2="22" y2="112" stroke-width="1"/>
+</svg>

--- a/logo/otterbot-logo-v4.svg
+++ b/logo/otterbot-logo-v4.svg
@@ -1,0 +1,146 @@
+<!-- Otterbot Logo v4: Circular badge/emblem version
+     Robotic otter silhouette inside a circle with 'OTTERBOT' text
+     Good for social media avatars and badges. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <defs>
+    <linearGradient id="ringGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#37474f"/>
+      <stop offset="100%" style="stop-color:#263238"/>
+    </linearGradient>
+    <linearGradient id="innerBg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a2530"/>
+      <stop offset="100%" style="stop-color:#0d1520"/>
+    </linearGradient>
+    <radialGradient id="eyeGlowV4" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" style="stop-color:#00e5ff"/>
+      <stop offset="80%" style="stop-color:#00bcd4"/>
+      <stop offset="100%" style="stop-color:#00838f;stop-opacity:0"/>
+    </radialGradient>
+    <filter id="glowV4">
+      <feGaussianBlur stdDeviation="1.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <style>
+    .ring { fill: url(#ringGrad); }
+    .ring-accent { stroke: #00bcd4; stroke-width: 1.5; fill: none; }
+    .inner-bg { fill: url(#innerBg); }
+    .otter-body { fill: #546e7a; }
+    .otter-light { fill: #78909c; }
+    .otter-dark { fill: #37474f; }
+    .otter-muzzle { fill: #90a4ae; }
+    .eye-cyan { fill: #00e5ff; }
+    .nose-dark { fill: #1a2530; }
+    .circuit-v4 { stroke: #00bcd4; stroke-width: 0.7; fill: none; opacity: 0.6; }
+    .circuit-dot-v4 { fill: #00bcd4; opacity: 0.8; }
+    .text-main { fill: #b0bec5; font-family: 'Arial', 'Helvetica', sans-serif; font-weight: 700; letter-spacing: 6px; }
+    .text-accent { fill: #00bcd4; font-family: 'Arial', 'Helvetica', sans-serif; font-weight: 400; font-size: 8px; letter-spacing: 2px; }
+    .divider-dot { fill: #00bcd4; }
+  </style>
+
+  <!-- Outer ring -->
+  <circle class="ring" cx="100" cy="100" r="96"/>
+  <!-- Ring border -->
+  <circle cx="100" cy="100" r="96" fill="none" stroke="#455a64" stroke-width="2"/>
+  <circle class="ring-accent" cx="100" cy="100" r="93"/>
+
+  <!-- Inner circle background -->
+  <circle class="inner-bg" cx="100" cy="100" r="72"/>
+  <circle cx="100" cy="100" r="72" fill="none" stroke="#37474f" stroke-width="1"/>
+
+  <!-- Text along top arc: OTTERBOT -->
+  <path id="topArc" d="M 18,100 A 82,82 0 0,1 182,100" fill="none"/>
+  <text class="text-main" font-size="16">
+    <textPath href="#topArc" startOffset="50%" text-anchor="middle">OTTERBOT</textPath>
+  </text>
+
+  <!-- Divider dots -->
+  <circle class="divider-dot" cx="28" cy="120" r="2.5"/>
+  <circle class="divider-dot" cx="172" cy="120" r="2.5"/>
+
+  <!-- Subtitle along bottom arc -->
+  <path id="bottomArc" d="M 35,145 A 78,78 0 0,0 165,145" fill="none"/>
+  <text class="text-accent">
+    <textPath href="#bottomArc" startOffset="50%" text-anchor="middle">AI GAME ENGINE</textPath>
+  </text>
+
+  <!-- Otter silhouette - positioned in center circle -->
+  <!-- Ears -->
+  <polygon class="otter-dark" points="72,52 62,38 72,46"/>
+  <polygon class="otter-dark" points="128,52 138,38 128,46"/>
+  <polygon class="eye-cyan" points="64,40 62,38 66,42" opacity="0.5"/>
+  <polygon class="eye-cyan" points="136,40 138,38 134,42" opacity="0.5"/>
+
+  <!-- Head -->
+  <ellipse class="otter-body" cx="100" cy="72" rx="32" ry="28"/>
+
+  <!-- Forehead plate -->
+  <path class="otter-dark" d="M82 56 Q100 48 118 56 Q116 62 100 66 Q84 62 82 56Z"/>
+
+  <!-- Muzzle -->
+  <ellipse class="otter-muzzle" cx="100" cy="80" rx="16" ry="11"/>
+
+  <!-- Eyes -->
+  <circle cx="88" cy="68" r="7" fill="url(#eyeGlowV4)" filter="url(#glowV4)"/>
+  <circle cx="112" cy="68" r="7" fill="url(#eyeGlowV4)" filter="url(#glowV4)"/>
+  <ellipse class="eye-cyan" cx="88" cy="68" rx="5" ry="5.5"/>
+  <ellipse class="eye-cyan" cx="112" cy="68" rx="5" ry="5.5"/>
+  <!-- Pupils -->
+  <circle cx="88" cy="69" r="2.5" fill="#003a4a"/>
+  <circle cx="112" cy="69" r="2.5" fill="#003a4a"/>
+  <!-- Highlights -->
+  <circle cx="90" cy="66" r="1.5" fill="#ffffff" opacity="0.7"/>
+  <circle cx="114" cy="66" r="1.5" fill="#ffffff" opacity="0.7"/>
+
+  <!-- Nose -->
+  <ellipse class="nose-dark" cx="100" cy="78" rx="3.5" ry="2.5"/>
+  <ellipse cx="100" cy="77.5" rx="1.8" ry="0.8" fill="#2a3540"/>
+
+  <!-- Mouth -->
+  <path d="M95 83 Q100 87 105 83" stroke="#607d8b" stroke-width="0.8" fill="none"/>
+
+  <!-- Whiskers -->
+  <line x1="84" y1="80" x2="68" y2="77" stroke="#78909c" stroke-width="0.7"/>
+  <line x1="84" y1="83" x2="66" y2="84" stroke="#78909c" stroke-width="0.7"/>
+  <line x1="116" y1="80" x2="132" y2="77" stroke="#78909c" stroke-width="0.7"/>
+  <line x1="116" y1="83" x2="134" y2="84" stroke="#78909c" stroke-width="0.7"/>
+
+  <!-- Neck plate -->
+  <rect class="otter-dark" x="86" y="96" width="28" height="8" rx="3"/>
+  <path class="circuit-v4" d="M92 97 L92 103 M100 96 L100 104 M108 97 L108 103"/>
+
+  <!-- Body -->
+  <ellipse class="otter-body" cx="100" cy="122" rx="28" ry="22"/>
+  <ellipse class="otter-light" cx="100" cy="124" rx="18" ry="16"/>
+
+  <!-- Arms -->
+  <path class="otter-body" d="M74 110 Q62 120 64 132 Q66 136 70 134 Q72 130 74 120Z"/>
+  <path class="otter-body" d="M126 110 Q138 120 136 132 Q134 136 130 134 Q128 130 126 120Z"/>
+
+  <!-- Body circuits -->
+  <path class="circuit-v4" d="M90 115 L88 125 L92 130"/>
+  <path class="circuit-v4" d="M110 115 L112 125 L108 130"/>
+  <circle class="circuit-dot-v4" cx="88" cy="125" r="1.2"/>
+  <circle class="circuit-dot-v4" cx="112" cy="125" r="1.2"/>
+
+  <!-- Head circuits -->
+  <path class="circuit-v4" d="M72 58 L66 62 L66 70"/>
+  <path class="circuit-v4" d="M128 58 L134 62 L134 70"/>
+  <circle class="circuit-dot-v4" cx="66" cy="70" r="1.2"/>
+  <circle class="circuit-dot-v4" cx="134" cy="70" r="1.2"/>
+
+  <!-- Forehead circuit -->
+  <path class="circuit-v4" d="M94 52 L94 48 M100 50 L100 46 M106 52 L106 48"/>
+  <circle class="circuit-dot-v4" cx="94" cy="48" r="1"/>
+  <circle class="circuit-dot-v4" cx="100" cy="46" r="1.2"/>
+  <circle class="circuit-dot-v4" cx="106" cy="48" r="1"/>
+
+  <!-- Decorative ring notches -->
+  <circle class="divider-dot" cx="100" cy="6" r="2"/>
+  <circle class="divider-dot" cx="100" cy="194" r="2"/>
+  <circle class="divider-dot" cx="6" cy="100" r="2"/>
+  <circle class="divider-dot" cx="194" cy="100" r="2"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add 4 SVG logo variations in `logo/` directory as fallback assets for AI image generation
- **v1**: Minimal robotic otter head/bust icon — metallic silver/blue, glowing cyan eyes, works at small sizes (favicon-friendly)
- **v2**: Detailed full-body robotic otter — dark charcoal with blue/cyan accents, visible circuit patterns, for larger displays
- **v3**: Geometric/stylized robotic otter — clean flat design with teal/green accents, professional and brand-friendly
- **v4**: Circular badge/emblem — otter silhouette with "OTTERBOT" text rim, for avatars and badges

## Design details
- All SVGs use `viewBox` (responsive, no fixed dimensions)
- Clean vector paths with inline styles, no raster elements
- Each file is self-contained with a descriptive comment header

## Test plan
- [ ] Open each SVG in a browser to verify rendering
- [ ] Verify SVGs scale correctly at various sizes (16px, 64px, 256px, 512px)
- [ ] Check v1 works as a favicon candidate
- [ ] Check v4 text renders correctly along the circular path