### PR TITLE
fix: use lightweight models endpoint for install progress polling

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5641,6 +5641,12 @@ async function main() {
     return getComfyUiSettingsSummary();
   });
 
+  // Lightweight endpoint for polling model statuses (no health check)
+  app.get("/api/settings/comfyui/models", async () => {
+    const { listManagedComfyModels } = await import("./asset-providers/comfyui.js");
+    return { models: listManagedComfyModels() };
+  });
+
   app.get("/api/settings/local-compute", async () => {
     const { getLocalComputeStatus } = await import("./local-compute/local-compute.js");
     return getLocalComputeStatus();

--- a/packages/web/src/components/settings/AssetGenTab.tsx
+++ b/packages/web/src/components/settings/AssetGenTab.tsx
@@ -176,15 +176,15 @@ function InstallModal({
   } | null>(null);
   const closedRef = useRef(false);
 
-  // Poll server for model status every 2s
+  // Poll server for model status every 2s (lightweight endpoint, no health check)
   useEffect(() => {
     let timer: ReturnType<typeof setInterval>;
 
     const poll = async () => {
       try {
-        const res = await fetch("/api/settings/comfyui");
-        const data = await res.json() as ComfyUiSummary;
-        const packModels = data.models.filter((m) => m.starterPackId === packId);
+        const res = await fetch("/api/settings/comfyui/models");
+        const data = await res.json() as { models: ManagedComfyModel[] };
+        const packModels = (data.models ?? []).filter((m) => m.starterPackId === packId);
         setModels(packModels);
 
         // Auto-close when all models installed


### PR DESCRIPTION
## Summary

The install progress modal was polling `GET /api/settings/comfyui` which calls `getComfyUiHealthStatus()` — this tries to connect to the ComfyUI sidecar via HTTP. If the sidecar is unreachable (common during initial setup), each poll stalls for the full TCP timeout (~30s+), so the modal just spins at "Starting download...".

- Add `GET /api/settings/comfyui/models` — returns just the managed model records with no health check
- Modal now polls this lightweight endpoint instead, getting instant responses

## Test plan
- [ ] Click Install Pack — modal should show model status within 2s
- [ ] Works even when ComfyUI sidecar is not running