### PR TITLE
feat: show download progress for starter pack and model installs

### DIFF
--- a/packages/server/src/asset-providers/comfyui.ts
+++ b/packages/server/src/asset-providers/comfyui.ts
@@ -294,7 +294,9 @@ async function fetchBuffer(url: string): Promise<Buffer> {
   return Buffer.from(await res.arrayBuffer());
 }
 
-async function downloadToFile(url: string, destination: string): Promise<void> {
+type DownloadProgressCallback = (bytesDownloaded: number, totalBytes: number) => void;
+
+async function downloadToFile(url: string, destination: string, onProgress?: DownloadProgressCallback): Promise<void> {
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Request failed (${res.status}) for ${url}`);
@@ -302,6 +304,8 @@ async function downloadToFile(url: string, destination: string): Promise<void> {
   if (!res.body) {
     throw new Error(`Download response had no body for ${url}`);
   }
+  const contentLength = Number(res.headers.get("content-length") ?? 0);
+  let bytesDownloaded = 0;
   const writer = createWriteStream(destination);
   const reader = res.body.getReader();
   try {
@@ -309,6 +313,10 @@ async function downloadToFile(url: string, destination: string): Promise<void> {
       const { done, value } = await reader.read();
       if (done) break;
       if (!value) continue;
+      bytesDownloaded += value.byteLength;
+      if (onProgress && contentLength > 0) {
+        onProgress(bytesDownloaded, contentLength);
+      }
       await new Promise<void>((resolvePromise, rejectPromise) => {
         writer.write(value, (error) => {
           if (error) rejectPromise(error);
@@ -421,7 +429,13 @@ export function addManagedComfyModel(input: {
   return record;
 }
 
-export async function installComfyStarterPack(packId: string): Promise<ManagedComfyModelRecord[]> {
+export interface ModelDownloadEmitter {
+  onProgress: (modelId: string, label: string, packId: string | undefined, bytesDownloaded: number, totalBytes: number) => void;
+  onComplete: (modelId: string, label: string, packId: string | undefined) => void;
+  onError: (modelId: string, label: string, packId: string | undefined, error: string) => void;
+}
+
+export async function installComfyStarterPack(packId: string, emitter?: ModelDownloadEmitter): Promise<ManagedComfyModelRecord[]> {
   const pack = STARTER_PACKS.find((candidate) => candidate.id === packId);
   if (!pack) throw new Error(`Unknown ComfyUI starter pack: ${packId}`);
 
@@ -431,7 +445,7 @@ export async function installComfyStarterPack(packId: string): Promise<ManagedCo
       ...model,
       starterPackId: pack.id,
     });
-    installed.push(await installManagedComfyModel(record.id));
+    installed.push(await installManagedComfyModel(record.id, emitter));
   }
   return installed;
 }
@@ -444,7 +458,7 @@ export function removeManagedComfyModel(id: string): boolean {
   return true;
 }
 
-export async function installManagedComfyModel(id: string): Promise<ManagedComfyModelRecord> {
+export async function installManagedComfyModel(id: string, emitter?: ModelDownloadEmitter): Promise<ManagedComfyModelRecord> {
   const records = readManagedModels();
   const index = records.findIndex((record) => record.id === id);
   if (index === -1) throw new Error(`Managed ComfyUI model not found: ${id}`);
@@ -461,9 +475,13 @@ export async function installManagedComfyModel(id: string): Promise<ManagedComfy
   records[index] = next;
   writeManagedModels(records);
 
+  const onProgress = emitter
+    ? (bytesDownloaded: number, totalBytes: number) => emitter.onProgress(current.id, current.label, current.starterPackId, bytesDownloaded, totalBytes)
+    : undefined;
+
   try {
     ensureParentDir(targetPath);
-    await downloadToFile(current.sourceUrl, tempPath);
+    await downloadToFile(current.sourceUrl, tempPath, onProgress);
     renameSync(tempPath, targetPath);
     const installed: ManagedComfyModelRecord = {
       ...next,
@@ -474,6 +492,7 @@ export async function installManagedComfyModel(id: string): Promise<ManagedComfy
     };
     records[index] = installed;
     writeManagedModels(records);
+    emitter?.onComplete(current.id, current.label, current.starterPackId);
     return installed;
   } catch (error) {
     try {
@@ -481,14 +500,16 @@ export async function installManagedComfyModel(id: string): Promise<ManagedComfy
     } catch {
       // ignore
     }
+    const errMsg = error instanceof Error ? error.message : String(error);
     const failed: ManagedComfyModelRecord = {
       ...next,
       status: "error",
-      error: error instanceof Error ? error.message : String(error),
+      error: errMsg,
       updatedAt: new Date().toISOString(),
     };
     records[index] = failed;
     writeManagedModels(records);
+    emitter?.onError(current.id, current.label, current.starterPackId, errMsg);
     return failed;
   }
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5688,7 +5688,18 @@ async function main() {
   }>("/api/settings/comfyui/packs/:id/install", async (req, reply) => {
     try {
       const { installComfyStarterPack } = await import("./asset-providers/comfyui.js");
-      return { models: await installComfyStarterPack(req.params.id) };
+      const emitter = {
+        onProgress: (modelId: string, label: string, packId: string | undefined, bytesDownloaded: number, totalBytes: number) => {
+          io.emit("model:download-progress", { modelId, label, packId, bytesDownloaded, totalBytes, percentage: Math.round((bytesDownloaded / totalBytes) * 100) });
+        },
+        onComplete: (modelId: string, label: string, packId: string | undefined) => {
+          io.emit("model:download-complete", { modelId, label, packId });
+        },
+        onError: (modelId: string, label: string, packId: string | undefined, error: string) => {
+          io.emit("model:download-error", { modelId, label, packId, error });
+        },
+      };
+      return { models: await installComfyStarterPack(req.params.id, emitter) };
     } catch (error) {
       reply.code(404);
       return { error: error instanceof Error ? error.message : String(error) };
@@ -5700,7 +5711,18 @@ async function main() {
   }>("/api/settings/comfyui/models/:id/install", async (req, reply) => {
     try {
       const { installManagedComfyModel } = await import("./asset-providers/comfyui.js");
-      return { model: await installManagedComfyModel(req.params.id) };
+      const emitter = {
+        onProgress: (modelId: string, label: string, packId: string | undefined, bytesDownloaded: number, totalBytes: number) => {
+          io.emit("model:download-progress", { modelId, label, packId, bytesDownloaded, totalBytes, percentage: Math.round((bytesDownloaded / totalBytes) * 100) });
+        },
+        onComplete: (modelId: string, label: string, packId: string | undefined) => {
+          io.emit("model:download-complete", { modelId, label, packId });
+        },
+        onError: (modelId: string, label: string, packId: string | undefined, error: string) => {
+          io.emit("model:download-error", { modelId, label, packId, error });
+        },
+      };
+      return { model: await installManagedComfyModel(req.params.id, emitter) };
     } catch (error) {
       reply.code(404);
       return { error: error instanceof Error ? error.message : String(error) };

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -113,6 +113,11 @@ export interface ServerToClientEvents {
   "video:deleted": (data: { videoId: string; projectId: string }) => void;
   "video:render-progress": (data: { videoId: string; projectId: string; percent: number; stage: string }) => void;
   "video:render-complete": (data: { videoId: string; projectId: string; outputPath: string; duration: number }) => void;
+
+  // Model download progress (starter packs & managed models)
+  "model:download-progress": (data: { modelId: string; label: string; packId?: string; bytesDownloaded: number; totalBytes: number; percentage: number }) => void;
+  "model:download-complete": (data: { modelId: string; label: string; packId?: string }) => void;
+  "model:download-error": (data: { modelId: string; label: string; packId?: string; error: string }) => void;
 }
 
 /** Events emitted from client to server */

--- a/packages/web/src/components/settings/AssetGenTab.tsx
+++ b/packages/web/src/components/settings/AssetGenTab.tsx
@@ -137,6 +137,13 @@ const STATUS_STYLES: Record<ProviderHealthStatus["status"], string> = {
   fallback: "bg-blue-500/10 text-blue-300 border-blue-500/20",
 };
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
 export function AssetGenTab() {
   const [providers, setProviders] = useState<AssetProviderMeta[]>([]);
   const [config, setConfig] = useState<AssetProviderConfig>({ image: "procedural", model: "procedural", sound: "procedural" });
@@ -157,6 +164,14 @@ export function AssetGenTab() {
   const [installingModelId, setInstallingModelId] = useState<string | null>(null);
   const [installingPackId, setInstallingPackId] = useState<string | null>(null);
   const [addingModel, setAddingModel] = useState(false);
+  const [downloadProgress, setDownloadProgress] = useState<{
+    modelId: string;
+    label: string;
+    packId?: string;
+    percentage: number;
+    bytesDownloaded: number;
+    totalBytes: number;
+  } | null>(null);
 
   useEffect(() => {
     fetch("/api/settings/asset-providers")
@@ -178,6 +193,32 @@ export function AssetGenTab() {
     const data = await res.json() as ComfyUiSummary;
     setComfyui(data);
   };
+
+  // Listen for model download progress via Socket.IO
+  useEffect(() => {
+    const socket = (window as any).__otterbot_socket;
+    if (!socket) return;
+
+    const onProgress = (data: { modelId: string; label: string; packId?: string; bytesDownloaded: number; totalBytes: number; percentage: number }) => {
+      setDownloadProgress(data);
+    };
+    const onComplete = () => {
+      setDownloadProgress(null);
+      reloadComfyui();
+    };
+    const onError = () => {
+      setDownloadProgress(null);
+    };
+
+    socket.on("model:download-progress", onProgress);
+    socket.on("model:download-complete", onComplete);
+    socket.on("model:download-error", onError);
+    return () => {
+      socket.off("model:download-progress", onProgress);
+      socket.off("model:download-complete", onComplete);
+      socket.off("model:download-error", onError);
+    };
+  }, []);
 
   const handleProviderChange = async (category: AssetCategory, providerType: string) => {
     setSaving(true);
@@ -422,15 +463,31 @@ export function AssetGenTab() {
                     <p className="mt-2 text-zinc-500">
                       Approx. {pack.estimatedSizeGb.toFixed(1)} GB · Presets: {pack.presetIds.join(", ")}
                     </p>
-                    <div className="mt-3 flex items-center gap-2">
-                      <button
-                        onClick={() => handleInstallPack(pack.id)}
-                        disabled={installingPackId === pack.id}
-                        className="text-xs px-3 py-1 rounded bg-blue-600 text-blue-50 hover:bg-blue-500 transition-colors disabled:opacity-60"
-                      >
-                        {installingPackId === pack.id ? "Installing..." : isInstalled ? "Reinstall Pack" : "Install Pack"}
-                      </button>
-                      {isInstalled && <span className="text-emerald-300">Installed</span>}
+                    <div className="mt-3 space-y-2">
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => handleInstallPack(pack.id)}
+                          disabled={installingPackId === pack.id}
+                          className="text-xs px-3 py-1 rounded bg-blue-600 text-blue-50 hover:bg-blue-500 transition-colors disabled:opacity-60"
+                        >
+                          {installingPackId === pack.id ? "Installing..." : isInstalled ? "Reinstall Pack" : "Install Pack"}
+                        </button>
+                        {isInstalled && !installingPackId && <span className="text-emerald-300">Installed</span>}
+                      </div>
+                      {installingPackId === pack.id && downloadProgress?.packId === pack.id && (
+                        <div className="space-y-1">
+                          <div className="flex items-center justify-between text-[10px] text-zinc-400">
+                            <span>Downloading: {downloadProgress.label}</span>
+                            <span>{downloadProgress.percentage}% · {formatBytes(downloadProgress.bytesDownloaded)} / {formatBytes(downloadProgress.totalBytes)}</span>
+                          </div>
+                          <div className="w-full h-1.5 bg-zinc-700 rounded-full overflow-hidden">
+                            <div
+                              className="h-full bg-blue-500 rounded-full transition-all duration-300"
+                              style={{ width: `${downloadProgress.percentage}%` }}
+                            />
+                          </div>
+                        </div>
+                      )}
                     </div>
                   </div>
                 );


### PR DESCRIPTION
## Summary

- Emit `model:download-progress/complete/error` Socket.IO events during model file downloads
- Track `Content-Length` in `downloadToFile` and report bytes downloaded vs total
- Show a live progress bar in the AssetGenTab settings page when installing starter packs or individual models (model name, percentage, bytes transferred)

## Files changed
- `packages/shared/src/types/events.ts` — new Socket.IO event types
- `packages/server/src/asset-providers/comfyui.ts` — progress callback in download, emitter interface
- `packages/server/src/index.ts` — wire emitter into pack/model install endpoints
- `packages/web/src/components/settings/AssetGenTab.tsx` — progress bar UI + socket listener

## Test plan
- [ ] Install a starter pack in settings and verify progress bar shows model name, percentage, and byte counts
- [ ] Verify progress bar disappears on completion and model list refreshes
- [ ] Verify single model install also shows progress