### PR TITLE
fix: match pack models by sourceUrl and add install logging

### DIFF
--- a/packages/server/src/asset-providers/comfyui.ts
+++ b/packages/server/src/asset-providers/comfyui.ts
@@ -420,7 +420,10 @@ export function addManagedComfyModel(input: {
   const filename = sanitizeFilename(input.sourceUrl, input.filename);
   const records = readManagedModels();
   const existing = records.find((record) => record.sourceUrl === input.sourceUrl.trim() && record.filename === filename);
-  if (existing) return existing;
+  if (existing) {
+    console.log(`[comfyui] Model already exists: id=${existing.id}, status=${existing.status}, starterPackId=${existing.starterPackId}`);
+    return existing;
+  }
 
   const now = new Date().toISOString();
   const record: ManagedComfyModelRecord = {
@@ -449,14 +452,20 @@ export async function installComfyStarterPack(packId: string, emitter?: ModelDow
   const pack = STARTER_PACKS.find((candidate) => candidate.id === packId);
   if (!pack) throw new Error(`Unknown ComfyUI starter pack: ${packId}`);
 
+  console.log(`[comfyui] Installing starter pack "${pack.label}" (${packId}) with ${pack.models.length} model(s)`);
   const installed: ManagedComfyModelRecord[] = [];
   for (const model of pack.models) {
+    console.log(`[comfyui] Adding model "${model.label}" (${model.filename}) from ${model.sourceUrl}`);
     const record = addManagedComfyModel({
       ...model,
       starterPackId: pack.id,
     });
-    installed.push(await installManagedComfyModel(record.id, emitter));
+    console.log(`[comfyui] Model record id=${record.id}, status=${record.status}, starterPackId=${record.starterPackId}`);
+    const result = await installManagedComfyModel(record.id, emitter);
+    console.log(`[comfyui] Model "${model.label}" install result: status=${result.status}${result.error ? `, error=${result.error}` : ""}`);
+    installed.push(result);
   }
+  console.log(`[comfyui] Pack "${pack.label}" install complete: ${installed.filter((m) => m.status === "installed").length}/${installed.length} succeeded`);
   return installed;
 }
 
@@ -476,6 +485,8 @@ export async function installManagedComfyModel(id: string, emitter?: ModelDownlo
   const current = records[index];
   const targetPath = resolveModelPath(current);
   const tempPath = `${targetPath}.download`;
+  console.log(`[comfyui] Starting download: "${current.label}" → ${targetPath}`);
+  console.log(`[comfyui] Source URL: ${current.sourceUrl}`);
   const next: ManagedComfyModelRecord = {
     ...current,
     status: "installing",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5709,15 +5709,23 @@ async function main() {
     Params: { id: string };
   }>("/api/settings/comfyui/packs/:id/install", async (req, reply) => {
     const packId = req.params.id;
+    console.log(`[api] POST /api/settings/comfyui/packs/${packId}/install`);
     try {
       const { installComfyStarterPack } = await import("./asset-providers/comfyui.js");
       // Return immediately — downloads run in background, progress via Socket.IO
       installComfyStarterPack(packId, createDownloadEmitter())
-        .then(() => io.emit("model:pack-install-complete", { packId }))
-        .catch((err) => io.emit("model:pack-install-error", { packId, error: err instanceof Error ? err.message : String(err) }));
+        .then(() => {
+          console.log(`[api] Pack "${packId}" install complete, emitting model:pack-install-complete`);
+          io.emit("model:pack-install-complete", { packId });
+        })
+        .catch((err) => {
+          console.error(`[api] Pack "${packId}" install failed:`, err);
+          io.emit("model:pack-install-error", { packId, error: err instanceof Error ? err.message : String(err) });
+        });
       reply.code(202);
       return { status: "installing", packId };
     } catch (error) {
+      console.error(`[api] Pack "${packId}" endpoint error:`, error);
       reply.code(404);
       return { error: error instanceof Error ? error.message : String(error) };
     }

--- a/packages/web/src/components/settings/AssetGenTab.tsx
+++ b/packages/web/src/components/settings/AssetGenTab.tsx
@@ -95,6 +95,7 @@ interface ComfyStarterPack {
   recommendedTiers: Array<"cpu" | "low" | "medium" | "high">;
   estimatedSizeGb: number;
   presetIds: string[];
+  models: Array<{ sourceUrl: string; filename: string }>;
 }
 
 interface ComfyUiSummary {
@@ -161,10 +162,12 @@ const STATUS_COLORS: Record<string, string> = {
 function InstallModal({
   packLabel,
   packId,
+  packModelUrls,
   onClose,
 }: {
   packLabel: string;
   packId: string;
+  packModelUrls: string[];
   onClose: (installed: boolean) => void;
 }) {
   const [models, setModels] = useState<ManagedComfyModel[]>([]);
@@ -180,11 +183,13 @@ function InstallModal({
   useEffect(() => {
     let timer: ReturnType<typeof setInterval>;
 
+    const urlSet = new Set(packModelUrls);
+
     const poll = async () => {
       try {
         const res = await fetch("/api/settings/comfyui/models");
         const data = await res.json() as { models: ManagedComfyModel[] };
-        const packModels = (data.models ?? []).filter((m) => m.starterPackId === packId);
+        const packModels = (data.models ?? []).filter((m) => urlSet.has(m.sourceUrl));
         setModels(packModels);
 
         // Auto-close when all models installed
@@ -332,7 +337,7 @@ export function AssetGenTab() {
   const [installingModelId, setInstallingModelId] = useState<string | null>(null);
   const [installingPackId, setInstallingPackId] = useState<string | null>(null);
   const [addingModel, setAddingModel] = useState(false);
-  const [installModalPack, setInstallModalPack] = useState<{ id: string; label: string } | null>(null);
+  const [installModalPack, setInstallModalPack] = useState<ComfyStarterPack | null>(null);
 
   useEffect(() => {
     fetch("/api/settings/asset-providers")
@@ -455,7 +460,7 @@ export function AssetGenTab() {
     await fetch(`/api/settings/comfyui/models/${id}/install`, { method: "POST" });
   };
 
-  const handleInstallPack = async (pack: { id: string; label: string }) => {
+  const handleInstallPack = async (pack: ComfyStarterPack) => {
     setInstallingPackId(pack.id);
     setInstallModalPack(pack);
     // Server returns 202 immediately; progress + completion come via Socket.IO
@@ -611,8 +616,9 @@ export function AssetGenTab() {
             <div className="grid gap-3 lg:grid-cols-2">
               {comfyui.starterPacks.map((pack) => {
                 const recommended = !comfyui.health.tier || pack.recommendedTiers.includes(comfyui.health.tier);
-                const installedModels = comfyui.models.filter((model) => model.starterPackId === pack.id && model.status === "installed");
-                const isInstalled = installedModels.length > 0;
+                const packUrls = new Set(pack.models.map((m) => m.sourceUrl));
+                const installedModels = comfyui.models.filter((model) => packUrls.has(model.sourceUrl) && model.status === "installed");
+                const isInstalled = installedModels.length === pack.models.length;
                 return (
                   <div key={pack.id} className="rounded border border-zinc-800 bg-zinc-900/70 p-3 text-xs text-zinc-300">
                     <div className="flex items-center justify-between gap-2">
@@ -631,7 +637,7 @@ export function AssetGenTab() {
                     </p>
                     <div className="mt-3 flex items-center gap-2">
                       <button
-                        onClick={() => handleInstallPack({ id: pack.id, label: pack.label })}
+                        onClick={() => handleInstallPack(pack)}
                         disabled={installingPackId === pack.id}
                         className="text-xs px-3 py-1 rounded bg-blue-600 text-blue-50 hover:bg-blue-500 transition-colors disabled:opacity-60"
                       >
@@ -897,6 +903,7 @@ export function AssetGenTab() {
         <InstallModal
           packId={installModalPack.id}
           packLabel={installModalPack.label}
+          packModelUrls={installModalPack.models.map((m) => m.sourceUrl)}
           onClose={handleInstallModalClose}
         />
       )}


### PR DESCRIPTION
## Summary

**Root cause:** All 4 starter packs share the same `sd15-base.ckpt` model. `addManagedComfyModel` deduplicates by URL+filename and returns the existing record with the *first* pack's `starterPackId`. When installing a different pack, both the modal and the pack card filtered by `starterPackId === packId` — which never matched.

**Fixes:**
- Include `models[].sourceUrl` in the starter pack definition sent to the client
- Match models by `sourceUrl` instead of `starterPackId` in both the modal poll and the pack card "Installed" check
- Add `[comfyui]` server-side logging throughout the install flow: pack start, model add/existing detection, download start, download result, pack complete

## Test plan
- [ ] Install any starter pack — modal shows model status immediately
- [ ] Install a second pack that shares the same model — shows as already installed
- [ ] Check server logs for `[comfyui]` messages during install
- [ ] Pack card shows "Installed" badge correctly for all packs sharing the model