### PR TITLE
fix: fix DuckDuckGo search parsing and add key deletion for search providers

### DIFF
--- a/modules/deep-research/src/search-providers.ts
+++ b/modules/deep-research/src/search-providers.ts
@@ -163,7 +163,11 @@ async function searchDuckDuckGo(
   await acquireSlot("html.duckduckgo.com");
   const res = await fetch("https://html.duckduckgo.com/html/", {
     method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+    },
     body: `q=${encodeURIComponent(query)}`,
     signal: AbortSignal.timeout(timeout),
   });
@@ -174,32 +178,37 @@ async function searchDuckDuckGo(
   const html = await res.text();
   const results: SearchResult[] = [];
 
-  const blockRe =
-    /<div[^>]+class="[^"]*result [^"]*"[^>]*>([\s\S]*?)<\/div>\s*(?=<div[^>]+class="[^"]*result |$)/g;
-  let block: RegExpExecArray | null;
+  // Find each result link directly — avoids fragile block-level regex that
+  // breaks on nested <div>s inside DDG result blocks.
+  const linkRe =
+    /<a[^>]+class="result__a"[^>]+href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/g;
+  let linkMatch: RegExpExecArray | null;
   while (
-    (block = blockRe.exec(html)) !== null &&
+    (linkMatch = linkRe.exec(html)) !== null &&
     results.length < maxResults
   ) {
-    const inner = block[1];
-
-    const linkMatch = inner.match(
-      /<a[^>]+class="result__a"[^>]+href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/,
-    );
-    if (!linkMatch) continue;
-
     let url = linkMatch[1];
     const uddgMatch = url.match(/[?&]uddg=([^&]+)/);
     if (uddgMatch) url = decodeURIComponent(uddgMatch[1]);
 
     const title = linkMatch[2].replace(/<[^>]*>/g, "").trim();
 
-    const snippetMatch = inner.match(
+    // Look for the nearest snippet after this link
+    const afterLink = html.slice(linkMatch.index + linkMatch[0].length);
+    const snippetMatch = afterLink.match(
       /<a[^>]+class="result__snippet"[^>]*>([\s\S]*?)<\/a>/,
     );
-    const snippet = snippetMatch
-      ? snippetMatch[1].replace(/<[^>]*>/g, "").trim()
-      : "";
+    // Only use the snippet if it appears before the next result link
+    let snippet = "";
+    if (snippetMatch) {
+      const nextLinkInAfter = afterLink.indexOf('class="result__a"');
+      if (
+        nextLinkInAfter === -1 ||
+        snippetMatch.index! < nextLinkInAfter
+      ) {
+        snippet = snippetMatch[1].replace(/<[^>]*>/g, "").trim();
+      }
+    }
 
     if (url && title) {
       results.push({ title, url, snippet });

--- a/packages/server/src/settings/settings.ts
+++ b/packages/server/src/settings/settings.ts
@@ -948,7 +948,13 @@ export async function testSearchProvider(
     }
 
     const response = await provider.search("test", 1);
-    // Any non-error response counts as success
+    if (response.results.length === 0) {
+      return {
+        ok: false,
+        error: "Connected but no results returned — provider may be misconfigured or blocking requests.",
+        latencyMs: Date.now() - start,
+      };
+    }
     return {
       ok: true,
       latencyMs: Date.now() - start,

--- a/packages/server/src/tools/search/providers.ts
+++ b/packages/server/src/tools/search/providers.ts
@@ -179,7 +179,11 @@ class DuckDuckGoProvider implements SearchProvider {
   async search(query: string, maxResults: number): Promise<SearchResponse> {
     const res = await fetch("https://html.duckduckgo.com/html/", {
       method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+      },
       body: `q=${encodeURIComponent(query)}`,
       signal: AbortSignal.timeout(15_000),
     });
@@ -190,19 +194,15 @@ class DuckDuckGoProvider implements SearchProvider {
     const html = await res.text();
     const results: SearchResult[] = [];
 
-    // Parse result blocks: each is a <div class="result ..."> containing
-    // an <a class="result__a"> (title + URL) and <a class="result__snippet"> (snippet).
-    const blockRe = /<div[^>]+class="[^"]*result [^"]*"[^>]*>([\s\S]*?)<\/div>\s*(?=<div[^>]+class="[^"]*result |$)/g;
-    let block: RegExpExecArray | null;
-    while ((block = blockRe.exec(html)) !== null && results.length < maxResults) {
-      const inner = block[1];
-
-      // Title + URL from <a class="result__a" href="...">Title</a>
-      const linkMatch = inner.match(
-        /<a[^>]+class="result__a"[^>]+href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/,
-      );
-      if (!linkMatch) continue;
-
+    // Find each result link directly — avoids fragile block-level regex that
+    // breaks on nested <div>s inside DDG result blocks.
+    const linkRe =
+      /<a[^>]+class="result__a"[^>]+href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/g;
+    let linkMatch: RegExpExecArray | null;
+    while (
+      (linkMatch = linkRe.exec(html)) !== null &&
+      results.length < maxResults
+    ) {
       let url = linkMatch[1];
       // DuckDuckGo wraps URLs in a redirect; extract the real one
       const uddgMatch = url.match(/[?&]uddg=([^&]+)/);
@@ -210,13 +210,22 @@ class DuckDuckGoProvider implements SearchProvider {
 
       const title = linkMatch[2].replace(/<[^>]*>/g, "").trim();
 
-      // Snippet from <a class="result__snippet" ...>
-      const snippetMatch = inner.match(
+      // Look for the nearest snippet after this link
+      const afterLink = html.slice(linkMatch.index + linkMatch[0].length);
+      const snippetMatch = afterLink.match(
         /<a[^>]+class="result__snippet"[^>]*>([\s\S]*?)<\/a>/,
       );
-      const snippet = snippetMatch
-        ? snippetMatch[1].replace(/<[^>]*>/g, "").trim()
-        : "";
+      // Only use the snippet if it appears before the next result link
+      let snippet = "";
+      if (snippetMatch) {
+        const nextLinkInAfter = afterLink.indexOf('class="result__a"');
+        if (
+          nextLinkInAfter === -1 ||
+          snippetMatch.index! < nextLinkInAfter
+        ) {
+          snippet = snippetMatch[1].replace(/<[^>]*>/g, "").trim();
+        }
+      }
 
       if (url && title) {
         results.push({ title, url, snippet });

--- a/packages/web/src/components/settings/SearchTab.tsx
+++ b/packages/web/src/components/settings/SearchTab.tsx
@@ -56,6 +56,8 @@ function SearchProviderCard({
     (provider.apiKeySet || !provider.needsApiKey) &&
     (!!provider.baseUrl || !provider.needsBaseUrl);
 
+  const [removing, setRemoving] = useState(false);
+
   const handleSave = async () => {
     setSaving(true);
     const data: { apiKey?: string; baseUrl?: string } = {};
@@ -68,6 +70,19 @@ function SearchProviderCard({
     await updateSearchProvider(provider.id, data);
     setApiKey("");
     setSaving(false);
+  };
+
+  const handleRemoveKey = async () => {
+    setRemoving(true);
+    await updateSearchProvider(provider.id, { apiKey: "" });
+    setRemoving(false);
+  };
+
+  const handleRemoveUrl = async () => {
+    setRemoving(true);
+    await updateSearchProvider(provider.id, { baseUrl: "" });
+    setBaseUrl("");
+    setRemoving(false);
   };
 
   const handleTest = () => {
@@ -145,17 +160,28 @@ function SearchProviderCard({
               <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
                 API Key
               </label>
-              <input
-                type="password"
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                placeholder={
-                  provider.apiKeySet
-                    ? `Current: ${provider.apiKey}`
-                    : "Enter API key..."
-                }
-                className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary"
-              />
+              <div className="flex items-center gap-2">
+                <input
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder={
+                    provider.apiKeySet
+                      ? `Current: ${provider.apiKey}`
+                      : "Enter API key..."
+                  }
+                  className="flex-1 bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary"
+                />
+                {provider.apiKeySet && (
+                  <button
+                    onClick={handleRemoveKey}
+                    disabled={removing}
+                    className="text-xs text-red-500 hover:text-red-400 px-2 py-1.5 rounded-md hover:bg-red-500/10 disabled:opacity-50 whitespace-nowrap"
+                  >
+                    {removing ? "Removing..." : "Remove Key"}
+                  </button>
+                )}
+              </div>
             </div>
           )}
 
@@ -165,13 +191,24 @@ function SearchProviderCard({
               <label className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1 block">
                 Base URL
               </label>
-              <input
-                type="text"
-                value={baseUrl}
-                onChange={(e) => setBaseUrl(e.target.value)}
-                placeholder={placeholder}
-                className="w-full bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary"
-              />
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={baseUrl}
+                  onChange={(e) => setBaseUrl(e.target.value)}
+                  placeholder={placeholder}
+                  className="flex-1 bg-secondary rounded-md px-3 py-1.5 text-sm outline-none focus:ring-1 ring-primary"
+                />
+                {provider.baseUrl && (
+                  <button
+                    onClick={handleRemoveUrl}
+                    disabled={removing}
+                    className="text-xs text-red-500 hover:text-red-400 px-2 py-1.5 rounded-md hover:bg-red-500/10 disabled:opacity-50 whitespace-nowrap"
+                  >
+                    {removing ? "Removing..." : "Remove URL"}
+                  </button>
+                )}
+              </div>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
Fixes #472

- **DDG search fix**: Added browser User-Agent header to avoid bot-detection blocking, and rewrote HTML parser to match result links directly instead of using fragile block-level div regex that broke on nested elements.
- **Test connection improvement**: `testSearchProvider` now returns failure when the provider connects but returns zero results, catching misconfigured or blocked providers.
- **Key deletion UI**: Added "Remove Key" and "Remove URL" buttons to search provider settings cards, allowing users to clear saved API keys and base URLs.

## Test plan
- [ ] Configure DuckDuckGo as active search provider and verify search returns results
- [ ] Run "Test Connection" on DDG and verify it reports success with results
- [ ] Add an API key to a provider (e.g., Brave), then use "Remove Key" to clear it
- [ ] Add a base URL to SearXNG, then use "Remove URL" to clear it
- [ ] Verify deep-research module also returns DDG results correctly