### PR TITLE
feat: auto-detect GPU for ComfyUI CUDA/PyTorch version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22 AS base
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
-# Install dependencies
+# ── Stage 1: Install dependencies (cached unless lock/package.json change) ──
 FROM base AS deps
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY packages/shared/package.json ./packages/shared/
@@ -14,16 +14,19 @@ COPY modules/deep-research/package.json ./modules/deep-research/
 COPY modules/discord-support/package.json ./modules/discord-support/
 RUN pnpm install --frozen-lockfile
 
-# Build
+# ── Stage 2: Build (cached unless source changes) ──────────────────────────
 FROM deps AS build
 ARG BUILD_VERSION
 ENV VITE_APP_VERSION=${BUILD_VERSION}
 COPY . .
 RUN pnpm build
 
-# Production
+# ── Stage 3: Production image ──────────────────────────────────────────────
 FROM base AS production
+
+# Layer 1: ALL system packages in a single apt transaction
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Core tools
     tini git curl sudo gnupg apt-transport-https ca-certificates ffmpeg sqlite3 \
     build-essential pkg-config iproute2 net-tools vim \
     # Playwright/Chromium system dependencies
@@ -31,15 +34,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libdrm2 libdbus-1-3 libxkbcommon0 libatspi2.0-0 libxcomposite1 \
     libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 \
     libcairo2 libasound2 libwayland-client0 \
-    && rm -rf /var/lib/apt/lists/*
-
-# Desktop environment (conditionally started at runtime via ENABLE_DESKTOP)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Desktop environment
     xvfb xfce4 xfce4-terminal dbus-x11 x11vnc x11-utils \
     xdg-utils fonts-noto-color-emoji fonts-dejavu-core \
+    # Languages
+    python3 python3-pip python3-venv \
+    default-jdk-headless \
+    ruby-full \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GitHub CLI (gh)
+# Layer 2: GitHub CLI (separate due to external keyring/repo setup)
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL --retry 3 --retry-delay 5 https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
@@ -48,14 +52,13 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Go
+# Layer 3: Go + Rust (rarely change, large downloads — cached together)
 ENV GOLANG_VERSION=1.24.0
 RUN curl -fsSL --retry 3 --retry-delay 5 "https://go.dev/dl/go${GOLANG_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \
     | tar xz -C /usr/local \
     && ln -s /usr/local/go/bin/go /usr/local/bin/go \
     && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
-# Install Rust via rustup (shared location so all users can access it)
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf --retry 3 --retry-delay 5 https://sh.rustup.rs \
@@ -63,38 +66,15 @@ RUN curl --proto '=https' --tlsv1.2 -sSf --retry 3 --retry-delay 5 https://sh.ru
     && chmod -R a+rX /usr/local/rustup /usr/local/cargo
 ENV PATH="/usr/local/cargo/bin:$PATH"
 
-# Install Python 3 with pip and venv
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-venv \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Java (OpenJDK headless)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    default-jdk-headless \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Ruby
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ruby-full \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install coding agents
-# OpenCode + Codex go into /usr/local/lib/otterbot-tools via NPM_CONFIG_PREFIX
-# (NOT /otterbot/tools — that path is overlaid by bind-mounted volumes at runtime)
-# Claude Code uses the native installer → /usr/local/lib/otterbot-tools/claude-home/.local/bin/claude
+# Layer 4: All coding agents + global npm tools in one layer
 ENV NPM_CONFIG_PREFIX=/usr/local/lib/otterbot-tools
 ENV PATH="/usr/local/lib/otterbot-tools/bin:$PATH"
-RUN mkdir -p /usr/local/lib/otterbot-tools /otterbot/home
-RUN npm install -g opencode-ai@latest
-RUN npm install -g @openai/codex@latest
-RUN npm install -g @google/gemini-cli@latest
-RUN HOME=/otterbot/home curl -fsSL --retry 3 --retry-delay 5 https://claude.ai/install.sh | HOME=/otterbot/home bash
+RUN mkdir -p /usr/local/lib/otterbot-tools /otterbot/home \
+    && npm install -g opencode-ai@latest @openai/codex@latest @google/gemini-cli@latest \
+    && HOME=/otterbot/home curl -fsSL --retry 3 --retry-delay 5 https://claude.ai/install.sh | HOME=/otterbot/home bash \
+    && PUPPETEER_SKIP_DOWNLOAD=true npm install -g puppeteer
 
-# Install puppeteer globally so coding agents can import it from any workspace.
-# Skip bundled Chromium download — we reuse Playwright's Chromium via PUPPETEER_EXECUTABLE_PATH.
-RUN PUPPETEER_SKIP_DOWNLOAD=true npm install -g puppeteer
-
-# Create non-root user with configurable UID/GID
+# Layer 5: Create non-root user
 ARG OTTERBOT_UID=1000
 ARG OTTERBOT_GID=1000
 ENV OTTERBOT_UID=${OTTERBOT_UID}
@@ -103,8 +83,7 @@ RUN (getent group ${OTTERBOT_GID} || groupadd -g ${OTTERBOT_GID} otterbot) \
     && useradd -u ${OTTERBOT_UID} -g ${OTTERBOT_GID} -m -d /otterbot/home otterbot 2>/dev/null \
     || useradd -u ${OTTERBOT_UID} -g ${OTTERBOT_GID} -m -o -d /otterbot/home otterbot
 
-# Sudoers configuration is handled at runtime in entrypoint.sh (SUDO_MODE env var)
-
+# Layer 6: Copy build artifacts (changes every build)
 WORKDIR /app
 COPY --from=build /app/package.json /app/pnpm-workspace.yaml ./
 COPY --from=build /app/node_modules ./node_modules
@@ -131,13 +110,10 @@ RUN mkdir -p modules/github-discussions/node_modules/@otterbot \
     && mkdir -p modules/discord-support/node_modules/@otterbot \
     && ln -sf /app/packages/shared modules/discord-support/node_modules/@otterbot/shared
 
-# Install Playwright Chromium browser (headless, for agent web browsing)
-# Use a fixed path so both root (build) and otterbot (runtime) can find it
+# Layer 7: Playwright Chromium + browser setup
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
 RUN node packages/server/node_modules/playwright/cli.js install chromium
 
-# Make Playwright's Chromium available as the system default browser.
-# Wrapper script passes --no-sandbox (required in containers).
 RUN CHROME_BIN=$(find /opt/playwright -name chrome -type f -path '*/chrome-linux*/chrome' | head -1) \
     && printf '#!/bin/sh\nexec "%s" --no-sandbox --disable-dev-shm-usage --user-data-dir=/tmp/otterbot-desktop-browser "$@"\n' "$CHROME_BIN" \
        > /usr/local/bin/chromium-browser \
@@ -148,8 +124,7 @@ RUN CHROME_BIN=$(find /opt/playwright -name chrome -type f -path '*/chrome-linux
     && update-alternatives --install /usr/bin/x-www-browser x-www-browser /usr/local/bin/chromium-browser 200 \
     && update-alternatives --install /usr/bin/gnome-www-browser gnome-www-browser /usr/local/bin/chromium-browser 200
 
-# Download noVNC ES module source (native ESM — served as static files for the web viewer)
-# Both core/ and vendor/ are needed because core/inflator.js imports ../vendor/pako/
+# Layer 8: noVNC static files
 RUN curl -fsSL --retry 3 --retry-delay 5 https://github.com/novnc/noVNC/archive/refs/tags/v1.5.0.tar.gz | tar xz -C /tmp \
     && mkdir -p /app/novnc \
     && mv /tmp/noVNC-1.5.0/core /app/novnc/core \
@@ -157,7 +132,7 @@ RUN curl -fsSL --retry 3 --retry-delay 5 https://github.com/novnc/noVNC/archive/
     && rm -rf /tmp/noVNC-1.5.0 \
     && ls -la /app/novnc/core/rfb.js
 
-# Create data directories (use numeric UID:GID since group name may differ)
+# Layer 9: Data directories + entrypoint
 RUN mkdir -p /otterbot/config /otterbot/data /otterbot/projects /otterbot/logs /otterbot/home \
     && chown -R ${OTTERBOT_UID}:${OTTERBOT_GID} /otterbot /app
 

--- a/docker-compose.comfyui.yml
+++ b/docker-compose.comfyui.yml
@@ -7,6 +7,9 @@ services:
     build:
       context: .
       dockerfile: docker/comfyui/Dockerfile
+      args:
+        CUDA_TAG: ${COMFYUI_CUDA_TAG:-11.8.0-runtime-ubuntu22.04}
+        TORCH_INDEX: ${COMFYUI_TORCH_INDEX:-https://download.pytorch.org/whl/cu118}
     environment:
       - CLI_ARGS=${COMFYUI_CLI_ARGS:---listen 0.0.0.0 --port 8188}
       - COMFYUI_DATA_ROOT=/data

--- a/docker/comfyui/Dockerfile
+++ b/docker/comfyui/Dockerfile
@@ -1,16 +1,38 @@
-FROM python:3.11-slim
+# ComfyUI sidecar with GPU auto-detection
+#
+# Build args:
+#   CUDA_TAG    — NVIDIA base image tag (default: 11.8.0-runtime-ubuntu22.04)
+#   TORCH_INDEX — PyTorch wheel index URL (default: cu118 for Pascal+ compat)
+#
+# docker-stack.sh detects the host GPU and passes the appropriate values.
+# CUDA 11.8 / cu118 is the safe default — it supports Pascal (sm_61) through Hopper.
+# CUDA 12.4 / cu124 gives better performance on Turing (sm_75) and newer.
+
+ARG CUDA_TAG=11.8.0-runtime-ubuntu22.04
+FROM nvidia/cuda:${CUDA_TAG}
+
+ARG TORCH_INDEX=https://download.pytorch.org/whl/cu118
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV COMFYUI_HOME=/opt/comfyui
 ENV COMFYUI_DATA_ROOT=/data
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip python3-venv \
     git curl ca-certificates libgl1 libglib2.0-0 \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*
+
+# Install PyTorch with the selected CUDA version
+RUN pip install --no-cache-dir \
+    torch torchvision torchaudio \
+    --index-url ${TORCH_INDEX}
 
 WORKDIR /opt
 RUN git clone --depth=1 https://github.com/comfyanonymous/ComfyUI.git "${COMFYUI_HOME}"
 WORKDIR ${COMFYUI_HOME}
+
+# Install ComfyUI deps (torch already installed above)
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY docker/comfyui/entrypoint.sh /entrypoint.sh

--- a/packages/server/src/asset-providers/comfyui.ts
+++ b/packages/server/src/asset-providers/comfyui.ts
@@ -628,13 +628,26 @@ async function waitForImage(baseUrl: string, promptId: string): Promise<{ filena
       : [];
     if (images.length > 0) return images[0];
     if (entry?.status?.status_str === "error") {
-      // Extract error details from ComfyUI status messages
-      const errorMessages = (entry.status.messages ?? [])
-        .filter(([type]) => type === "execution_error" || type === "error")
-        .map(([, data]) => data?.message ?? data?.details ?? "unknown error")
-        .join("; ");
-      const detail = errorMessages || JSON.stringify(entry.status.messages ?? []);
-      console.error(`[comfyui] Generation failed for prompt ${promptId}:`, detail);
+      // Log the full status for debugging
+      console.error(`[comfyui] Generation failed for prompt ${promptId}. Full status:`, JSON.stringify(entry.status, null, 2));
+      // Also log full entry outputs/keys for context
+      console.error(`[comfyui] Full history entry keys:`, Object.keys(entry));
+
+      // Try to extract error details from various ComfyUI response formats
+      const messages = entry.status.messages ?? [];
+      const errorParts: string[] = [];
+      for (const msg of messages) {
+        if (Array.isArray(msg) && msg.length >= 2) {
+          const [type, data] = msg;
+          if (typeof data === "object" && data !== null) {
+            const d = data as Record<string, unknown>;
+            if (d.message) errorParts.push(`${type}: ${d.message}`);
+            else if (d.details) errorParts.push(`${type}: ${d.details}`);
+            else if (d.exception_message) errorParts.push(`${type}: ${d.exception_message}`);
+          }
+        }
+      }
+      const detail = errorParts.join("; ") || `status=error (check server logs for full response)`;
       throw new Error(`ComfyUI generation failed: ${detail}`);
     }
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 1500));

--- a/scripts/docker-stack.sh
+++ b/scripts/docker-stack.sh
@@ -134,6 +134,60 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# ── GPU detection for ComfyUI/TRELLIS CUDA builds ─────────────────────────
+# Detect GPU compute capability and select the right CUDA/PyTorch versions.
+# Pascal (6.x): cu118 only — CUDA 12 dropped Pascal support.
+# Turing+ (7.x+): cu124 for best performance.
+# Fallback: cu118 (broadest compatibility).
+detect_cuda_build_args() {
+  if ! command -v nvidia-smi &>/dev/null; then
+    echo "[gpu] nvidia-smi not found — using cu118 (CPU fallback)" >&2
+    echo "COMFYUI_CUDA_TAG=11.8.0-runtime-ubuntu22.04"
+    echo "COMFYUI_TORCH_INDEX=https://download.pytorch.org/whl/cu118"
+    return
+  fi
+  # Get the highest compute capability across all GPUs
+  local compute
+  compute=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader,nounits 2>/dev/null | sort -rn | head -1)
+  if [[ -z "$compute" ]]; then
+    echo "[gpu] Could not query GPU compute capability — using cu118" >&2
+    echo "COMFYUI_CUDA_TAG=11.8.0-runtime-ubuntu22.04"
+    echo "COMFYUI_TORCH_INDEX=https://download.pytorch.org/whl/cu118"
+    return
+  fi
+  local major="${compute%%.*}"
+  echo "[gpu] Detected GPU compute capability: ${compute}" >&2
+  if [[ "$major" -le 6 ]]; then
+    # Pascal (sm_61): Tesla P4/P40, GTX 10xx — CUDA 12 dropped Pascal
+    echo "[gpu] Pascal GPU detected — using CUDA 11.8 / cu118" >&2
+    echo "COMFYUI_CUDA_TAG=11.8.0-runtime-ubuntu22.04"
+    echo "COMFYUI_TORCH_INDEX=https://download.pytorch.org/whl/cu118"
+  elif [[ "$major" -le 9 ]]; then
+    # Turing (sm_75): RTX 20xx — through Ada Lovelace (sm_89): RTX 40xx
+    echo "[gpu] Turing/Ampere/Ada GPU detected — using CUDA 12.4 / cu124" >&2
+    echo "COMFYUI_CUDA_TAG=12.4.1-runtime-ubuntu22.04"
+    echo "COMFYUI_TORCH_INDEX=https://download.pytorch.org/whl/cu124"
+  else
+    # Blackwell (sm_100+): RTX 50xx — needs CUDA 12.8+
+    echo "[gpu] Blackwell+ GPU detected — using CUDA 12.8 / cu128" >&2
+    echo "COMFYUI_CUDA_TAG=12.8.1-runtime-ubuntu22.04"
+    echo "COMFYUI_TORCH_INDEX=https://download.pytorch.org/whl/cu128"
+  fi
+}
+
+# Export build args if any compose file references comfyui or trellis
+needs_gpu_build=false
+for file in "${compose_files[@]}"; do
+  case "$file" in
+    *comfyui*|*trellis*|*gpu*|*local-ai*) needs_gpu_build=true ;;
+  esac
+done
+
+if [[ "$needs_gpu_build" == "true" ]]; then
+  eval "$(detect_cuda_build_args)"
+  export COMFYUI_CUDA_TAG COMFYUI_TORCH_INDEX
+fi
+
 docker_args=()
 for file in "${compose_files[@]}"; do
   docker_args+=(-f "${REPO_ROOT}/${file}")


### PR DESCRIPTION
## Summary

The ComfyUI Dockerfile previously used `python:3.11-slim` with no CUDA support, causing `cudaErrorNoKernelImageForDevice` on GPU execution.

- Dockerfile now uses `nvidia/cuda` base image with `CUDA_TAG` and `TORCH_INDEX` build args (default: cu118 for broadest compat)
- `docker-stack.sh` auto-detects GPU compute capability via `nvidia-smi` and selects:
  - **Pascal** (6.x — Tesla P4/P40, GTX 10xx): CUDA 11.8 / cu118
  - **Turing–Ada** (7.x–9.x — RTX 20xx–40xx, RTX PRO 6000 Ada): CUDA 12.4 / cu124
  - **Blackwell** (10.x+ — RTX 50xx, RTX PRO 6000 Blackwell): CUDA 12.8 / cu128
- `docker-compose.comfyui.yml` passes build args from environment
- Falls back to cu118 when no GPU or nvidia-smi is unavailable

## Test plan
- [ ] `./scripts/docker-stack.sh comfyui-nvidia --build` on Pascal GPU — logs show cu118 selection
- [ ] Test image generation works after rebuild
- [ ] On machine without GPU — falls back to cu118 gracefully