### PR TITLE
fix: make starter pack install non-blocking with real-time progress

### DIFF
--- a/packages/server/src/asset-providers/comfyui.ts
+++ b/packages/server/src/asset-providers/comfyui.ts
@@ -306,6 +306,8 @@ async function downloadToFile(url: string, destination: string, onProgress?: Dow
   }
   const contentLength = Number(res.headers.get("content-length") ?? 0);
   let bytesDownloaded = 0;
+  let lastProgressEmit = 0;
+  const THROTTLE_MS = 500; // emit progress at most every 500ms
   const writer = createWriteStream(destination);
   const reader = res.body.getReader();
   try {
@@ -314,8 +316,12 @@ async function downloadToFile(url: string, destination: string, onProgress?: Dow
       if (done) break;
       if (!value) continue;
       bytesDownloaded += value.byteLength;
-      if (onProgress && contentLength > 0) {
-        onProgress(bytesDownloaded, contentLength);
+      if (onProgress) {
+        const now = Date.now();
+        if (now - lastProgressEmit >= THROTTLE_MS) {
+          lastProgressEmit = now;
+          onProgress(bytesDownloaded, contentLength);
+        }
       }
       await new Promise<void>((resolvePromise, rejectPromise) => {
         writer.write(value, (error) => {
@@ -323,6 +329,10 @@ async function downloadToFile(url: string, destination: string, onProgress?: Dow
           else resolvePromise();
         });
       });
+    }
+    // Emit final progress so UI reaches 100%
+    if (onProgress) {
+      onProgress(bytesDownloaded, contentLength || bytesDownloaded);
     }
     await new Promise<void>((resolvePromise, rejectPromise) => {
       writer.end((error: Error | null | undefined) => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5683,23 +5683,34 @@ async function main() {
     return { model: addManagedComfyModel({ label, sourceUrl, modelType, filename }) };
   });
 
+  // Shared emitter factory for model download progress via Socket.IO
+  function createDownloadEmitter() {
+    return {
+      onProgress: (modelId: string, label: string, packId: string | undefined, bytesDownloaded: number, totalBytes: number) => {
+        const percentage = totalBytes > 0 ? Math.round((bytesDownloaded / totalBytes) * 100) : 0;
+        io.emit("model:download-progress", { modelId, label, packId, bytesDownloaded, totalBytes, percentage });
+      },
+      onComplete: (modelId: string, label: string, packId: string | undefined) => {
+        io.emit("model:download-complete", { modelId, label, packId });
+      },
+      onError: (modelId: string, label: string, packId: string | undefined, error: string) => {
+        io.emit("model:download-error", { modelId, label, packId, error });
+      },
+    };
+  }
+
   app.post<{
     Params: { id: string };
   }>("/api/settings/comfyui/packs/:id/install", async (req, reply) => {
+    const packId = req.params.id;
     try {
       const { installComfyStarterPack } = await import("./asset-providers/comfyui.js");
-      const emitter = {
-        onProgress: (modelId: string, label: string, packId: string | undefined, bytesDownloaded: number, totalBytes: number) => {
-          io.emit("model:download-progress", { modelId, label, packId, bytesDownloaded, totalBytes, percentage: Math.round((bytesDownloaded / totalBytes) * 100) });
-        },
-        onComplete: (modelId: string, label: string, packId: string | undefined) => {
-          io.emit("model:download-complete", { modelId, label, packId });
-        },
-        onError: (modelId: string, label: string, packId: string | undefined, error: string) => {
-          io.emit("model:download-error", { modelId, label, packId, error });
-        },
-      };
-      return { models: await installComfyStarterPack(req.params.id, emitter) };
+      // Return immediately — downloads run in background, progress via Socket.IO
+      installComfyStarterPack(packId, createDownloadEmitter())
+        .then(() => io.emit("model:pack-install-complete", { packId }))
+        .catch((err) => io.emit("model:pack-install-error", { packId, error: err instanceof Error ? err.message : String(err) }));
+      reply.code(202);
+      return { status: "installing", packId };
     } catch (error) {
       reply.code(404);
       return { error: error instanceof Error ? error.message : String(error) };
@@ -5709,20 +5720,14 @@ async function main() {
   app.post<{
     Params: { id: string };
   }>("/api/settings/comfyui/models/:id/install", async (req, reply) => {
+    const modelId = req.params.id;
     try {
       const { installManagedComfyModel } = await import("./asset-providers/comfyui.js");
-      const emitter = {
-        onProgress: (modelId: string, label: string, packId: string | undefined, bytesDownloaded: number, totalBytes: number) => {
-          io.emit("model:download-progress", { modelId, label, packId, bytesDownloaded, totalBytes, percentage: Math.round((bytesDownloaded / totalBytes) * 100) });
-        },
-        onComplete: (modelId: string, label: string, packId: string | undefined) => {
-          io.emit("model:download-complete", { modelId, label, packId });
-        },
-        onError: (modelId: string, label: string, packId: string | undefined, error: string) => {
-          io.emit("model:download-error", { modelId, label, packId, error });
-        },
-      };
-      return { model: await installManagedComfyModel(req.params.id, emitter) };
+      // Return immediately — download runs in background, progress via Socket.IO
+      installManagedComfyModel(modelId, createDownloadEmitter())
+        .catch((err) => io.emit("model:download-error", { modelId, label: "", packId: undefined, error: err instanceof Error ? err.message : String(err) }));
+      reply.code(202);
+      return { status: "installing", modelId };
     } catch (error) {
       reply.code(404);
       return { error: error instanceof Error ? error.message : String(error) };

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -118,6 +118,8 @@ export interface ServerToClientEvents {
   "model:download-progress": (data: { modelId: string; label: string; packId?: string; bytesDownloaded: number; totalBytes: number; percentage: number }) => void;
   "model:download-complete": (data: { modelId: string; label: string; packId?: string }) => void;
   "model:download-error": (data: { modelId: string; label: string; packId?: string; error: string }) => void;
+  "model:pack-install-complete": (data: { packId: string }) => void;
+  "model:pack-install-error": (data: { packId: string; error: string }) => void;
 }
 
 /** Events emitted from client to server */

--- a/packages/web/src/components/settings/AssetGenTab.tsx
+++ b/packages/web/src/components/settings/AssetGenTab.tsx
@@ -202,21 +202,39 @@ export function AssetGenTab() {
     const onProgress = (data: { modelId: string; label: string; packId?: string; bytesDownloaded: number; totalBytes: number; percentage: number }) => {
       setDownloadProgress(data);
     };
-    const onComplete = () => {
+    const onModelComplete = (data: { modelId: string }) => {
       setDownloadProgress(null);
+      // Clear single-model installing state if this was a standalone install
+      setInstallingModelId((current) => current === data.modelId ? null : current);
       reloadComfyui();
     };
-    const onError = () => {
+    const onModelError = (data: { modelId: string }) => {
       setDownloadProgress(null);
+      setInstallingModelId((current) => current === data.modelId ? null : current);
+      reloadComfyui();
+    };
+    const onPackComplete = () => {
+      setDownloadProgress(null);
+      setInstallingPackId(null);
+      reloadComfyui();
+    };
+    const onPackError = () => {
+      setDownloadProgress(null);
+      setInstallingPackId(null);
+      reloadComfyui();
     };
 
     socket.on("model:download-progress", onProgress);
-    socket.on("model:download-complete", onComplete);
-    socket.on("model:download-error", onError);
+    socket.on("model:download-complete", onModelComplete);
+    socket.on("model:download-error", onModelError);
+    socket.on("model:pack-install-complete", onPackComplete);
+    socket.on("model:pack-install-error", onPackError);
     return () => {
       socket.off("model:download-progress", onProgress);
-      socket.off("model:download-complete", onComplete);
-      socket.off("model:download-error", onError);
+      socket.off("model:download-complete", onModelComplete);
+      socket.off("model:download-error", onModelError);
+      socket.off("model:pack-install-complete", onPackComplete);
+      socket.off("model:pack-install-error", onPackError);
     };
   }, []);
 
@@ -286,22 +304,14 @@ export function AssetGenTab() {
 
   const handleInstallModel = async (id: string) => {
     setInstallingModelId(id);
-    try {
-      await fetch(`/api/settings/comfyui/models/${id}/install`, { method: "POST" });
-      await reloadComfyui();
-    } finally {
-      setInstallingModelId(null);
-    }
+    // Server returns 202 immediately; progress + completion come via Socket.IO
+    await fetch(`/api/settings/comfyui/models/${id}/install`, { method: "POST" });
   };
 
   const handleInstallPack = async (id: string) => {
     setInstallingPackId(id);
-    try {
-      await fetch(`/api/settings/comfyui/packs/${id}/install`, { method: "POST" });
-      await reloadComfyui();
-    } finally {
-      setInstallingPackId(null);
-    }
+    // Server returns 202 immediately; progress + completion come via Socket.IO
+    await fetch(`/api/settings/comfyui/packs/${id}/install`, { method: "POST" });
   };
 
   const getProvidersForCategory = (category: AssetCategory): AssetProviderMeta[] => {
@@ -478,13 +488,21 @@ export function AssetGenTab() {
                         <div className="space-y-1">
                           <div className="flex items-center justify-between text-[10px] text-zinc-400">
                             <span>Downloading: {downloadProgress.label}</span>
-                            <span>{downloadProgress.percentage}% · {formatBytes(downloadProgress.bytesDownloaded)} / {formatBytes(downloadProgress.totalBytes)}</span>
+                            {downloadProgress.totalBytes > 0 ? (
+                              <span>{downloadProgress.percentage}% · {formatBytes(downloadProgress.bytesDownloaded)} / {formatBytes(downloadProgress.totalBytes)}</span>
+                            ) : (
+                              <span>{formatBytes(downloadProgress.bytesDownloaded)} downloaded</span>
+                            )}
                           </div>
                           <div className="w-full h-1.5 bg-zinc-700 rounded-full overflow-hidden">
-                            <div
-                              className="h-full bg-blue-500 rounded-full transition-all duration-300"
-                              style={{ width: `${downloadProgress.percentage}%` }}
-                            />
+                            {downloadProgress.totalBytes > 0 ? (
+                              <div
+                                className="h-full bg-blue-500 rounded-full transition-all duration-300"
+                                style={{ width: `${downloadProgress.percentage}%` }}
+                              />
+                            ) : (
+                              <div className="h-full bg-blue-500 rounded-full animate-pulse" style={{ width: "100%" }} />
+                            )}
                           </div>
                         </div>
                       )}


### PR DESCRIPTION
## Summary

- Server returns 202 immediately for pack/model install; downloads run in background
- Progress emits every 500ms (throttled) even without Content-Length header
- New `model:pack-install-complete` / `model:pack-install-error` Socket.IO events signal when all models in a pack finish
- UI clears "Installing..." state and refreshes via Socket.IO instead of awaiting the HTTP response (which was timing out on large packs)
- Handles unknown file size with pulsing progress bar + bytes-downloaded display

## Test plan
- [ ] Install a starter pack — verify progress bar appears with model name and byte counts
- [ ] Verify "Installed" badge appears after pack completes
- [ ] Navigate away and back during install — verify state is consistent